### PR TITLE
Move Blog Tags to Bottom of Page

### DIFF
--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -30,17 +30,6 @@ const { page, allTags } = Astro.props;
       <p class="text-xl text-on-surface-variant dark:text-dark-on-surface-variant max-w-2xl mx-auto">
         Explora nuestros artículos sobre desarrollo Android, mejores prácticas, arquitectura de software y novedades tecnológicas.
       </p>
-
-      <div class="mt-10 flex flex-wrap justify-center gap-3 animate-fade-in-up">
-        {allTags.map((tag) => (
-          <a
-            href={`/blog/tag/${slugify(tag)}/`}
-            class="px-4 py-2 rounded-full bg-surface dark:bg-dark-surface border border-primary/20 hover:border-primary text-on-surface dark:text-dark-on-surface hover:bg-primary hover:text-white transition-all duration-300 text-sm font-medium shadow-sm hover:shadow-md focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
-          >
-            #{tag}
-          </a>
-        ))}
-      </div>
     </div>
   </div>
 
@@ -66,6 +55,22 @@ const { page, allTags } = Astro.props;
             <span class="material-icons ml-2 text-base" aria-hidden="true">arrow_forward</span>
           </a>
         )}
+      </div>
+    </div>
+  </section>
+
+  <section class="bg-surface-variant/30 dark:bg-dark-surface-variant/30 py-16 md:py-24">
+    <div class="container mx-auto px-4 text-center">
+      <h2 class="text-2xl font-bold mb-6 text-on-surface dark:text-dark-on-surface">Filtrar por etiquetas</h2>
+      <div class="flex flex-wrap justify-center gap-3 animate-fade-in-up">
+        {allTags.map((tag) => (
+          <a
+            href={`/blog/tag/${slugify(tag)}/`}
+            class="px-4 py-2 rounded-full bg-surface dark:bg-dark-surface border border-primary/20 hover:border-primary text-on-surface dark:text-dark-on-surface hover:bg-primary hover:text-white transition-all duration-300 text-sm font-medium shadow-sm hover:shadow-md focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
+          >
+            #{tag}
+          </a>
+        ))}
       </div>
     </div>
   </section>


### PR DESCRIPTION
Moved the blog tags filtering section to the bottom of the blog page, below the pagination controls, as requested. Added a new "Filtrar por etiquetas" heading and maintained the visual style of the section. Verified with Playwright and manual inspection of the generated screenshot.

---
*PR created automatically by Jules for task [16819497434378365648](https://jules.google.com/task/16819497434378365648) started by @ArceApps*