### PR TITLE
⚡ Bolt: Fix Service Worker installation failure

### DIFF
--- a/agents/bitácora/Bolt.md
+++ b/agents/bitácora/Bolt.md
@@ -256,3 +256,12 @@ Este patrón es robusto para interfaces tipo "tarjeta clickable" que contienen a
 **Impacto:**
 - **Rendimiento:** Reducción del trabajo de renderizado inicial. El navegador ahora solo procesa el layout de las secciones inferiores cuando se acercan al viewport.
 - **Eficiencia:** Mejora en métricas de INP y FCP al liberar el hilo principal durante la carga crítica.
+
+## 2026-01-26 - [Reparación de Instalación Service Worker]
+**Revisado:** `public/sw.js`, `src/layouts/Layout.astro`, `public/`.
+**Propuesta:** Se detectó que el Service Worker intentaba cachear `/favicon.svg` durante la fase de instalación (`install`). Sin embargo, este archivo no existe en el directorio `public/`, lo que provocaba que la promesa `cache.addAll()` fallara y el Service Worker nunca se instalara correctamente. Esto deshabilitaba completamente el soporte offline y el cacheo de assets estáticos.
+**Cambios Realizados:**
+1.  Se eliminó `/favicon.svg` del array `ASSETS_TO_CACHE` en `public/sw.js`.
+**Impacto:**
+- **Funcionalidad:** Habilitación exitosa del Service Worker.
+- **Rendimiento:** Cacheo efectivo de la shell de la aplicación (`/`, `/logo.png`, `/manifest.json`) para cargas subsecuentes instantáneas y soporte offline.

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,6 @@
 const CACHE_NAME = 'arceapps-v1';
 const ASSETS_TO_CACHE = [
   '/',
-  '/favicon.svg',
   '/logo.png',
   '/manifest.json'
 ];


### PR DESCRIPTION
Removed `/favicon.svg` from `ASSETS_TO_CACHE` in `public/sw.js` because the file does not exist in the public directory. This was causing `cache.addAll()` to reject, preventing the Service Worker from installing. This fix enables the Service Worker to successfully install, cache the app shell (logo, manifest, root), and provide offline capabilities. Updated `agents/bitácora/Bolt.md` with the audit log entry.

---
*PR created automatically by Jules for task [12373245535755954960](https://jules.google.com/task/12373245535755954960) started by @ArceApps*