### PR TITLE
🛡️ Sentinel: HIGH Mitigated DoS vulnerability in fast-xml-parser

### DIFF
--- a/agents/bitácora/bitacora_sentinel.md
+++ b/agents/bitácora/bitacora_sentinel.md
@@ -189,3 +189,15 @@
 - Se eliminó `/favicon.svg` de la lista de caché en `sw.js`.
 - Se arregló el entorno de pruebas mockeando `window.matchMedia`.
 **Aprendizaje (si aplica):** La seguridad incluye la disponibilidad. Un Service Worker roto impide que la aplicación funcione en condiciones adversas. Además, mantener un CI verde (tests pasando) es vital para detectar regresiones de seguridad rápidamente.
+
+## 2026-01-30 - Mitigación de DoS en Parser XML
+**Estado:** Realizado
+**Análisis:**
+- Se detectó una vulnerabilidad de severidad ALTA (DoS Numeric Entities Bug) en `fast-xml-parser` versiones `< 5.3.4` mediante `pnpm audit`.
+- Esta librería es una dependencia transitiva de `@astrojs/rss`, utilizada para la generación de feeds RSS del blog.
+- La vulnerabilidad permitía ataques de Denegación de Servicio mediante entidades numéricas malformadas.
+**Cambios:**
+- Se añadió un override en `package.json` para forzar el uso de `fast-xml-parser` versión `^5.3.4`.
+- Se verificó la eliminación de la vulnerabilidad con `pnpm audit`.
+- Se confirmó la integridad del build con `pnpm build`.
+**Aprendizaje (si aplica):** Las vulnerabilidades en dependencias transitivas deben ser mitigadas proactivamente mediante overrides si los paquetes padres no han lanzado actualizaciones oportunas, especialmente cuando afectan la disponibilidad (DoS).

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "pnpm": {
     "overrides": {
-      "lodash": "^4.17.23"
+      "lodash": "^4.17.23",
+      "fast-xml-parser": "^5.3.4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   lodash: ^4.17.23
+  fast-xml-parser: ^5.3.4
 
 importers:
 
@@ -1221,8 +1222,8 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-parser@5.3.3:
-    resolution: {integrity: sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA==}
+  fast-xml-parser@5.3.4:
+    resolution: {integrity: sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==}
     hasBin: true
 
   fastq@1.20.1:
@@ -2556,7 +2557,7 @@ snapshots:
 
   '@astrojs/rss@4.0.14':
     dependencies:
-      fast-xml-parser: 5.3.3
+      fast-xml-parser: 5.3.4
       piccolore: 0.1.3
 
   '@astrojs/sitemap@3.6.0':
@@ -3583,7 +3584,7 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-parser@5.3.3:
+  fast-xml-parser@5.3.4:
     dependencies:
       strnum: 2.1.2
 


### PR DESCRIPTION
Added pnpm.overrides to package.json to force fast-xml-parser to ^5.3.4, mitigating a High Severity DoS vulnerability (Numeric Entities Bug) present in the transitive dependency chain of @astrojs/rss. Verified with pnpm audit and pnpm build.

---
*PR created automatically by Jules for task [9807826992765522566](https://jules.google.com/task/9807826992765522566) started by @ArceApps*