### PR TITLE
🛡️ Sentinel: Fix Draft Leak in RSS

### DIFF
--- a/agents/bitácora/bitacora_sentinel.md
+++ b/agents/bitácora/bitacora_sentinel.md
@@ -201,3 +201,13 @@
 - Se verificó la eliminación de la vulnerabilidad con `pnpm audit`.
 - Se confirmó la integridad del build con `pnpm build`.
 **Aprendizaje (si aplica):** Las vulnerabilidades en dependencias transitivas deben ser mitigadas proactivamente mediante overrides si los paquetes padres no han lanzado actualizaciones oportunas, especialmente cuando afectan la disponibilidad (DoS).
+
+## 2026-01-31 - Leak de Borradores en RSS
+**Estado:** Realizado
+**Análisis:**
+- Se detectó que el endpoint `src/pages/rss.xml.js` recuperaba la colección 'blog' completa sin aplicar el filtro de borradores (`draft: true`).
+- Esto exponía contenido en progreso o no autorizado en el feed RSS público, permitiendo el acceso a información que debería estar oculta.
+**Cambios:**
+- Se modificó `src/pages/rss.xml.js` para incluir una función de filtrado en `getCollection('blog', ({ data }) => !data.draft)`.
+- Se verificó la corrección creando un post borrador y confirmando su ausencia en `dist/rss.xml`.
+**Aprendizaje (si aplica):** La función `getCollection` de Astro devuelve *todos* los elementos por defecto. Siempre se debe aplicar un filtro explícito para excluir borradores o contenido privado en *cualquier* punto de acceso (listados, búsqueda, RSS).

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -2,7 +2,7 @@ import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 
 export async function GET(context) {
-  const blog = await getCollection('blog');
+  const blog = await getCollection('blog', ({ data }) => !data.draft);
   return rss({
     title: 'ArceApps Blog',
     description: 'Artículos sobre desarrollo Android, mejores prácticas y tecnología.',


### PR DESCRIPTION
During the daily security scan, I identified that the RSS feed endpoint (`src/pages/rss.xml.js`) was exposing draft posts because it was fetching the entire 'blog' collection without filtering.

This behavior violated the content access control policy, potentially leaking unfinished or sensitive content.

I fixed this by adding a filter `({ data }) => !data.draft` to the `getCollection` call.

I verified the fix by creating a dummy draft post, building the project, and confirming it was absent from `dist/rss.xml`.

I also updated `agents/bitácora/bitacora_sentinel.md` with the details of this intervention.

---
*PR created automatically by Jules for task [7951563438560249450](https://jules.google.com/task/7951563438560249450) started by @ArceApps*