### PR TITLE
🛡️ Sentinel: [HIGH] Fix Draft Leakage in RSS Feed

### DIFF
--- a/agents/bitácora/bitacora_sentinel.md
+++ b/agents/bitácora/bitacora_sentinel.md
@@ -211,3 +211,12 @@
 - Se refinó la validación en `src/content/config.ts` añadiendo `.regex(/^https?:\/\//)` a los campos `repoUrl`, `demoUrl`, `googlePlayUrl` y `realIconUrl`.
 - Esto obliga a que los enlaces comiencen explícitamente con `http://` o `https://`.
 **Aprendizaje (si aplica):** La validación `z.string().url()` de Zod solo verifica la estructura de la URL, no el protocolo. Para prevenir XSS, es necesario restringir explícitamente los esquemas permitidos (whitelist).
+
+## 2026-02-02 - Fix Draft Leakage in RSS Feed
+**Estado:** Realizado
+**Análisis:**
+- Se identificó que `src/pages/rss.xml.js` no filtraba los borradores (`draft: true`) de la colección `blog` al generar el feed RSS.
+- Esto resultaba en la exposición pública de contenido no finalizado o sensible, contradiciendo la política de control de acceso de contenido.
+**Cambios:**
+- Se actualizó `src/pages/rss.xml.js` añadiendo el filtro `({ data }) => !data.draft` a la llamada `getCollection('blog')`.
+**Aprendizaje (si aplica):** Los endpoints de generación de feeds y sitemaps deben aplicar los mismos filtros de visibilidad que las páginas de listado para evitar fugas de información.

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -2,7 +2,7 @@ import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 
 export async function GET(context) {
-  const blog = await getCollection('blog');
+  const blog = await getCollection('blog', ({ data }) => !data.draft);
   return rss({
     title: 'ArceApps Blog',
     description: 'Artículos sobre desarrollo Android, mejores prácticas y tecnología.',


### PR DESCRIPTION
This PR addresses a security/privacy issue where draft blog posts were included in the RSS feed. The `getCollection` call in `src/pages/rss.xml.js` now explicitly filters out items with `draft: true`. This ensures that unpublished content is not leaked via RSS. The Sentinel logbook has been updated with the details of this fix.

---
*PR created automatically by Jules for task [4014147612526200863](https://jules.google.com/task/4014147612526200863) started by @ArceApps*