### PR TITLE
🛡️ Sentinel: [HIGH] Fix RSS Draft Leak & Dep Vulnerability

### DIFF
--- a/agents/bitácora/bitacora_sentinel.md
+++ b/agents/bitácora/bitacora_sentinel.md
@@ -189,3 +189,14 @@
 - Se eliminó `/favicon.svg` de la lista de caché en `sw.js`.
 - Se arregló el entorno de pruebas mockeando `window.matchMedia`.
 **Aprendizaje (si aplica):** La seguridad incluye la disponibilidad. Un Service Worker roto impide que la aplicación funcione en condiciones adversas. Además, mantener un CI verde (tests pasando) es vital para detectar regresiones de seguridad rápidamente.
+
+## 2026-01-30 - Fix RSS Draft Leak & Dependency Vulnerability
+**Estado:** Realizado
+**Análisis:**
+- Se detectó que `src/pages/rss.xml.js` incluía posts en borrador (`draft: true`) en el feed RSS público, lo que constituye una fuga de información.
+- Se identificó una vulnerabilidad de alta severidad (DoS) en `fast-xml-parser` (dependencia transitiva de `@astrojs/rss`).
+**Cambios:**
+- Se actualizó la consulta en `src/pages/rss.xml.js` para filtrar posts donde `draft` sea verdadero.
+- Se añadió un override en `package.json` para forzar `fast-xml-parser` a la versión `^5.3.4`, mitigando la vulnerabilidad.
+- Se verificó la ausencia de borradores en el feed generado y la resolución de la vulnerabilidad con `pnpm audit`.
+**Aprendizaje (si aplica):** La seguridad de contenido requiere consistencia en todos los canales de distribución. Si se filtran borradores en la web, también deben filtrarse en RSS, sitemaps y búsquedas.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "pnpm": {
     "overrides": {
-      "lodash": "^4.17.23"
+      "lodash": "^4.17.23",
+      "fast-xml-parser": "^5.3.4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   lodash: ^4.17.23
+  fast-xml-parser: ^5.3.4
 
 importers:
 
@@ -1221,8 +1222,8 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-parser@5.3.3:
-    resolution: {integrity: sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA==}
+  fast-xml-parser@5.3.4:
+    resolution: {integrity: sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==}
     hasBin: true
 
   fastq@1.20.1:
@@ -2556,7 +2557,7 @@ snapshots:
 
   '@astrojs/rss@4.0.14':
     dependencies:
-      fast-xml-parser: 5.3.3
+      fast-xml-parser: 5.3.4
       piccolore: 0.1.3
 
   '@astrojs/sitemap@3.6.0':
@@ -3583,7 +3584,7 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-parser@5.3.3:
+  fast-xml-parser@5.3.4:
     dependencies:
       strnum: 2.1.2
 

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -2,7 +2,7 @@ import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 
 export async function GET(context) {
-  const blog = await getCollection('blog');
+  const blog = await getCollection('blog', ({ data }) => !data.draft);
   return rss({
     title: 'ArceApps Blog',
     description: 'Artículos sobre desarrollo Android, mejores prácticas y tecnología.',


### PR DESCRIPTION
This PR addresses two security issues identified by Sentinel:

1.  **RSS Draft Leak**: Modified `src/pages/rss.xml.js` to filter out blog posts marked as `draft: true`. This prevents unpublished content from being exposed via the RSS feed.
2.  **Dependency Vulnerability**: Added a `pnpm.overrides` entry in `package.json` to force `fast-xml-parser` to version `^5.3.4`, mitigating a high-severity DoS vulnerability (GHSA-37qj-frw5-hhjh) present in the transitive dependency chain of `@astrojs/rss`.

Verified by:
- Creating a test draft post and confirming it does not appear in `dist/rss.xml` after build.
- Running `pnpm audit` to confirm the vulnerability is resolved.

---
*PR created automatically by Jules for task [6091968421234102286](https://jules.google.com/task/6091968421234102286) started by @ArceApps*