### PR TITLE
🛡️ Sentinel: Sanitize Search Index & Harden Headers

### DIFF
--- a/agents/bitácora/bitacora_sentinel.md
+++ b/agents/bitácora/bitacora_sentinel.md
@@ -160,3 +160,14 @@
 - Se actualizó `escapeHtml` para convertir `"` en `&quot;`.
 - Se aplicó `escapeHtml(item.slug)` al construir el enlace del resultado.
 **Aprendizaje (si aplica):** Al construir HTML mediante strings (template literals), *toda* variable inyectada en atributos debe ser sanitizada, incluso si parece provenir de una fuente interna como el sistema de archivos, para mantener la defensa en profundidad.
+
+## 2026-01-27 - Sanitización de Índice de Búsqueda y Hardening de Cabeceras
+**Estado:** Realizado
+**Análisis:**
+- Se identificó que `src/pages/search-index.json.ts` no implementaba la sanitización y truncamiento descrita en la memoria de seguridad, generando riesgos de DoS por payloads grandes y XSS almacenado (aunque mitigado por el cliente).
+- Se detectó que `src/layouts/Layout.astro` exponía la versión del framework mediante la etiqueta `meta generator`.
+**Cambios:**
+- Se creó `src/utils/sanitizer.ts` con la función `sanitizeForSearch` (strip HTML + truncamiento) y sus respectivos tests unitarios.
+- Se actualizó `src/pages/search-index.json.ts` para aplicar esta sanitización a los campos de título (100 chars) y descripción (200 chars).
+- Se eliminó la etiqueta `<meta name="generator" ... />` de `src/layouts/Layout.astro`.
+**Aprendizaje (si aplica):** La sanitización en el servidor (o build time) es crucial para la defensa en profundidad, reduciendo la superficie de ataque antes de que los datos lleguen al cliente.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,7 +36,6 @@ const socialImageURL = new URL(image, Astro.url);
     <link rel="icon" type="image/png" href="/logo.png" />
     <link rel="apple-touch-icon" href="/logo.png" />
     <link rel="canonical" href={canonicalURL} />
-    <meta name="generator" content={Astro.generator} />
     <ClientRouter />
 
     <!-- Security Headers -->

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -1,4 +1,5 @@
 import { getCollection } from 'astro:content';
+import { sanitizeForSearch } from '../utils/sanitizer';
 
 export async function GET() {
   const posts = await getCollection('blog', ({ data }) => !data.draft);
@@ -6,16 +7,16 @@ export async function GET() {
 
   const searchIndex = [
     ...posts.map((post) => ({
-      title: post.data.title,
-      description: post.data.description,
+      title: sanitizeForSearch(post.data.title, 100),
+      description: sanitizeForSearch(post.data.description, 200),
       slug: `/blog/${post.slug}`,
       type: 'Blog',
       tags: post.data.tags || [],
     })),
     ...apps.map((app) => ({
-      title: app.data.title,
-      description: app.data.description,
-      slug: `/apps/${app.slug}`, // Assuming apps are at /apps/slug based on file structure, need to verify
+      title: sanitizeForSearch(app.data.title, 100),
+      description: sanitizeForSearch(app.data.description, 200),
+      slug: `/apps/${app.slug}`,
       type: 'App',
       tags: app.data.tags || [],
     })),

--- a/src/utils/sanitizer.test.ts
+++ b/src/utils/sanitizer.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeForSearch } from './sanitizer';
+
+describe('sanitizeForSearch', () => {
+  it('should handle empty input', () => {
+    expect(sanitizeForSearch('')).toBe('');
+    // @ts-ignore
+    expect(sanitizeForSearch(null)).toBe('');
+    // @ts-ignore
+    expect(sanitizeForSearch(undefined)).toBe('');
+  });
+
+  it('should strip HTML tags', () => {
+    const input = '<p>Hello <b>World</b></p>';
+    expect(sanitizeForSearch(input)).toBe('Hello World');
+  });
+
+  it('should normalize whitespace', () => {
+    const input = 'Hello   \n   World';
+    expect(sanitizeForSearch(input)).toBe('Hello World');
+  });
+
+  it('should truncate long text', () => {
+    const input = 'a'.repeat(300);
+    const result = sanitizeForSearch(input, 10);
+    expect(result.length).toBe(13); // 10 chars + 3 dots
+    expect(result).toBe('aaaaaaaaaa...');
+  });
+
+  it('should handle text shorter than limit', () => {
+    const input = 'Short text';
+    expect(sanitizeForSearch(input, 20)).toBe('Short text');
+  });
+
+  it('should strip HTML and then truncate', () => {
+    const input = '<b>Bold</b> text that is very long and needs truncation';
+    const result = sanitizeForSearch(input, 9);
+    expect(result).toBe('Bold text...');
+  });
+});

--- a/src/utils/sanitizer.ts
+++ b/src/utils/sanitizer.ts
@@ -1,0 +1,24 @@
+/**
+ * Sanitizes and truncates text for search index.
+ * Strips HTML tags and limits length to prevent DoS payloads.
+ *
+ * @param text The text to sanitize
+ * @param maxLength The maximum length of the result (default 200)
+ * @returns Sanitized and truncated string
+ */
+export function sanitizeForSearch(text: string, maxLength: number = 200): string {
+  if (!text) return "";
+
+  // 1. Remove HTML tags
+  let cleaned = text.replace(/<[^>]*>/g, "");
+
+  // 2. Normalize whitespace (remove newlines, multiple spaces)
+  cleaned = cleaned.replace(/\s+/g, " ").trim();
+
+  // 3. Truncate
+  if (cleaned.length > maxLength) {
+    return cleaned.substring(0, maxLength) + "...";
+  }
+
+  return cleaned;
+}


### PR DESCRIPTION
Implemented sanitization for the search index generation to strip HTML and truncate text, mitigating DoS risks. Removed the framework version generator tag for security hardening.

---
*PR created automatically by Jules for task [1129234333834658165](https://jules.google.com/task/1129234333834658165) started by @ArceApps*