### PR TITLE
Add philosophy section regarding ads and design

### DIFF
--- a/src/components/PhilosophyCard.astro
+++ b/src/components/PhilosophyCard.astro
@@ -1,0 +1,28 @@
+---
+import { getLangFromUrl, useTranslations } from "../i18n/utils";
+
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
+---
+
+<div class="relative bg-surface dark:bg-dark-surface rounded-3xl p-8 md:p-12 shadow-sm border border-primary/20 dark:border-primary/20 overflow-hidden mb-16 fade-in-section">
+  <!-- Decorative background icon -->
+  <div class="absolute -top-6 -right-6 text-primary/5 dark:text-primary/10 select-none pointer-events-none" aria-hidden="true">
+    <span class="material-icons text-9xl">spa</span>
+  </div>
+
+  <div class="relative z-10 flex flex-col md:flex-row gap-8 items-start md:items-center">
+    <div class="shrink-0 p-4 bg-primary/10 rounded-2xl text-primary">
+      <span class="material-icons text-4xl" aria-hidden="true">spa</span>
+    </div>
+
+    <div class="space-y-4 max-w-3xl">
+      <h2 class="text-2xl md:text-3xl font-bold text-on-surface dark:text-dark-on-surface">
+        {t('philosophy.title')}
+      </h2>
+      <p class="text-lg text-on-surface-variant dark:text-dark-on-surface-variant leading-relaxed">
+        {t('philosophy.text')}
+      </p>
+    </div>
+  </div>
+</div>

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -43,6 +43,8 @@ export const ui = {
     'apps.subtitle': 'Premium Android Applications.',
     'common.read_more': 'Read more',
     'common.back': 'Back',
+    'philosophy.title': 'Our Philosophy',
+    'philosophy.text': 'We believe in clean and respectful applications. We don\'t want to flood your screen with intrusive ads because we value your experience and good design. However, we are independent developers and also seek to make a living from our passion. That\'s why we strive for a fair balance that allows us to keep creating quality tools for you.',
   },
   es: {
     'nav.home': 'Inicio',
@@ -81,5 +83,7 @@ export const ui = {
     'apps.subtitle': 'Aplicaciones Android Premium.',
     'common.read_more': 'Leer más',
     'common.back': 'Volver',
+    'philosophy.title': 'Nuestra Filosofía',
+    'philosophy.text': 'Creemos en aplicaciones limpias y respetuosas. No queremos inundar tu pantalla de publicidad intrusiva, porque valoramos tu experiencia y el buen diseño. Sin embargo, somos desarrolladores independientes y también buscamos vivir de nuestra pasión. Por eso, buscamos un equilibrio justo que nos permita seguir creando herramientas de calidad para ti.',
   },
 } as const;

--- a/src/pages/about-me.astro
+++ b/src/pages/about-me.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import ContactForm from "../components/ContactForm.astro";
+import PhilosophyCard from "../components/PhilosophyCard.astro";
 import { Image } from "astro:assets";
 import brandIcon from "../assets/brand-icon.png";
 
@@ -168,6 +169,11 @@ const techStack = [
         </div>
       </div>
     </div>
+  </div>
+
+  <!-- Philosophy Section -->
+  <div class="container mx-auto px-4 mt-20">
+    <PhilosophyCard />
   </div>
 
   <!-- Tech Stack Section -->

--- a/src/pages/apps/index.astro
+++ b/src/pages/apps/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import ProjectCard from "../../components/ProjectCard.astro";
+import PhilosophyCard from "../../components/PhilosophyCard.astro";
 import { getCollection } from "astro:content";
 import { useTranslations } from "../../i18n/utils";
 
@@ -29,6 +30,7 @@ const apps = (await getCollection("apps", ({ data, id }) => !data.draft && id.st
 
   <section class="py-16 md:py-24 bg-surface-variant/30 dark:bg-dark-surface-variant/30 cv-auto" style="contain-intrinsic-size: 800px;">
     <div class="container mx-auto px-4">
+      <PhilosophyCard />
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
         {apps.map((app) => (
           <ProjectCard

--- a/src/pages/es/about-me.astro
+++ b/src/pages/es/about-me.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import ContactForm from "../../components/ContactForm.astro";
+import PhilosophyCard from "../../components/PhilosophyCard.astro";
 import { Image } from "astro:assets";
 import brandIcon from "../../assets/brand-icon.png";
 
@@ -172,6 +173,11 @@ const techStack = [
         </div>
       </div>
     </div>
+  </div>
+
+  <!-- Philosophy Section -->
+  <div class="container mx-auto px-4 mt-20">
+    <PhilosophyCard />
   </div>
 
   <!-- Tech Stack Section -->

--- a/src/pages/es/apps/index.astro
+++ b/src/pages/es/apps/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../../../layouts/Layout.astro";
 import ProjectCard from "../../../components/ProjectCard.astro";
+import PhilosophyCard from "../../../components/PhilosophyCard.astro";
 import { getCollection } from "astro:content";
 import { useTranslations } from "../../../i18n/utils";
 
@@ -29,6 +30,7 @@ const apps = (await getCollection("apps", ({ data, id }) => !data.draft && id.st
 
   <section class="py-16 md:py-24 bg-surface-variant/30 dark:bg-dark-surface-variant/30 cv-auto" style="contain-intrinsic-size: 800px;">
     <div class="container mx-auto px-4">
+      <PhilosophyCard />
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
         {apps.map((app) => (
           <ProjectCard


### PR DESCRIPTION
Added a "Philosophy" section to the Apps and About Me pages (both English and Spanish) to communicate the project's commitment to clean design and non-intrusive advertising while acknowledging the need for sustainable revenue.

Created a reusable `PhilosophyCard` component and integrated it into the relevant pages using the project's i18n system.

---
*PR created automatically by Jules for task [6661371379389853805](https://jules.google.com/task/6661371379389853805) started by @ArceApps*