### PR TITLE
Fix 404 on blog language switch using reference_id

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,6 +7,12 @@ import { getLangFromUrl, useTranslations } from "../i18n/utils";
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 
+interface Props {
+  translatedPath?: string;
+}
+
+const { translatedPath } = Astro.props;
+
 const navItems = [
   { label: t('nav.home'), href: lang === 'es' ? '/es' : '/' },
   { label: t('nav.apps'), href: lang === 'es' ? '/es/apps' : '/apps' },
@@ -29,18 +35,22 @@ const currentLang = lang;
 const nextLang = currentLang === 'es' ? 'en' : 'es';
 const nextLangLabel = currentLang === 'es' ? 'EN' : 'ES';
 
-// Simple path replacement for language switching
-// Note: This works perfectly for structural pages. For content with different slugs (blog posts),
-// it might lead to 404s if slugs don't match.
-// Ideally, we would map exact content paths, but for now this covers the main navigation.
-let nextPath = pathname;
-if (currentLang === 'es') {
-  nextPath = pathname.replace(/^\/es/, '') || '/';
-} else {
-  nextPath = '/es' + pathname;
+// Use translatedPath if provided, otherwise fallback to simple path replacement
+let nextPath = translatedPath;
+
+if (!nextPath) {
+  // Simple path replacement for language switching
+  // Note: This works perfectly for structural pages. For content with different slugs (blog posts),
+  // it might lead to 404s if slugs don't match.
+  // Ideally, we would map exact content paths, but for now this covers the main navigation.
+  if (currentLang === 'es') {
+    nextPath = pathname.replace(/^\/es/, '') || '/';
+  } else {
+    nextPath = '/es' + pathname;
+  }
+  // Fix double slashes just in case
+  nextPath = nextPath.replace(/\/\//g, '/');
 }
-// Fix double slashes just in case
-nextPath = nextPath.replace(/\/\//g, '/');
 ---
 
 <header

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -8,6 +8,7 @@ const blogCollection = defineCollection({
     heroImage: z.string().optional(),
     tags: z.array(z.string()).optional(),
     draft: z.boolean().optional().default(false),
+    reference_id: z.string().optional(),
   }),
 });
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,6 +16,7 @@ interface Props {
   publishDate?: Date;
   author?: string;
   lang?: string;
+  translatedPath?: string;
 }
 
 const lang = Astro.props.lang || getLangFromUrl(Astro.url);
@@ -27,6 +28,7 @@ const {
   type = "website",
   publishDate,
   author = "ArceApps",
+  translatedPath,
 } = Astro.props;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
@@ -197,7 +199,7 @@ const socialImageURL = new URL(image, Astro.url);
     >
       Skip to content
     </a>
-    <Header />
+    <Header translatedPath={translatedPath} />
     <main id="main-content" class="flex-grow">
       <slot />
     </main>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -12,6 +12,7 @@ const t = useTranslations('en');
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data, id }) => !data.draft && id.startsWith('en/'));
+  const esPosts = await getCollection('blog', ({ data, id }) => !data.draft && id.startsWith('es/'));
   // Sort posts by date to ensure correct next/prev logic
   const sortedPosts = posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
@@ -21,6 +22,15 @@ export async function getStaticPaths() {
     // "Previous" post (chronologically older) is at index + 1.
     const nextPost = index > 0 ? sortedPosts[index - 1] : undefined;
     const prevPost = index < sortedPosts.length - 1 ? sortedPosts[index + 1] : undefined;
+
+    // Find translated post
+    let translatedPath = undefined;
+    if (post.data.reference_id) {
+       const esPost = esPosts.find(p => p.data.reference_id === post.data.reference_id);
+       if (esPost) {
+         translatedPath = `/es/blog/${esPost.slug.split('/').pop()}`;
+       }
+    }
 
     return {
       params: { slug: post.slug.split('/').pop() },
@@ -33,13 +43,14 @@ export async function getStaticPaths() {
         nextPost: nextPost ? {
           slug: nextPost.slug.split('/').pop()!,
           title: nextPost.data.title
-        } : undefined
+        } : undefined,
+        translatedPath,
       },
     };
   });
 }
 
-const { post, prevPost, nextPost } = Astro.props;
+const { post, prevPost, nextPost, translatedPath } = Astro.props;
 const { Content, headings } = await post.render();
 
 const wordCount = post.body.split(/\s+/g).length;
@@ -77,7 +88,7 @@ const breadcrumbItems = [
 ];
 ---
 
-<Layout title={`${post.data.title} - ArceApps Blog`} description={post.data.description}>
+<Layout title={`${post.data.title} - ArceApps Blog`} description={post.data.description} translatedPath={translatedPath}>
   <!-- Progress Bar -->
   <div id="progress-container" class="fixed top-0 left-0 w-full h-1 z-[100] bg-transparent">
     <div id="progress-bar" class="scroll-progress-bar h-full bg-secondary w-full origin-left"></div>

--- a/src/pages/es/blog/[...slug].astro
+++ b/src/pages/es/blog/[...slug].astro
@@ -6,18 +6,25 @@ import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import SocialShare from '../../../components/SocialShare.astro';
 import PostNavigation from '../../../components/PostNavigation.astro';
 import { slugify } from '../../../utils/slugs';
-import { useTranslations } from '../../../i18n/utils';
-
-const t = useTranslations('es');
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data, id }) => !data.draft && id.startsWith('es/'));
+  const enPosts = await getCollection('blog', ({ data, id }) => !data.draft && id.startsWith('en/'));
   // Sort posts by date to ensure correct next/prev logic
   const sortedPosts = posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
   return sortedPosts.map((post, index) => {
     const nextPost = index > 0 ? sortedPosts[index - 1] : undefined;
     const prevPost = index < sortedPosts.length - 1 ? sortedPosts[index + 1] : undefined;
+
+    // Find translated post
+    let translatedPath = undefined;
+    if (post.data.reference_id) {
+       const enPost = enPosts.find(p => p.data.reference_id === post.data.reference_id);
+       if (enPost) {
+         translatedPath = `/blog/${enPost.slug.split('/').pop()}`;
+       }
+    }
 
     return {
       params: { slug: post.slug.split('/').pop() },
@@ -30,13 +37,14 @@ export async function getStaticPaths() {
         nextPost: nextPost ? {
           slug: nextPost.slug.split('/').pop()!,
           title: nextPost.data.title
-        } : undefined
+        } : undefined,
+        translatedPath,
       },
     };
   });
 }
 
-const { post, prevPost, nextPost } = Astro.props;
+const { post, prevPost, nextPost, translatedPath } = Astro.props;
 const { Content, headings } = await post.render();
 
 const wordCount = post.body.split(/\s+/g).length;
@@ -74,7 +82,7 @@ const breadcrumbItems = [
 ];
 ---
 
-<Layout title={`${post.data.title} - ArceApps Blog`} description={post.data.description}>
+<Layout title={`${post.data.title} - ArceApps Blog`} description={post.data.description} translatedPath={translatedPath}>
   <!-- Progress Bar -->
   <div id="progress-container" class="fixed top-0 left-0 w-full h-1 z-[100] bg-transparent">
     <div id="progress-bar" class="scroll-progress-bar h-full bg-secondary w-full origin-left"></div>


### PR DESCRIPTION
Implemented a robust solution for bidirectional language switching on blog posts where slugs differ between languages.

Key changes:
1.  **Schema Update**: Added optional `reference_id` to `blogCollection` in `src/content/config.ts`.
2.  **Page Logic**: Modified `getStaticPaths` in both English and Spanish blog post pages to look up the corresponding translation via `reference_id`.
3.  **Header Logic**: The `Header` component now accepts a `translatedPath` prop. If provided, the language toggle button uses this path instead of the default regex-based path replacement.
4.  **Cleanup**: Removed unused `useTranslations` import and variable in the Spanish blog post template, as the UI uses hardcoded Spanish strings.

This ensures that users can seamlessly switch between English and Spanish versions of a technical article without hitting a 404 page, even if the URL slugs are completely different (e.g., `android-16-baklava-features` vs `blog-android-16-baklava`).

---
*PR created automatically by Jules for task [8203074754569838724](https://jules.google.com/task/8203074754569838724) started by @ArceApps*