### PR TITLE
Fix inline code contrast in dark mode

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -197,7 +197,7 @@
 
   /* Code (Inline) */
   .prose code {
-    @apply text-secondary dark:text-secondary bg-surface-variant dark:bg-gray-800 px-1.5 py-0.5 rounded font-mono text-sm;
+    @apply text-secondary! dark:text-dark-on-surface! bg-surface-variant dark:bg-gray-800 px-1.5 py-0.5 rounded font-mono text-sm;
   }
   .prose code::before, .prose code::after {
     content: none;


### PR DESCRIPTION
This PR fixes the contrast issue for inline code blocks in dark mode. Previously, inline code used the secondary color (Orange), which was resolving to a dark/muddy color or being overridden, resulting in poor readability against the dark background (`bg-gray-800`). The fix aligns the text color with article headings (White/Light Gray) using `dark:text-dark-on-surface`, ensuring high contrast and readability as requested. Verified with Playwright screenshot.

---
*PR created automatically by Jules for task [6236582369631728586](https://jules.google.com/task/6236582369631728586) started by @ArceApps*