### PR TITLE
🛡️ Sentinel: Fix Lodash Vulnerability & SW 404

### DIFF
--- a/agents/bitácora/bitacora_sentinel.md
+++ b/agents/bitácora/bitacora_sentinel.md
@@ -172,8 +172,20 @@
 - Se eliminó la etiqueta `<meta name="generator" ... />` de `src/layouts/Layout.astro`.
 **Aprendizaje (si aplica):** La sanitización en el servidor (o build time) es crucial para la defensa en profundidad, reduciendo la superficie de ataque antes de que los datos lleguen al cliente.
 
-## 2026-01-28 - Implementación de Sanitización en Recolección de RSS
+## 2026-01-28 - Sanitización de Recolección de RSS
 **Estado:** Realizado
 **Análisis:** Se detectó que `scripts/fetch-rss.js` extraía contenido de feeds RSS externos sin sanitización ni truncamiento adecuados. Esto presentaba un riesgo de Denegación de Servicio (DoS) por payloads excesivamente grandes y potencial inyección de contenido malicioso en el sistema de agentes (Curator).
 **Cambios:** Se modificó `scripts/fetch-rss.js` para usar `JSDOM` para limpiar etiquetas HTML de forma robusta y se implementó un límite estricto de caracteres (150 para títulos, 500 para snippets). Se normalizaron los espacios en blanco.
 **Aprendizaje (si aplica):** Nunca confiar en datos externos, incluso de fuentes "conocidas". La sanitización debe ocurrir en la frontera de entrada (Input Boundary).
+
+## 2026-01-29 - Hardening de Dependencias y Fiabilidad de SW
+**Estado:** Realizado
+**Análisis:**
+- Se detectó una vulnerabilidad moderada (Prototype Pollution) en `lodash` (dependencia transitiva) mediante `pnpm audit`.
+- Se identificó que el Service Worker (`sw.js`) intentaba cachear `/favicon.svg`, archivo inexistente, lo que provocaba un fallo en la instalación del SW y pérdida de funcionalidad offline.
+- Se encontraron tests unitarios rotos (`layout.test.ts`) debido a falta de mocking en el entorno JSDOM.
+**Cambios:**
+- Se añadió `pnpm.overrides` en `package.json` forzando `lodash` a `^4.17.23`.
+- Se eliminó `/favicon.svg` de la lista de caché en `sw.js`.
+- Se arregló el entorno de pruebas mockeando `window.matchMedia`.
+**Aprendizaje (si aplica):** La seguridad incluye la disponibilidad. Un Service Worker roto impide que la aplicación funcione en condiciones adversas. Además, mantener un CI verde (tests pasando) es vital para detectar regresiones de seguridad rápidamente.

--- a/package.json
+++ b/package.json
@@ -32,5 +32,10 @@
     "terser": "5.46.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
+  },
+  "pnpm": {
+    "overrides": {
+      "lodash": "^4.17.23"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash: ^4.17.23
+
 importers:
 
   .:
@@ -1486,8 +1489,8 @@ packages:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
     engines: {node: '>= 12.0.0'}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -3874,7 +3877,7 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   longest-streak@3.1.0: {}
 
@@ -4981,7 +4984,7 @@ snapshots:
       '@vscode/l10n': 0.0.18
       ajv: 8.17.1
       ajv-draft-04: 1.0.0(ajv@8.17.1)
-      lodash: 4.17.21
+      lodash: 4.17.23
       prettier: 3.7.4
       request-light: 0.5.8
       vscode-json-languageservice: 4.1.8

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,6 @@
 const CACHE_NAME = 'arceapps-v1';
 const ASSETS_TO_CACHE = [
   '/',
-  '/favicon.svg',
   '/logo.png',
   '/manifest.json'
 ];

--- a/src/scripts/layout.test.ts
+++ b/src/scripts/layout.test.ts
@@ -23,6 +23,21 @@ describe('Layout Script', () => {
         unobserve: vi.fn(),
       };
     }) as any;
+
+    // Mock matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(), // deprecated
+        removeListener: vi.fn(), // deprecated
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
This PR addresses a security vulnerability and a reliability issue:
1.  **Lodash Vulnerability:** `pnpm audit` reported a Prototype Pollution vulnerability in `lodash` (transitive dependency). Added `pnpm.overrides` to force version `^4.17.23`.
2.  **Service Worker Reliability:** The Service Worker was failing to install because it tried to cache `/favicon.svg` which does not exist (causing a 404). This was removed from the cache list to ensure offline functionality works.
3.  **Test Fix:** Fixed pre-existing failures in `layout.test.ts` caused by missing `matchMedia` mock in JSDOM environment.

---
*PR created automatically by Jules for task [6139880262661013141](https://jules.google.com/task/6139880262661013141) started by @ArceApps*