### PR TITLE
feat(devlog): add mydevbot devlog trilogy

### DIFF
--- a/public/images/mydevbot-cicd-future-hero.svg
+++ b/public/images/mydevbot-cicd-future-hero.svg
@@ -1,0 +1,7 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#f5f5f5"/>
+  <polygon points="200,315 600,50 1000,315 600,580" fill="#018786" opacity="0.8"/>
+  <circle cx="400" cy="315" r="100" fill="#FF9800" opacity="0.8"/>
+  <circle cx="800" cy="315" r="100" fill="#FF9800" opacity="0.8"/>
+  <rect x="500" y="215" width="200" height="200" fill="#018786" opacity="0.5"/>
+</svg>

--- a/public/images/mydevbot-hardware-hero.svg
+++ b/public/images/mydevbot-hardware-hero.svg
@@ -1,0 +1,6 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#f5f5f5"/>
+  <circle cx="600" cy="315" r="200" fill="#018786" opacity="0.8"/>
+  <rect x="450" y="165" width="300" height="300" fill="#FF9800" opacity="0.8"/>
+  <polygon points="600,100 800,500 400,500" fill="#018786" opacity="0.5"/>
+</svg>

--- a/public/images/mydevbot-skills-cron-hero.svg
+++ b/public/images/mydevbot-skills-cron-hero.svg
@@ -1,0 +1,6 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#f5f5f5"/>
+  <rect x="300" y="215" width="600" height="200" fill="#018786" opacity="0.8"/>
+  <circle cx="600" cy="315" r="150" fill="#FF9800" opacity="0.8"/>
+  <polygon points="300,315 600,100 900,315 600,530" fill="#018786" opacity="0.5"/>
+</svg>

--- a/src/content/devlog/en/2026-03-05-mydevbot-genesis-hardware.md
+++ b/src/content/devlog/en/2026-03-05-mydevbot-genesis-hardware.md
@@ -1,0 +1,127 @@
+---
+title: "The birth of mydevbot and the odyssey of the perfect hardware"
+description: "How the need to control my development ecosystem from Telegram arises, the analysis of the AIPAL repository, the disappointment with the Synology DS212+ and the final decision for a Mini PC with the native Gemini SDK."
+pubDate: 2026-03-05
+tags: ["devlog", "telegram", "mydevbot", "gemini", "hardware", "minipc", "docker"]
+heroImage: "/images/mydevbot-hardware-hero.svg"
+reference_id: "a2e2f3d0-729b-4fcb-ae9c-5c9c95977d00"
+---
+
+Sometimes, the best ideas are born out of pure frustration. It was a Thursday afternoon, I was on public transport, coming home after an exhausting day, and suddenly I remembered that I hadn't reviewed a critical Pull Request in one of my personal repositories. I also hadn't scheduled the cron job for a maintenance task that was supposed to run that same night. I took out my phone, opened the browser, entered GitHub and found the typical mobile experience: zooming in, trying to press the right button with my clumsy fingers, dealing with the intermittent subway connection... It was a disaster.
+
+At that moment, I looked at the Telegram application that I had just opened to reply to a message and had an epiphany. Telegram is fast, lightweight, works perfectly even with terrible coverage, and its bot API is one of the best in the industry. What if I could manage my entire development ecosystem, my repositories, my scheduled tasks, and my infrastructure directly from a Telegram chat? What if I could have an intelligent assistant, powered by Artificial Intelligence, that not only executed commands but understood my intentions in natural language?
+
+That was the seed of **mydevbot**. A personal, private, sovereign, and extremely capable bot. But from concept to reality, there is a technological abyss. In this first entry of my development diary, I will recount the first steps of this project, which began not with code, but with deep research on architecture and hardware. Because, as I would soon discover, someone else's cloud was not the right place for my personal assistant.
+
+### The Starting Point: Exploring the Existing Ecosystem
+
+My first reaction, as a good developer, was to look if someone had already solved this problem. There was no point in reinventing the wheel if a robust, open-source solution already existed. During my research, I stumbled upon a very interesting repository called [AIPAL](https://github.com/antoniolg/aipal), created by antoniolg.
+
+AIPAL proposes using Telegram as a bridge to interact with a local AI. The premise is fantastic: you maintain privacy, use your own resources, and have a universal chat interface. I cloned it, configured it, and it worked. It was magical to be able to send a message from the street and have my PC at home process the request and return the AI's response. The bot acted as a perfect bridge. I didn't need to open ports on my router or deal with complex NAT configurations, since the Telegram library uses *long polling*. The bot simply asks Telegram's servers periodically if there are new messages.
+
+However, after the initial euphoria, the limitations became evident. AIPAL and similar solutions have a fundamental Achilles heel for my use case: they require the equipment where they are running to be turned on and connected to the Internet permanently. In my case, that meant leaving my main computer (a powerful, noisy tower with significant energy consumption) turned on 24/7.
+
+Leaving a 600W machine turned on all day just to keep a Telegram bot alive that receives a few dozen messages a day is inefficient from any point of view. Economically it is a waste on the electricity bill, and ecologically it is irresponsible. Furthermore, the noise of the fans in the silence of the night was a constant annoyance. I needed another solution. The concept of AIPAL validated my hypothesis that Telegram was the perfect interface, but it forced me to completely rethink the hardware.
+
+### The Illusion of the Synology DS212+ and the Clash with Reality
+
+Thinking about low-power hardware that I already had at home, my gaze settled on a corner of my shelf where an old but loyal NAS server was gathering dust: the **Synology DS212+**. It is a classic model, released in 2012. In its golden age, it was a marvel for network storage, and best of all: it consumes very little. We are talking about 15-20W at peak performance and just a few watts at rest. It seemed like the ideal candidate.
+
+The idea was brilliant: run the bot on the NAS. The NAS is already always on, managing my backups and my media files. What does it matter to add a small Python script to manage *mydevbot*?
+
+I connected via SSH to the old DS212+. The terminal welcomed me with that familiar, spartan, stripped-down Linux prompt. I started reviewing the specifications and possibilities. And this is where my dreams violently crashed against the wall of technological obsolescence.
+
+The first major problem: the processor. The DS212+ has an old 32-bit ARM processor. The RAM memory is barely 512 MB. This, in the year 2026, is the technological equivalent of trying to cross the ocean in a nutshell. But the real nail in the coffin was the **lack of support for Docker**.
+
+In the Synology family, only the more recent "+" series models with x86_64 processors (Intel or AMD) have official and functional support for Docker (or Container Manager, as they call it now). For J or Play series models, and certainly for a 2012 model, Docker is an impossible dream.
+
+Why is Docker so critical? You could just install Python, you might say. And yes, it is possible to install Python 3 on the DS212+ through the package center or using community repositories like Entware. But developing, deploying, and maintaining a modern application in such a hostile and fragile environment is a recipe for disaster. Managing virtualized dependencies, compiling C libraries that the AI ecosystem often requires, and dealing with a proprietary operating system (DSM) that is not meant to be a general-purpose application server... was not the way to go.
+
+I imagined the workflow: writing the code on my laptop, passing it via SCP to the NAS, crossing my fingers that the pip dependencies would install correctly on that old ARMv5 architecture, and using the NAS task scheduler to restart the script if it failed. It was going back to the deployment practices of fifteen years ago. The friction would be so high that I would end up abandoning the project.
+
+The Synology DS212+ was ruled out. It remains an excellent guardian of my historical files, but to host *mydevbot*, I needed something modern, efficient, and versatile.
+
+### The Mini PC Revolution: The Perfect Balance
+
+Having ruled out the main PC due to consumption and the NAS due to obsolescence, I evaluated cloud server alternatives. A free Oracle VPS or a small AWS EC2 instance. But here my principles of **technological sovereignty** came into play. If this bot was going to have access to all my private repositories, my tasks, my calendar, and if it was going to be my "extended brain", I didn't want it to be hosted on the infrastructure of a tech giant, subject to changes in terms of service, regional outages, or data inspections. I wanted the iron in my house. Physically under my control.
+
+This led me to the fascinating and competitive world of modern Mini PCs. In recent years, the Mini PC market has exploded, driven by advances in laptop processors that offer spectacular performance with ridiculously low consumption.
+
+I spent days researching, watching benchmarks, and comparing options. The balance quickly tipped towards platforms based on AMD Ryzen. My finalists were three specific models that marked the sweet spot between price, power, efficiency, and crucially, future connectivity.
+
+The undisputed king of my options was the **Minisforum UM890 Pro**. With a Ryzen 9 8945HS processor (Hawk Point architecture with integrated NPU for AI tasks), 32GB of DDR5 RAM, and plenty of connectivity. This beast is the equivalent of a top-tier laptop compressed into a box the size of a small book. Its idle power consumption is around 10-15W, and at peak performance, it doesn't exceed 65W. It was the homelabber's wet dream. However, its price was around €800. A significant investment.
+
+As cheaper alternatives, around €500, there were the **Minisforum UM780 XTX** and the **GMKtec K8**. Both mount the excellent Ryzen 7 7840HS. A step behind the 8945HS, but with more than enough power to be the brain of my digital home, run dozens of Docker containers without breaking a sweat, and handle the bot with ease.
+
+What made these models stand out above other cheaper options (like the typical Intel N100s) was a key feature that weighed heavily on my long-term decision: the **OCuLink port**.
+
+Although *mydevbot* would initially communicate with the Gemini cloud API, my vision for the future is to have the ability to run complex LLMs (deep reasoning models) 100% locally. For that, you need graphics power (VRAM). Integrated graphics (the Radeon 780M on these Ryzens) are surprisingly good, but they can't compete with a dedicated GPU.
+
+The OCuLink (Optical-Copper Link) port is a direct PCIe x4 connection. It is much more efficient than Thunderbolt 4/5 for connecting an external graphics card (eGPU). With an OCuLink eGPU dock, I could connect a desktop graphics card (like a hypothetical RTX 5070 or 5080) directly to the Mini PC in the future. The performance loss compared to plugging it into a traditional motherboard is barely 5-10%. That is to say, the Mini PC gave me the low consumption of a laptop for daily use, with the ability to transform into an AI processing monster when I needed it, simply by plugging in a cable.
+
+Finally, I decided to purchase the Minisforum UM890 Pro. I wanted that extra power from the integrated NPU and the peace of mind of having top-tier hardware for the next five years. I received it at home, installed Ubuntu Server 26.04 LTS on it, and configured the base environment with Docker and Docker Compose. Seeing the system boot up in seconds and consume barely 11 watts confirmed that I had made the right decision. I now had the perfect home for *mydevbot*.
+
+### The Software Architecture: Gemini CLI or Native SDK?
+
+With the hardware ready (the UM890 Pro purring silently on a living room shelf), it was time to define the software stack. I knew I would use Python. I knew I would use the `python-telegram-bot` library to handle the long-polling communication with Telegram's servers. But the central piece was the brain of the AI.
+
+Initially, I evaluated using the official **Gemini CLI** tool. It is a fantastic tool for bash scripts and quick automations. I could have the Python script launch a subprocess (`subprocess.run`), execute the Gemini CLI command passing it the user's message, capture the standard output, and send it back via Telegram.
+
+I did a proof of concept. It worked. But it was clunky.
+
+The CLI-based approach has several serious problems when you try to build a persistent conversational bot:
+
+1. **Context and state management:** Every call to the CLI is, by default, stateless. To maintain a fluid conversation, I would have to save the conversation history in a temporary file, pass the whole thing to the CLI on every call, and parse the response. A nightmare of inefficiency.
+2. **Latency (Startup overhead):** No matter how fast it is to invoke a binary, launching a new operating system subprocess for every message adds latency. I wanted *mydevbot* to be instantaneous, agile.
+3. **Blind error handling:** Capturing errors by analyzing the output text of a terminal command (stderr) is fragile. If the API changes its error format, the bot breaks silently.
+4. **Loss of advanced features:** Features like "Function Calling" (where the AI decides to execute an external tool, like querying the GitHub API) are tremendously complex to implement by parsing text from a CLI.
+
+The decision was obvious: I had to use the **official Google GenAI SDK for Python** (`google-genai`).
+
+By integrating the SDK directly into my bot's code, I gained absolute control. I could initialize an instance of the **Gemini 1.5 Flash** model (I chose Flash for its extreme speed and extremely low cost/free tier, ideal for a quick assistant). The SDK allows managing chat sessions with persistent state. I just have to instantiate a `ChatSession` object, pass it the user's new message, and the SDK takes care of sending all the previous context to the API and returning the response.
+
+The code was simplified enormously:
+
+```python
+import google.generativeai as genai
+
+# Initial setup
+genai.configure(api_key=os.environ["GEMINI_API_KEY"])
+model = genai.GenerativeModel('gemini-1.5-flash')
+chat_session = model.start_chat(history=[])
+
+def handle_message(update, context):
+    user_text = update.message.text
+    # Send to the model, maintaining context
+    response = chat_session.send_message(user_text)
+    # Reply on Telegram
+    update.message.reply_text(response.text)
+```
+
+That simplicity is power. With the native SDK, responses arrive in milliseconds. Exception handling (exceeded quotas, network errors) is managed elegantly with `try-catch` blocks. And most importantly, it opened the doors wide to Gemini's tools (Tools/Skills), which would allow me to integrate GitHub natively. But I will talk about that in the next article.
+
+### Conclusion of this first phase: The birth of mydevbot
+
+That same Sunday night, after hours of configuring the server and writing the basic structure of the bot in Python, the moment of truth arrived. I packaged the code into a Docker container using a simple `Dockerfile`, created a `docker-compose.yml` to manage the environment variables (the Telegram Token and the Gemini API Key, safe and protected), and executed the magic command:
+
+`docker compose up -d`
+
+The container started. I checked the logs: `[INFO] Bot started. Polling Telegram servers...`
+
+I turned off my phone's Wi-Fi, connecting to the 5G network to simulate being away from home. I opened Telegram, searched for `@my_private_dev_bot` and wrote the inaugural message:
+
+`"Hello, are you there? Tell me what hardware is running you."`
+
+Half a second passed. The Telegram double check turned blue. And the answer appeared on my screen:
+
+`"Hello! I'm online and ready. Analyzing my environment... I am running inside a Linux container (probably Docker). And judging by the number of cores I see in /proc/cpuinfo, I am running on an 8-core, 16-thread monster. How can I help you boss?"`
+
+I couldn't help but smile. **mydevbot** was born. I no longer depended on my noisy desktop PC being turned on. I had a low-power, powerful, dedicated server, and a clean, native software architecture.
+
+The bridge between my mobile phone anywhere in the world and my development ecosystem was built. But a bridge is not useful if it doesn't lead anywhere. The bot could chat, but it couldn't *work* yet.
+
+The next step, the real challenge that would change the way I work, was to endow it with real skills. Teach it to interact with the GitHub API so it could read my repositories, create issues, and manage my tasks. And, of course, implement a cron task system so the bot would proactively inform me, instead of waiting for my orders.
+
+All of that will be the main topic of the next entry in this devlog. The real revolution of *mydevbot* has just begun. See you tomorrow.
+
+*(Continues in: Teaching mydevbot to program - GitHub Skills and Cron Tasks)*

--- a/src/content/devlog/en/2026-03-06-mydevbot-github-cron-skills.md
+++ b/src/content/devlog/en/2026-03-06-mydevbot-github-cron-skills.md
@@ -1,0 +1,172 @@
+---
+title: "Teaching mydevbot to program - GitHub Skills and Cron Tasks"
+description: "The second phase of mydevbot. How to integrate the GitHub API using Gemini's Function Calling capabilities and set up scheduled tasks with APScheduler to receive daily summaries."
+pubDate: 2026-03-06
+tags: ["devlog", "telegram", "mydevbot", "gemini", "github", "cron", "python"]
+heroImage: "/images/mydevbot-skills-cron-hero.svg"
+reference_id: "0463727d-8058-4f3a-b565-1baec56b3470"
+---
+
+Yesterday I left the story at a sweet spot. I had **mydevbot** running in its brand new home: a Minisforum UM890 Pro Mini PC with ridiculous power consumption and plenty of power. The bot could reply to Telegram messages in milliseconds thanks to the use of the native Google Gemini SDK (specifically, Gemini 1.5 Flash). It was fast, efficient, and private.
+
+But let's be honest: a bot that is only good for chatting, no matter how fast it is, is nothing more than a glorified ChatGPT with a different interface. For *mydevbot* to earn its name and truly revolutionize my workflow, I needed to give it hands. I needed it to be able to touch my repositories, read my code, manage my issues, and keep an eye on my infrastructure while I was busy with other things.
+
+The goal of this second development phase was twofold:
+1.  **Deep integration with GitHub:** Make the bot able to manage entire repositories, create issues, review Pull Requests, and even suggest code, all from the Telegram chat interface.
+2.  **Proactivity through Cron tasks:** Stop the bot from being purely reactive. I wanted it to wake me up in the morning with a summary of server errors or pending issues, without me having to ask.
+
+This is the chronicle of how *mydevbot* went from being a conversational parrot to becoming my personal DevOps engineer.
+
+### The Art of Skills: Function Calling with Gemini
+
+In the world of Large Language Models (LLMs), there is a before and an after "Function Calling" (or tool/skill invocation). Before, if you wanted an AI to interact with an external system, you had to juggle prompts. You would tell the AI: *"If the user asks you for the temperature in Madrid, reply exactly with the word WEATHER_MADRID and nothing else"*. Then, your code would parse that exact response, call the weather API, and return the data to the AI so it could draft the final answer. It was a fragile, error-prone process, severely limited in complexity.
+
+Function Calling changed the rules of the game. Now, instead of trying to trick the AI, you give it an explicit instruction manual on what tools (Python functions) it has at its disposal, what parameters those functions accept, and what they return. The AI natively decides when it is appropriate to use a tool based on the user's request.
+
+For *mydevbot*, this meant I didn't have to write a complex `if/else` tree to parse whether the user said "create an issue" or "review this repo". I simply gave Gemini the tool, and it took care of the semantics.
+
+The first step was to integrate the GitHub API. I used the **PyGithub** library, an excellent and robust wrapper for interacting with the GitHub REST v3 API in Python. The main challenge here was security. Under no circumstances was I going to hardcode my credentials directly into the code. I generated a **Personal Access Token (PAT)** on GitHub with strictly limited permissions (read repositories and write issues/PRs, but no permissions to delete repositories). This token would be loaded as a secure environment variable in the Docker container.
+
+Once access was secured, I started defining *mydevbot*'s "Skills". The first and most obvious one: getting a summary of the repositories.
+
+I defined the Python function using PyGithub:
+
+```python
+from github import Github
+import os
+
+def get_repo_summary(repo_name: str) -> str:
+    """Gets a summary of the current state of a GitHub repository (stars, forks, open issues)."""
+    try:
+        g = Github(os.environ["GITHUB_PAT"])
+        repo = g.get_repo(repo_name)
+
+        summary = f"Repository: {repo.full_name}\n"
+        summary += f"Description: {repo.description}\n"
+        summary += f"Stars: {repo.stargazers_count}\n"
+        summary += f"Open Issues: {repo.open_issues_count}\n"
+        return summary
+    except Exception as e:
+        return f"Error accessing the repository: {str(e)}"
+```
+
+The magic happens in how you pass this function to the Gemini SDK. When you initialize the model, you tell it that this tool is available. The model reads the docstring (`"""Gets a summary..."""`) and the type annotations (`repo_name: str`) to understand how and when to use it.
+
+The first test was a moment of pure nerd euphoria. I opened Telegram and wrote to *mydevbot*:
+*"Hey, how is the ArceApps/PuzzleHub repository doing? Do we have a lot of pending work?"*
+
+On the backend, I watched the server logs. The flow went like this:
+1.  Gemini received my message.
+2.  It analyzed my intent and determined that it needed to query GitHub data to answer me.
+3.  Instead of generating a text response, Gemini returned a structured request: *"I want to execute the function `get_repo_summary` with the parameter `repo_name="ArceApps/PuzzleHub"`"*.
+4.  My Python script intercepted this request, executed the actual function against the GitHub API, and got the text with the stars and issues.
+5.  My script returned that data to Gemini.
+6.  Finally, Gemini analyzed that data and drafted the natural response for Telegram: *"I just checked the ArceApps/PuzzleHub repository. It currently has 3 open issues pending review. Do you want me to list the titles of those issues for you?"*
+
+It worked! The bot was using tools autonomously. And the natural response (the fact that it asked me if I wanted to list the titles) proved that it maintained context and reasoned about the data obtained; it wasn't a simple database dump.
+
+### Expanding the Arsenal: From Reading to Writing
+
+Reading data is fine, but the real power lies in acting. The next phase was to endow *mydevbot* with the ability to actively interact with my projects. Writing code, creating issues, commenting on PRs.
+
+I created a complete suite of tools for GitHub. Some of the most useful ones I implemented that same afternoon were:
+
+*   `create_github_issue(repo_name: str, title: str, body: str, labels: list)`: To report bugs on the fly. If I'm testing one of my apps on my phone and I find a UI error, I no longer have to open my laptop. I simply go to Telegram and tell mydevbot: *"Create an issue in the web repo indicating that the contact button in dark mode doesn't have enough contrast. Label it as bug and ui"*. The bot extracts the parameters perfectly and creates the ticket.
+*   `get_latest_pr_diff(repo_name: str)`: This was one of my favorites. It allows the bot to read the diff (the code changes) of the latest open Pull Request. And since Gemini has a huge context window (especially the 1.5 Pro version, although Flash also works very well for medium diffs), it can analyze that code and look for bugs.
+*   `comment_on_pr(repo_name: str, pr_number: int, comment: str)`: The logical complement to the previous one. After the bot reads the diff, it can post a comment directly on GitHub.
+
+I remember the first time I tested the full flow. I had pushed a small patch from my laptop, but I wasn't sure if I had introduced a possible concurrency issue. I went to the couch, opened Telegram, and asked mydevbot to review the PR.
+
+The bot queried the API, downloaded the diff, analyzed it (using its inherent programming knowledge), and replied to me: *"I have reviewed PR #42. The code seems solid overall, but in the `worker.py` file you are using a dictionary shared between threads without a lock. This could cause race conditions. Do you want me to leave this comment on the PR for you?"*.
+
+I replied with a simple *"Yes, please, and add that I will review it tomorrow"*. Seconds later, my phone vibrated with a notification from the official GitHub app: *mydevbot* had commented on my PR exactly what I had asked, drafted in a professional tone.
+
+The level of friction for managing my projects had been reduced to almost zero. I could do review tasks, planning, and bug triage while walking down the street, using only my voice (through Telegram voice messages, which we also integrated using Whisper, but that's another story) and my personal bot.
+
+### The Need for Proactivity: The Problem with Being Reactive
+
+Up to this point, *mydevbot* was a formidable tool, but it was still reactive. It only did things when I spoke to it. And one of the fundamental problems of managing personal infrastructure or side projects is forgetting.
+
+If I don't remember to ask the bot how the repositories are doing, issues pile up. If I don't ask it about the server status, a hard drive can silently fill up until it causes a catastrophic failure. A real assistant doesn't wait for you to ask if the house is on fire; it warns you as soon as it smells smoke.
+
+I needed to implement background tasks. I needed **Cron**.
+
+In the traditional Linux environment, setting up repetitive tasks is done with the cron daemon (editing `crontab`). It's reliable, rock-solid, but it's an operating system component. If I configured cron on the Mini PC at the system level to call Python scripts, I would be breaking the encapsulation of my Docker environment. Furthermore, I would lose the seamless integration with the bot's persistent instance and the Gemini SDK.
+
+I wanted the scheduled tasks to live inside the same *mydevbot* code, sharing the same memory context, the same Telegram session, and the same GitHub tools. The answer was obvious to any Python developer: **APScheduler** (Advanced Python Scheduler).
+
+APScheduler is a fantastic library that allows you to schedule Python jobs similarly to cron, but integrated directly into your application. It is lightweight, requires no external processes, and integrates beautifully with asynchronous applications like `python-telegram-bot`.
+
+### Implementing APScheduler: The Morning Briefing
+
+The integration was surprisingly simple. I added the dependency to my `requirements.txt` and modified the main bot script.
+
+The inaugural goal for the cron system was to create the **Morning Briefing**. I wanted *mydevbot* to send me a structured message every day at 08:30 in the morning, Monday through Friday, with a summary of everything I needed to know to start the day.
+
+```python
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+async def morning_briefing(context: ContextTypes.DEFAULT_TYPE):
+    chat_id = os.environ["MY_TELEGRAM_CHAT_ID"]
+
+    # Gather data (using the previously created functions)
+    repo_status = get_repo_summary("ArceApps/PuzzleHub")
+
+    # Ask Gemini to format the summary in a friendly way
+    prompt = f"Act as my personal assistant. Write a friendly and professional good morning message. " \
+             f"Include this main repository status in a summarized way: {repo_status}. " \
+             f"Add a short motivational message at the end."
+
+    response = chat_session.send_message(prompt)
+
+    # Send the message via Telegram proactively
+    await context.bot.send_message(chat_id=chat_id, text=response.text)
+
+# On bot initialization:
+scheduler = AsyncIOScheduler()
+scheduler.add_job(
+    morning_briefing,
+    trigger=CronTrigger(day_of_week='mon-fri', hour=8, minute=30),
+    args=[application] # Pass the Telegram app instance
+)
+scheduler.start()
+```
+
+That code is the foundation of proactivity. The `CronTrigger` block allows for incredible flexibility. I could schedule tasks to run every hour, on the first Sunday of every month, or complex combinations.
+
+The morning after implementing this was magical. I was having my first coffee of the day, mentally preparing for the workday, when my phone vibrated at exactly 08:30. It was a Telegram message from *mydevbot*:
+
+*"Good morning boss! I hope you rested well. Here is today's briefing: The ArceApps/PuzzleHub repository currently has 3 open issues waiting for your attention and 1 Pull Request ready for merge review. It looks like the community has been active tonight. Remember that small constant steps build great projects. Have a great day!"*
+
+I didn't have to open any app. I didn't have to remember to look. The information came to me, filtered, formatted nicely, and at the exact moment I needed it.
+
+From there, the possibilities for APScheduler "jobs" exploded in my head. I started adding more cron tasks to *mydevbot*'s arsenal:
+
+*   **Server health monitor (Every 6 hours):** A simple script that reads the CPU, RAM, and disk usage of the Mini PC. If any of these values exceed 90%, the bot sends me an urgent alert (using red/bold text formatting) on Telegram warning me of the bottleneck.
+*   **Docker container cleanup (Sundays at 3:00 AM):** A script that runs a `docker system prune -f` to free up space, and then sends me a message confirming the megabytes freed.
+*   **Stand-up reminders (Mondays at 10:00 AM):** A quick ping asking me what my weekly goals are for the devlog project, forcing me to write them down and, therefore, commit to them.
+
+### Reflection: The Qualitative Leap
+
+Going from a reactive conversational bot to a proactive assistant integrated with the API of my main tools was a massive qualitative leap. It was no longer just a fun proof of concept. It was a real productivity tool, hosted on my own hardware (the heroic UM890 Pro), with no recurring monthly subscriptions and total privacy for my data.
+
+I had solved the initial problem. I could now manage my repositories from the subway without getting frustrated with mobile web interfaces. I could find out about server issues before users complained. I had achieved my goal.
+
+But, as any developer knows, a project is never really finished. Once you solve the main problem, you start seeing new opportunities. The environment was perfect, the codebase was solid, and the modular architecture invited me to dream big.
+
+If I could create issues from my phone, why not be able to write complex code? If I had a free OCuLink port on the Mini PC, why limit myself to the cloud API if I could connect a dedicated desktop graphics card and run huge models locally? And if the manual configuration of Python code became tedious for very complex flows, what visual tools could I integrate?
+
+These ambitions would mark the third and final phase of this stage of development. A phase focused on continuous evolution, on the automation of the bot's own code (CI/CD), and on the exploration of the most cutting-edge technologies (eGPUs, automation tools like n8n, and Anthropic's new MCP standard). All this, along with the irony of how *mydevbot* updates itself, will be the story that closes this trilogy tomorrow.
+
+### Scalability and the Immediate Future of Skills
+
+Before concluding this entry, I think it is essential to reflect on what this Skills and Cron-based architecture really means for the future of my daily work. We have gone from a simple script that answers messages to a personal operating system distributed in the cloud, but firmly anchored in the hardware of my home.
+
+The modularity of the Python functions, exposed through the Gemini SDK, means that the limit of what *mydevbot* can do is defined solely by the APIs I decide to integrate. If tomorrow I want the bot to manage my personal finances, I only have to create a `finance_skills.py` file, integrate my bank's API, add the corresponding description in the docstring, and restart the container. Gemini will immediately understand its new purpose and its new capabilities.
+
+This organic extensibility is any software developer's wet dream. There is no need to rewrite the user interface, no need to design new menus or buttons in Telegram. The interface is natural language, and natural language is universal.
+
+Furthermore, the use of APScheduler has transformed my relationship with information. I am no longer the one chasing the data for my projects; the data comes to me when it is relevant. The morning summary is just the beginning. I imagine a near future where *mydevbot* not only informs me of problems but, using its GitHub Skills, proposes and executes automated solutions (like self-assigning trivial PRs, approving minor dependency changes, or even restarting unresponsive servers), notifying me only when the task has been successfully completed.
+
+The real challenge now is not technical, but conceptual. How much autonomy am I willing to give to this system? To what extent do I want an AI to manage my repositories without my direct supervision? These are fascinating questions that I will be answering as the project matures. For now, I have built the perfect foundations. Tomorrow we will explore how to scale this infrastructure and prepare it for the future.

--- a/src/content/devlog/en/2026-03-07-mydevbot-cicd-egpu-future.md
+++ b/src/content/devlog/en/2026-03-07-mydevbot-cicd-egpu-future.md
@@ -1,0 +1,139 @@
+---
+title: "The maturity of mydevbot - CI/CD, eGPUs and the future of mobile development"
+description: "The final phase. How mydevbot deploys itself using GitHub Actions and Watchtower, mobile programming with VS Code Server and the preparation of the UM890 Pro for extreme local AI via OCuLink."
+pubDate: 2026-03-07
+tags: ["devlog", "telegram", "mydevbot", "cicd", "oculink", "egpu", "vscode", "n8n"]
+heroImage: "/images/mydevbot-cicd-future-hero.svg"
+reference_id: "83523401-9392-426f-b039-f3ae73132d40"
+---
+
+We have reached the last entry of this trilogy about **mydevbot**. If in the [first article](2026-03-05-mydevbot-genesis-hardware) I talked about the odyssey to find the perfect hardware (the Minisforum UM890 Pro) and in the [second](2026-03-06-mydevbot-github-cron-skills) I detailed how I taught it to use the GitHub API and wake me up with daily summaries, today it's time to talk about scalability, automation, and the real development experience.
+
+Because here is a fascinating paradox: I have built a Telegram bot to manage my software development while I am away from home... but what happens when I want to develop or improve *the bot itself* while I am away from home?
+
+If I am in a coffee shop, without my laptop, and suddenly I come up with a great new *Skill* for mydevbot to format my code using *black*, how do I implement it? I can't send a voice message to the bot telling it to "modify your own source code", because that would be a monumental security risk (as well as technically suicidal with the current version).
+
+I needed to close the circle. I needed the Mini PC hosting mydevbot to become not just an execution server, but my complete remote development environment.
+
+### The Mobile Development Environment: VS Code Server
+
+Writing code on a 6-inch mobile screen is a pain, I admit it. But in the year 2026, modern smartphones (like my Pixel) have fantastic desktop modes when you connect them to an external monitor or even lightweight mixed reality glasses. Even without accessories, with a good foldable Bluetooth keyboard, you can manage very well.
+
+The historical problem has always been the environment. Setting up Git, Python, dependencies, and a decent editor on Android (using Termux, for example) is feasible but clunky.
+
+The solution was already on the Mini PC itself. The UM890 Pro, with its 32GB of RAM, was barely sweating with the *mydevbot* container. I decided to install **VS Code Server**.
+
+For those who don't know it, VS Code Server allows you to run the Visual Studio Code backend on your remote server and access the full, native user interface through any web browser.
+
+I added a new container to my `docker-compose.yml` on the Mini PC: an official `code-server` container from *linuxserver.io*. I configured it to map the folder where the *mydevbot* code lives as a working volume.
+
+To access it securely from outside my home without opening ports to the world (and exposing myself to brute force attacks), I used **Tailscale**. I installed the Tailscale client on the Mini PC and on my mobile phone. Thus, my phone was part of an encrypted mesh virtual private network (VPN) with the Mini PC.
+
+Now, the flow is pure science fiction:
+1.  I am on the train.
+2.  I turn on the Bluetooth keyboard.
+3.  I open my mobile browser (Brave) and type the Tailscale IP of my Mini PC (e.g., `http://100.80.x.x:8443`).
+4.  The full VS Code editor appears, with my themes, my keyboard shortcuts, and direct access to the *mydevbot* code.
+
+I can write a new Python function in the browser editor, save it, and immediately test it by running the script in the integrated browser terminal.
+
+But here a problem arises. If I change the code, I need to restart the *mydevbot* Docker container for it to pick up the changes. And worse, those changes are "loose" on the server; I need to commit and push them to GitHub so as not to lose version control.
+
+I could do it by hand from the VS Code Server terminal, but if I have built an automated ecosystem, I wanted my bot's deployment to be automatic as well.
+
+### CI/CD for a Home Bot: Watchtower to the Rescue
+
+I wanted to get to a point where I simply did `git push` (whether from the VS Code Server on my phone or from my laptop at home) and the Mini PC would update itself. A full-fledged Continuous Integration / Continuous Deployment (CI/CD) pipeline, but for my homelab.
+
+Traditionally, in enterprise environments, a GitHub Action would connect via SSH to my server and execute an update script. Or I would use tools like ArgoCD. But those options are complex to maintain in a home environment where my public IP might change (even using Tailscale).
+
+The most elegant answer for Docker containers is **Watchtower**.
+
+Watchtower is a container whose sole job is to watch other containers. Periodically (for example, every 5 minutes), Watchtower queries the image registry (Docker Hub, or GitHub Container Registry) to see if there is a newer version of the image of a currently running container. If it finds a new image, Watchtower gracefully stops the old container, downloads the new image, and starts it using exactly the same environment variables and volumes (`docker-compose` settings) as the original container.
+
+The full pipeline was set up like this:
+
+1.  **Development:** I modify the `mydevbot` code in the browser (via VS Code Server) or locally.
+2.  **Commit and Push:** I do `git commit -m "New finance skill"` and `git push`.
+3.  **GitHub Actions (CI):** On GitHub, an Action detects the push. It runs a Python linter (flake8), passes the basic unit tests I wrote, and if everything is green, it builds a new Docker image and pushes it to the GitHub Container Registry (GHCR) tagged as `latest`.
+4.  **Watchtower (CD):** On my Mini PC, Watchtower, which is running in the background, detects that there is a new `latest` image in the GHCR.
+5.  **Automatic Restart:** Watchtower kills the old *mydevbot* process, downloads the new image, and starts it.
+
+All this happens in about 3 minutes on the clock. I push from my phone, take a sip of coffee, and when I return to Telegram, I ask *mydevbot* what version it is running, and it answers with the new commit hash.
+
+It's the magic of DevOps applied to my personal life. There is no more friction. If the bot fails, I fix it, push it, and forget about it.
+
+### The Horizon of Local AI: The OCuLink Port and eGPUs
+
+At this point, the software architecture was solid. But I want to talk about hardware again. About that OCuLink port I mentioned in the first article and which was the decisive factor for buying the Minisforum UM890 Pro instead of cheaper alternatives.
+
+Currently, *mydevbot* uses the Gemini 1.5 Flash API. It is fast, it is almost free, and it is brilliant for programming. But it is still "The Cloud". If tomorrow I lose internet access (and the fiber optic network in my area has occasional outages), or if Google decides to radically change its API pricing, my automated brain will stop working.
+
+The true sovereignty I spoke of at the beginning is only achieved when the Language Model runs physically in your home.
+
+For simple tasks, the Ryzen 9 8945HS of the Mini PC (with its CPU and its NPU) can run small local models (like a Llama 3 8B or a Phi-3) at an acceptable speed using tools like **Ollama**. But if I want a model that can read my entire code repositories and perform complex reasoning about the software architecture, I need larger models (from 30B to 70B parameters).
+
+And those models devour VRAM (Video Memory).
+
+This is where the OCuLink port comes into play. The plan for Q3 2026 is to acquire an eGPU (External GPU) dock that connects via OCuLink. These docks are essentially a bare PCIe slot with a power supply.
+
+My goal is to connect a dedicated desktop graphics card, like an **RTX 5070 Ti** or even an **RTX 5080** (when they drop in price on the second-hand market or there are sales), directly to the Mini PC.
+
+Unlike Thunderbolt 4 or 5, which introduce latency and bottlenecks due to their data encapsulation, OCuLink is pure PCIe. The performance loss is marginal (between 5% and 10%).
+
+With a 16GB or 24GB VRAM graphics card connected to my low-power Mini PC, *mydevbot*'s architecture will evolve dramatically:
+1.  On a day-to-day basis, the Mini PC will run autonomously with its 15W base consumption, managing the code, the cron jobs, and using small models or the cloud.
+2.  When I need *mydevbot* to do heavy lifting (like a massive automatic refactor, or complex vulnerability analysis), I will remotely turn on the eGPU power supply.
+3.  The bot will detect the presence of the graphics card and switch its inference backend from the Gemini API to a local Ollama/vLLM server running on the eGPU.
+
+This hybridization (low power by default, extreme power on demand) is the future of home servers and personal AI agents.
+
+### Beyond Python: Exploring n8n and MCP
+
+Manually building Skills in Python is fun and gives you total control. But let's admit it: sometimes you want to connect two services without having to write 50 lines of code and handle HTTP API exceptions.
+
+During the last few weeks of *mydevbot* development, I have encountered use cases where writing code seemed like overkill. For example, I wanted that if a billing email arrived at a specific Gmail account, the bot would notify me via Telegram and save it in a Google Drive folder.
+
+I could write a Python Skill for Gmail and Drive. But it's tedious.
+
+To solve this, I have started to integrate **n8n** into my Mini PC cluster.
+n8n is a visual workflow automation tool (similar to Zapier or Make, but open-source and self-hostable). It allows you to connect hundreds of applications by dragging and dropping nodes in a graphical interface.
+
+What's fascinating is that n8n doesn't replace *mydevbot*; it complements it. I have configured Webhooks in n8n that *mydevbot* can call as if they were Skills.
+Thus, if I tell the bot *"Hey, save this receipt in my invoices Drive"*, the bot invokes the `trigger_n8n_workflow_invoice` Skill, passes it the file, and n8n visually takes care of uploading it to Drive, renaming it, and classifying it. This separation of responsibilities (the AI manages the intention and language, n8n manages the plumbing of the APIs) is extremely efficient.
+
+Finally, the most promising horizon on the software level is the **Model Context Protocol (MCP)**, the standard promoted by Anthropic.
+Instead of me having to program each GitHub Skill by hand (writing PyGithub code), MCP proposes an architecture where applications (like GitHub, Notion, or local databases) expose MCP servers.
+
+The AI model simply connects to those MCP servers in a standard way and automatically "discovers" what tools it has available and how to use them.
+When Gemini (or local models like Claude/Llama) universally adopt MCP, the amount of "glue" code I'll have to write for *mydevbot* will be reduced by 90%. The bot will simply be the orchestrator (the brain) that connects to the different sensory organs and actuators of the system.
+
+### Epilogue: The End of Desktop PC Tyranny
+
+It has been an intense journey from that frustration on public transport to the sophisticated network of containers, AIs, and integrations that I have at home today.
+
+The most important lesson I have learned is that personal infrastructure must adapt to our way of life, not the other way around. It makes no sense to be chained to a noisy, power-hungry tower to develop software in the year 2026.
+
+With a Minisforum UM890 Pro, Tailscale, VS Code Server, and a super-smart Telegram bot powered by Gemini, I have decoupled *where* I am from *what* I can do.
+
+*mydevbot* welcomes me every morning with a summary of my obligations, watches my servers while I sleep, reviews the code I write from my phone, and deploys itself silently when it detects improvements.
+
+I am no longer a solo developer. I have an operations team working for me 24/7. And it only cost me a little research, some compact hardware, and a fun weekend coding in Python.
+
+The future of development is mobile, assisted, private, and extremely powerful. And thanks to projects like this, that future is already buzzing quietly on a shelf in my living room.
+
+### Real Productivity Impact and Final Thoughts
+
+Looking back at the moment I conceived the idea for *mydevbot* on that crowded subway car, I realize that the real impact of this project goes far beyond mere technical convenience. It's not just about being able to run a `git push` from a mobile phone, or receiving an automated message every morning at 8:30. It's about a fundamental transformation in how I interact with my own projects and my cognitive workload.
+
+Before *mydevbot* arrived, maintaining my personal repositories and home server infrastructure was often a chore. It required a severe mental context switch. I had to physically sit down at the desktop computer, turn on the monitors, open the browser, navigate through multiple GitHub tabs, review Docker container logs via SSH, and finally try to remember exactly what I wanted to do hours ago. That friction-filled process often resulted in procrastination. Issues piled up, dependency updates were postponed, and small UI bugs went unresolved for weeks, simply because "it wasn't worth turning on the PC just to fix a CSS padding."
+
+Today, the story is completely different. *mydevbot* has democratized access to my own development ecosystem, reducing friction to zero. When I spot a small visual bug while testing an app on my phone, I don't make a mental note that I will inevitably forget. I open Telegram, send a quick voice message to my bot explaining the problem, and within seconds, the AI has interpreted my words, interacted with the GitHub API, and created a perfectly formatted, tagged, and assigned issue. The task leaves my head immediately and enters the tracking system in a structured, actionable way.
+
+But the real magic lies in the proactivity driven by cron jobs and APScheduler. The fact that the system informs me, instead of me having to interrogate the system, completely changes the dynamic of responsibility. If a hard drive on my server reaches 90% capacity, *mydevbot* immediately alerts me on Telegram with a priority message. If a critical process fails overnight, I wake up to a detailed summary of the error and often an AI-generated suggestion on how to fix it. I no longer suffer from the anxiety of "is everything running correctly?" I trust that my digital assistant is watching and will let me know if my attention is truly needed.
+
+Furthermore, the integration of VS Code Server and Tailscale has turned any device with a web browser into a powerful software engineering workstation. I have fixed critical bugs, reviewed and merged complex Pull Requests, and even deployed new app versions from a dentist's waiting room, using only a foldable Bluetooth keyboard and my smartphone screen. The feeling of freedom and absolute control over my infrastructure is intoxicating.
+
+Looking to the future, the roadmap for *mydevbot* is as ambitious as it is exciting. The impending integration of an eGPU via the Minisforum UM890 Pro's OCuLink port will open the doors to running massive language models locally, ensuring absolute privacy and freeing me from reliance on cloud APIs. Adopting n8n for visual automation of complex workflows will drastically reduce the amount of custom code I need to write, allowing the bot to interact with hundreds of external services with just a few clicks. And the arrival of the Model Context Protocol (MCP) will standardize how AIs discover and use tools, making *mydevbot* a universal orchestrator capable of handling any task I throw at it.
+
+Ultimately, *mydevbot* is much more than a fun weekend project. It is a statement of intent. It is proof that, with the right hardware (powerful, efficient, and sovereign), modern software tools, and a dash of ingenuity, a solo developer can build and operate infrastructures that rival those of large tech companies in sophistication. The era of relying on the traditional desktop PC is over. The era of ubiquitous, intelligent, and automated development has arrived. And I, for one, am ready to enjoy the ride, knowing my loyal bot watches my repositories while I sleep.

--- a/src/content/devlog/es/2026-03-05-mydevbot-genesis-hardware.md
+++ b/src/content/devlog/es/2026-03-05-mydevbot-genesis-hardware.md
@@ -1,0 +1,127 @@
+---
+title: "El nacimiento de mydevbot y la odisea del hardware perfecto"
+description: "Cómo surge la necesidad de controlar mi ecosistema de desarrollo desde Telegram, el análisis del repositorio AIPAL, la decepción con el Synology DS212+ y la decisión final por un Mini PC con el SDK nativo de Gemini."
+pubDate: 2026-03-05
+tags: ["devlog", "telegram", "mydevbot", "gemini", "hardware", "minipc", "docker"]
+heroImage: "/images/mydevbot-hardware-hero.svg"
+reference_id: "a2e2f3d0-729b-4fcb-ae9c-5c9c95977d00"
+---
+
+A veces, las mejores ideas nacen de la frustración pura y dura. Era un jueves por la tarde, estaba en el transporte público, volviendo a casa después de una jornada agotadora, y de repente me acordé de que no había revisado una Pull Request crítica en uno de mis repositorios personales. Tampoco había programado el cron para una tarea de mantenimiento que debía ejecutarse esa misma noche. Saqué el móvil, abrí el navegador, entré a GitHub y me encontré con la típica experiencia móvil: hacer zoom, intentar pulsar el botón correcto con mis dedos torpes, lidiar con la conexión intermitente del metro... Fue un desastre.
+
+En ese momento, miré la aplicación de Telegram que acababa de abrir para responder un mensaje y tuve una epifanía. Telegram es rápido, ligero, funciona perfectamente incluso con coberturas pésimas y su API para bots es una de las mejores de la industria. ¿Y si pudiera gestionar todo mi ecosistema de desarrollo, mis repositorios, mis tareas programadas y mi infraestructura directamente desde un chat de Telegram? ¿Y si pudiera tener un asistente inteligente, impulsado por Inteligencia Artificial, que no solo ejecutara comandos, sino que entendiera mis intenciones en lenguaje natural?
+
+Ese fue el germen de **mydevbot**. Un bot personal, privado, soberano y extremadamente capaz. Pero del concepto a la realidad hay un abismo tecnológico. En esta primera entrada de mi diario de desarrollo, voy a relatar los primeros pasos de este proyecto, que comenzaron no con código, sino con una profunda investigación sobre arquitectura y hardware. Porque, como pronto descubriría, la nube de otra persona no era el lugar adecuado para mi asistente personal.
+
+### El punto de partida: Explorando el ecosistema existente
+
+Mi primera reacción, como buen desarrollador, fue buscar si alguien ya había resuelto este problema. No tenía sentido reinventar la rueda si ya existía una solución robusta y de código abierto. Durante mis investigaciones me topé con un repositorio muy interesante llamado [AIPAL](https://github.com/antoniolg/aipal), creado por antoniolg.
+
+AIPAL propone usar Telegram como puente para interactuar con una IA local. La premisa es fantástica: mantienes la privacidad, usas tus propios recursos y tienes una interfaz de chat universal. Lo cloné, lo configuré y funcionó. Era mágico poder enviar un mensaje desde la calle y que mi PC en casa procesara la petición y me devolviera la respuesta de la IA. El bot actuaba como un puente perfecto. No necesitaba abrir puertos en mi router ni lidiar con configuraciones complejas de NAT, ya que la librería de Telegram utiliza *long polling*. El bot simplemente pregunta periódicamente a los servidores de Telegram si hay mensajes nuevos.
+
+Sin embargo, tras la euforia inicial, las limitaciones se hicieron evidentes. AIPAL y soluciones similares tienen un talón de Aquiles fundamental para mi caso de uso: requieren que el equipo donde se ejecutan esté encendido y conectado a Internet permanentemente. En mi caso, eso significaba dejar mi ordenador principal (una torre potente, ruidosa y con un consumo energético nada despreciable) encendido 24/7.
+
+Dejar una máquina de 600W encendida todo el día solo para mantener vivo un bot de Telegram que recibe unas pocas docenas de mensajes al día es ineficiente desde cualquier punto de vista. Económicamente es un despilfarro en la factura de la luz, y ecológicamente es irresponsable. Además, el ruido de los ventiladores en el silencio de la noche era una molestia constante. Necesitaba otra solución. El concepto de AIPAL validó mi hipótesis de que Telegram era la interfaz perfecta, pero me obligó a replantearme completamente el hardware.
+
+### La ilusión del Synology DS212+ y el choque con la realidad
+
+Pensando en hardware de bajo consumo que ya tuviera en casa, mi mirada se posó en un rincón de mi estantería donde acumulaba polvo un viejo pero leal servidor NAS: el **Synology DS212+**. Es un modelo clásico, lanzado en 2012. En su época dorada era una maravilla para el almacenamiento en red, y lo mejor de todo: consume poquísimo. Estamos hablando de unos 15-20W en pleno rendimiento y apenas unos pocos vatios en reposo. Parecía el candidato ideal.
+
+La idea era brillante: ejecutar el bot en el NAS. El NAS ya está encendido siempre, gestionando mis copias de seguridad y mis archivos multimedia. ¿Qué más da añadirle un pequeño script de Python para gestionar a *mydevbot*?
+
+Me conecté por SSH al viejo DS212+. La terminal me recibió con ese familiar y espartano prompt de Linux recortado. Empecé a revisar las especificaciones y las posibilidades. Y aquí fue donde mis sueños se chocaron violentamente contra el muro de la obsolescencia tecnológica.
+
+El primer gran problema: el procesador. El DS212+ cuenta con un procesador ARM antiguo de 32 bits. La memoria RAM es de apenas 512 MB. Esto, en el año 2026, es el equivalente tecnológico a intentar cruzar el océano en una cáscara de nuez. Pero el verdadero clavo en el ataúd fue la **ausencia de soporte para Docker**.
+
+En la familia Synology, solo los modelos de la serie "+" más recientes y con procesadores x86_64 (Intel o AMD) tienen soporte oficial y funcional para Docker (o Container Manager, como lo llaman ahora). Para modelos de las series J o Play, y ciertamente para un modelo de 2012, Docker es un sueño imposible.
+
+¿Por qué es tan crítico Docker? Podría simplemente instalar Python, dirás. Y sí, es posible instalar Python 3 en el DS212+ a través del centro de paquetes o usando repositorios comunitarios como Entware. Pero desarrollar, desplegar y mantener una aplicación moderna en un entorno tan hostil y frágil es una receta para el desastre. Gestionar dependencias virtualizadas, compilar librerías en C que a menudo requiere el ecosistema de IA, y lidiar con un sistema operativo propietario (DSM) que no está pensado para ser un servidor de aplicaciones de propósito general... no era el camino.
+
+Imaginé el flujo de trabajo: escribir el código en mi portátil, pasarlo por SCP al NAS, cruzar los dedos para que las dependencias de pip se instalaran correctamente en esa arquitectura ARMvet vieja, y usar el programador de tareas del NAS para reiniciar el script si fallaba. Era volver a las prácticas de despliegue de hace quince años. La fricción sería tan alta que terminaría abandonando el proyecto.
+
+El Synology DS212+ quedó descartado. Sigue siendo un excelente guardián de mis archivos históricos, pero para albergar a *mydevbot*, necesitaba algo moderno, eficiente y versátil.
+
+### La revolución de los Mini PC: El equilibrio perfecto
+
+Descartado el PC principal por consumo y el NAS por obsolescencia, evalué las alternativas de servidores en la nube. Un VPS gratuito de Oracle o una pequeña instancia en AWS EC2. Pero aquí entraban en juego mis principios de **soberanía tecnológica**. Si este bot iba a tener acceso a todos mis repositorios privados, a mis tareas, a mi calendario, y si iba a ser mi "cerebro extendido", no quería que estuviera alojado en la infraestructura de un gigante tecnológico, sujeto a cambios de términos de servicio, caídas regionales o inspecciones de datos. Quería el hierro en mi casa. Físicamente bajo mi control.
+
+Esto me llevó al fascinante y competitivo mundo de los Mini PC modernos. En los últimos años, el mercado de los Mini PC ha explotado, impulsado por los avances en procesadores de portátiles que ofrecen un rendimiento espectacular con un consumo ridículamente bajo.
+
+Pasé días investigando, viendo benchmarks y comparando opciones. La balanza se inclinó rápidamente hacia plataformas basadas en AMD Ryzen. Mis finalistas fueron tres modelos específicos que marcaban el punto dulce entre precio, potencia, eficiencia y, crucialmente, conectividad futura.
+
+El rey indiscutible de mis opciones era el **Minisforum UM890 Pro**. Con un procesador Ryzen 9 8945HS (arquitectura Hawk Point con NPU integrada para tareas de IA), 32GB de RAM DDR5 y conectividad de sobra. Este bicho es el equivalente a un portátil de altísima gama comprimido en una caja del tamaño de un libro pequeño. Su consumo en reposo ronda los 10-15W, y a pleno rendimiento no pasa de los 65W. Era el sueño húmedo del homelabber. Sin embargo, su precio rondaba los 800€. Una inversión importante.
+
+Como alternativas más económicas, alrededor de los 500€, estaban el **Minisforum UM780 XTX** y el **GMKtec K8**. Ambos montan el excelente Ryzen 7 7840HS. Un paso por detrás del 8945HS, pero con potencia más que de sobra para ser el cerebro de mi hogar digital, ejecutar decenas de contenedores Docker sin sudar y manejar el bot con soltura.
+
+Lo que hacía que estos modelos destacaran por encima de otras opciones más baratas (como los típicos Intel N100) era una característica clave que pesó mucho en mi decisión a largo plazo: el **puerto OCuLink**.
+
+Aunque inicialmente *mydevbot* se comunicaría con la API en la nube de Gemini, mi visión a futuro es tener la capacidad de ejecutar LLMs complejos (modelos de razonamiento profundo) de forma 100% local. Para eso se necesita potencia gráfica (VRAM). Las gráficas integradas (las Radeon 780M de estos Ryzen) son sorprendentemente buenas, pero no pueden competir con una GPU dedicada.
+
+El puerto OCuLink (Optical-Copper Link) es una conexión PCIe directa x4. Es mucho más eficiente que Thunderbolt 4/5 para conectar una tarjeta gráfica externa (eGPU). Con una base eGPU OCuLink, podría conectar en el futuro una gráfica de escritorio (como una hipotética RTX 5070 o 5080) directamente al Mini PC. La pérdida de rendimiento respecto a pincharla en una placa base tradicional es de apenas un 5-10%. Es decir, el Mini PC me daba el bajo consumo de un portátil para el día a día, con la capacidad de transformarse en un monstruo del procesamiento de IA cuando lo necesitara, simplemente enchufando un cable.
+
+Finalmente, decidí adquirir el Minisforum UM890 Pro. Quería ese extra de potencia de la NPU integrada y la tranquilidad de tener hardware top-tier para los próximos cinco años. Lo recibí en casa, le instalé Ubuntu Server 26.04 LTS y configuré el entorno base con Docker y Docker Compose. Ver el sistema arrancar en segundos y consumir apenas 11 vatios me confirmó que había tomado la decisión correcta. Ya tenía el hogar perfecto para *mydevbot*.
+
+### La arquitectura del software: ¿Gemini CLI o SDK Nativo?
+
+Con el hardware listo (el UM890 Pro ronroneando silenciosamente en una estantería del salón), tocaba definir el stack de software. Sabía que usaría Python. Sabía que usaría la librería `python-telegram-bot` para gestionar la comunicación por long-polling con los servidores de Telegram. Pero la pieza central era el cerebro de la IA.
+
+Inicialmente, evalué usar la herramienta oficial **Gemini CLI**. Es una herramienta fantástica para bash scripts y automatizaciones rápidas. Podía hacer que el script de Python lanzara un subproceso (`subprocess.run`), ejecutara el comando de la CLI de Gemini pasándole el mensaje del usuario, capturara la salida estándar y la enviara de vuelta por Telegram.
+
+Hice una prueba de concepto. Funcionaba. Pero era torpe.
+
+El enfoque basado en CLI tiene varios problemas graves cuando intentas construir un bot conversacional persistente:
+
+1. **Gestión del contexto y el estado:** Cada llamada a la CLI es, por defecto, independiente (stateless). Para mantener una conversación fluida, tendría que guardar el historial de la conversación en un archivo temporal, pasárselo entero a la CLI en cada llamada, y parsear la respuesta. Una pesadilla de ineficiencia.
+2. **Latencia (Overhead de arranque):** Por muy rápido que sea invocar un binario, lanzar un subproceso nuevo del sistema operativo por cada mensaje añade latencia. Quería que *mydevbot* fuera instantáneo, ágil.
+3. **Manejo de errores ciego:** Capturar errores analizando el texto de salida de un comando de terminal (stderr) es frágil. Si la API cambia su formato de error, el bot se rompe en silencio.
+4. **Pérdida de funcionalidades avanzadas:** Características como el "Function Calling" (donde la IA decide ejecutar una herramienta externa, como consultar la API de GitHub) son tremendamente complejas de implementar parseando texto de una CLI.
+
+La decisión fue obvia: debía utilizar el **SDK oficial de Google GenAI para Python** (`google-genai`).
+
+Al integrar el SDK directamente en el código de mi bot, obtenía un control absoluto. Podía inicializar una instancia del modelo **Gemini 1.5 Flash** (elegí Flash por su extrema velocidad y bajísimo coste/gratuidad en el nivel básico, ideal para un asistente rápido). El SDK permite manejar sesiones de chat con estado persistente. Solo tengo que instanciar un objeto `ChatSession`, pasarle el nuevo mensaje del usuario, y el SDK se encarga de enviar todo el contexto previo a la API y devolver la respuesta.
+
+El código se simplificaba enormemente:
+
+```python
+import google.generativeai as genai
+
+# Configuración inicial
+genai.configure(api_key=os.environ["GEMINI_API_KEY"])
+model = genai.GenerativeModel('gemini-1.5-flash')
+chat_session = model.start_chat(history=[])
+
+def handle_message(update, context):
+    user_text = update.message.text
+    # Enviar al modelo, manteniendo contexto
+    response = chat_session.send_message(user_text)
+    # Responder en Telegram
+    update.message.reply_text(response.text)
+```
+
+Esa simplicidad es poder. Con el SDK nativo, las respuestas llegan en milisegundos. El manejo de excepciones (cuotas excedidas, errores de red) se gestiona elegantemente con bloques `try-catch`. Y lo más importante, me abría las puertas de par en par a las herramientas (Tools/Skills) de Gemini, lo que me permitiría integrar GitHub de forma nativa. Pero de eso hablaré en el próximo artículo.
+
+### Conclusión de esta primera fase: El nacimiento de mydevbot
+
+Esa misma noche de domingo, tras horas de configuración del servidor y de escribir la estructura básica del bot en Python, llegó el momento de la verdad. Empaqueté el código en un contenedor Docker usando un sencillo `Dockerfile`, creé un `docker-compose.yml` para gestionar las variables de entorno (el Token de Telegram y la API Key de Gemini, seguras y protegidas), y ejecuté el comando mágico:
+
+`docker compose up -d`
+
+El contenedor arrancó. Revisé los logs: `[INFO] Bot started. Polling Telegram servers...`
+
+Apagué el Wi-Fi de mi móvil, conectándome a la red 5G para simular que estaba fuera de casa. Abrí Telegram, busqué a `@my_private_dev_bot` y le escribí el mensaje inaugural:
+
+`"Hola, ¿estás ahí? Dime qué hardware te está ejecutando."`
+
+Pasó medio segundo. El doble check de Telegram se puso azul. Y la respuesta apareció en mi pantalla:
+
+`"¡Hola! Estoy en línea y listo. Analizando mi entorno... me estoy ejecutando dentro de un contenedor Linux (seguramente Docker). Y a juzgar por el número de núcleos que veo en /proc/cpuinfo, estoy corriendo en un monstruo de 8 núcleos y 16 hilos. ¿En qué puedo ayudarte jefe?"`
+
+No pude evitar sonreír. Había nacido **mydevbot**. Ya no dependía de que mi ruidoso PC de sobremesa estuviera encendido. Tenía un servidor de bajo consumo, potente y dedicado, y una arquitectura de software limpia y nativa.
+
+El puente entre mi móvil en cualquier parte del mundo y mi ecosistema de desarrollo estaba construido. Pero un puente no es útil si no lleva a ninguna parte. El bot podía charlar, pero aún no podía *trabajar*.
+
+El siguiente paso, el verdadero reto que cambiaría mi forma de trabajar, era dotarlo de habilidades reales. Enseñarle a interactuar con la API de GitHub para que pudiera leer mis repositorios, crear issues y gestionar mis tareas. Y, por supuesto, implementar un sistema de tareas cron para que el bot me informara proactivamente, en lugar de esperar a mis órdenes.
+
+Todo eso será el tema principal de la próxima entrada en esta bitácora. La verdadera revolución de *mydevbot* acaba de empezar. Nos leemos mañana.
+
+*(Continúa en: Enseñando a mydevbot a programar - GitHub Skills y Tareas Cron)*

--- a/src/content/devlog/es/2026-03-06-mydevbot-github-cron-skills.md
+++ b/src/content/devlog/es/2026-03-06-mydevbot-github-cron-skills.md
@@ -1,0 +1,172 @@
+---
+title: "Enseñando a mydevbot a programar - GitHub Skills y Tareas Cron"
+description: "La segunda fase de mydevbot. Cómo integrar la API de GitHub usando las capacidades de Function Calling de Gemini y configurar tareas programadas con APScheduler para recibir resúmenes diarios."
+pubDate: 2026-03-06
+tags: ["devlog", "telegram", "mydevbot", "gemini", "github", "cron", "python"]
+heroImage: "/images/mydevbot-skills-cron-hero.svg"
+reference_id: "0463727d-8058-4f3a-b565-1baec56b3470"
+---
+
+Ayer dejé la historia en un punto dulce. Tenía a **mydevbot** funcionando en su nueva y flamante casa: un Mini PC Minisforum UM890 Pro con un consumo irrisorio y potencia de sobra. El bot podía responder mensajes en Telegram en milisegundos gracias al uso del SDK nativo de Google Gemini (específicamente, Gemini 1.5 Flash). Era rápido, eficiente y privado.
+
+Pero seamos sinceros: un bot que solo sirve para charlar, por muy rápido que sea, no es más que un ChatGPT glorificado con otra interfaz. Para que *mydevbot* se ganara su nombre y realmente revolucionara mi flujo de trabajo, necesitaba darle manos. Necesitaba que pudiera tocar mis repositorios, leer mi código, gestionar mis problemas y mantener un ojo en mi infraestructura mientras yo estaba ocupado en otras cosas.
+
+El objetivo de esta segunda fase de desarrollo era doble:
+1.  **Integración profunda con GitHub:** Lograr que el bot pudiera gestionar repositorios enteros, crear issues, revisar Pull Requests e incluso sugerir código, todo desde la interfaz de chat de Telegram.
+2.  **Proactividad mediante tareas Cron:** Que el bot dejara de ser puramente reactivo. Quería que me despertara por la mañana con un resumen de los errores de los servidores o los issues pendientes, sin que yo tuviera que pedírselo.
+
+Esta es la crónica de cómo *mydevbot* pasó de ser un loro conversacional a convertirse en mi ingeniero DevOps personal.
+
+### El arte de las Skills: Function Calling con Gemini
+
+En el mundo de los Modelos de Lenguaje Grande (LLMs), hay un antes y un después del "Function Calling" (o invocación de herramientas/skills). Antes, si querías que una IA interactuara con un sistema externo, tenías que hacer malabares con prompts. Le decías a la IA: *"Si el usuario te pide la temperatura de Madrid, responde exactamente con la palabra CLIMA_MADRID y nada más"*. Luego, tu código parseaba esa respuesta exacta, llamaba a la API del clima, y le devolvías los datos a la IA para que redactara la respuesta final. Era un proceso frágil, propenso a errores y limitadísimo en complejidad.
+
+El Function Calling cambió las reglas del juego. Ahora, en lugar de intentar engañar a la IA, le das un manual de instrucciones explícito sobre qué herramientas (funciones de Python) tiene a su disposición, qué parámetros aceptan esas funciones y qué devuelven. La IA, de forma nativa, decide cuándo es apropiado usar una herramienta basándose en la petición del usuario.
+
+Para *mydevbot*, esto significaba que no tenía que escribir un complejo árbol de `if/else` para analizar si el usuario decía "crea un issue" o "revisa este repo". Simplemente le daba a Gemini la herramienta y él se encargaba de la semántica.
+
+El primer paso fue integrar la API de GitHub. Utilicé la librería **PyGithub**, un wrapper excelente y robusto para interactuar con la API REST v3 de GitHub en Python. El reto principal aquí era la seguridad. Bajo ningún concepto iba a quemar mis credenciales directamente en el código. Generé un **Personal Access Token (PAT)** en GitHub con permisos estrictamente limitados (lectura de repositorios y escritura de issues/PRs, pero sin permisos para borrar repositorios). Este token se cargaría como variable de entorno segura en el contenedor Docker.
+
+Una vez asegurado el acceso, empecé a definir las "Skills" de *mydevbot*. La primera y más obvia: obtener un resumen de los repositorios.
+
+Definí la función en Python usando PyGithub:
+
+```python
+from github import Github
+import os
+
+def get_repo_summary(repo_name: str) -> str:
+    """Obtiene un resumen del estado actual de un repositorio en GitHub (estrellas, forks, issues abiertos)."""
+    try:
+        g = Github(os.environ["GITHUB_PAT"])
+        repo = g.get_repo(repo_name)
+
+        summary = f"Repositorio: {repo.full_name}\n"
+        summary += f"Descripción: {repo.description}\n"
+        summary += f"Estrellas: {repo.stargazers_count}\n"
+        summary += f"Issues abiertos: {repo.open_issues_count}\n"
+        return summary
+    except Exception as e:
+        return f"Error al acceder al repositorio: {str(e)}"
+```
+
+La magia ocurre en cómo le pasas esta función al SDK de Gemini. Cuando inicializas el modelo, le indicas que tiene esta herramienta disponible. El modelo lee el docstring (`"""Obtiene un resumen..."""`) y las anotaciones de tipo (`repo_name: str`) para entender cómo y cuándo usarla.
+
+La primera prueba fue un momento de pura euforia nerd. Abrí Telegram y le escribí a *mydevbot*:
+*"Oye, ¿cómo va el repositorio de ArceApps/PuzzleHub? ¿Tenemos mucho trabajo pendiente?"*
+
+En el backend, observé los logs del servidor. El flujo fue el siguiente:
+1.  Gemini recibió mi mensaje.
+2.  Analizó mi intención y determinó que necesitaba consultar datos de GitHub para responderme.
+3.  En lugar de generar texto de respuesta, Gemini me devolvió una petición estructurada: *"Quiero ejecutar la función `get_repo_summary` con el parámetro `repo_name="ArceApps/PuzzleHub"`"*.
+4.  Mi script de Python interceptó esta petición, ejecutó la función real contra la API de GitHub, y obtuvo el texto con las estrellas y los issues.
+5.  Mi script le devolvió esos datos a Gemini.
+6.  Finalmente, Gemini analizó esos datos y redactó la respuesta natural para Telegram: *"Acabo de revisar el repositorio ArceApps/PuzzleHub. Actualmente tiene 3 issues abiertos pendientes de revisar. ¿Quieres que te liste los títulos de esos issues?"*
+
+¡Funcionaba! El bot estaba usando herramientas de forma autónoma. Y la respuesta natural (el hecho de que me preguntara si quería listar los títulos) demostraba que mantenía el contexto y razonaba sobre los datos obtenidos, no era un simple volcado de base de datos.
+
+### Ampliando el arsenal: De leer a escribir
+
+Leer datos está bien, pero el verdadero poder reside en actuar. La siguiente fase fue dotar a *mydevbot* de la capacidad de interactuar activamente con mis proyectos. Escribir código, crear incidencias, comentar PRs.
+
+Creé una suite completa de herramientas para GitHub. Algunas de las más útiles que implementé esa misma tarde fueron:
+
+*   `create_github_issue(repo_name: str, title: str, body: str, labels: list)`: Para reportar bugs sobre la marcha. Si estoy probando una de mis apps en el móvil y encuentro un error de UI, ya no tengo que abrir el portátil. Simplemente voy a Telegram y le digo a mydevbot: *"Crea un issue en el repo de la web indicando que el botón de contacto en modo oscuro no tiene suficiente contraste. Etiquétalo como bug y ui"*. El bot extrae los parámetros perfectamente y crea el ticket.
+*   `get_latest_pr_diff(repo_name: str)`: Esta fue una de mis favoritas. Le permite al bot leer el diff (los cambios de código) de la última Pull Request abierta. Y como Gemini tiene una ventana de contexto enorme (especialmente la versión 1.5 Pro, aunque en Flash también funciona muy bien para diffs medianos), puede analizar ese código y buscar errores.
+*   `comment_on_pr(repo_name: str, pr_number: int, comment: str)`: El complemento lógico de la anterior. Después de que el bot lee el diff, puede publicar un comentario directamente en GitHub.
+
+Recuerdo la primera vez que probé el flujo completo. Había subido un pequeño parche desde el portátil, pero no estaba seguro de si había introducido un posible problema de concurrencia. Me fui al sofá, abrí Telegram y le pedí a mydevbot que revisara el PR.
+
+El bot consultó la API, descargó el diff, lo analizó (usando su conocimiento inherente de programación) y me respondió: *"He revisado la PR #42. El código parece sólido en general, pero en el archivo `worker.py` estás usando un diccionario compartido entre hilos sin un cerrojo (lock). Esto podría causar condiciones de carrera. ¿Quieres que deje este comentario en la PR por ti?"*.
+
+Le respondí con un simple *"Sí, por favor, y añade que lo revisaré mañana"*. Segundos después, mi teléfono vibró con una notificación de la app oficial de GitHub: *mydevbot* había comentado en mi PR exactamente lo que le había pedido, redactado con un tono profesional.
+
+El nivel de fricción para gestionar mis proyectos se había reducido a casi cero. Podía hacer tareas de revisión, planificación y triage de bugs mientras caminaba por la calle, usando solo mi voz (a través de los mensajes de voz de Telegram, que también integramos usando Whisper, pero esa es otra historia) y mi bot personal.
+
+### La necesidad de la proactividad: El problema de ser reactivo
+
+Hasta este punto, *mydevbot* era una herramienta formidable, pero seguía siendo reactiva. Solo hacía cosas cuando yo le hablaba. Y uno de los problemas fundamentales de la gestión de infraestructuras personales o proyectos paralelos es el olvido.
+
+Si no me acuerdo de preguntarle al bot cómo están los repositorios, los issues se acumulan. Si no le pregunto por el estado del servidor, un disco duro puede llenarse silenciosamente hasta causar un fallo catastrófico. Un verdadero asistente no espera a que le preguntes si la casa se está quemando; te avisa en cuanto huele a humo.
+
+Necesitaba implementar tareas en segundo plano. Necesitaba **Cron**.
+
+En el entorno tradicional de Linux, configurar tareas repetitivas se hace con el demonio cron (editando `crontab`). Es fiable, sólido como una roca, pero es un componente del sistema operativo. Si configuraba cron en el Mini PC a nivel de sistema para llamar a scripts de Python, estaría rompiendo el encapsulamiento de mi entorno Docker. Además, perdería la integración fluida con la instancia persistente del bot y el SDK de Gemini.
+
+Quería que las tareas programadas vivieran dentro del mismo código de *mydevbot*, compartiendo el mismo contexto de memoria, la misma sesión de Telegram y las mismas herramientas de GitHub. La respuesta era obvia para cualquier desarrollador de Python: **APScheduler** (Advanced Python Scheduler).
+
+APScheduler es una librería fantástica que te permite programar trabajos en Python de forma similar a cron, pero integrado directamente en tu aplicación. Es ligero, no requiere procesos externos y se integra de maravilla con aplicaciones asíncronas como `python-telegram-bot`.
+
+### Implementando APScheduler: El briefing matutino
+
+La integración fue sorprendentemente sencilla. Añadí la dependencia a mi `requirements.txt` y modifiqué el script principal del bot.
+
+El objetivo inaugural para el sistema de cron era crear el **Briefing Matutino**. Quería que, todos los días a las 08:30 de la mañana, de lunes a viernes, *mydevbot* me enviara un mensaje estructurado con un resumen de todo lo que necesitaba saber para empezar el día.
+
+```python
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+async def morning_briefing(context: ContextTypes.DEFAULT_TYPE):
+    chat_id = os.environ["MY_TELEGRAM_CHAT_ID"]
+
+    # Recopilar datos (usando las funciones ya creadas)
+    repo_status = get_repo_summary("ArceApps/PuzzleHub")
+
+    # Pedirle a Gemini que formatee el resumen de forma amigable
+    prompt = f"Actúa como mi asistente personal. Redacta un mensaje de buenos días amable y profesional. " \
+             f"Incluye este estado del repositorio principal de forma resumida: {repo_status}. " \
+             f"Añade un mensaje motivacional corto al final."
+
+    response = chat_session.send_message(prompt)
+
+    # Enviar el mensaje por Telegram de forma proactiva
+    await context.bot.send_message(chat_id=chat_id, text=response.text)
+
+# En la inicialización del bot:
+scheduler = AsyncIOScheduler()
+scheduler.add_job(
+    morning_briefing,
+    trigger=CronTrigger(day_of_week='mon-fri', hour=8, minute=30),
+    args=[application] # Pasar la instancia de la app de Telegram
+)
+scheduler.start()
+```
+
+Ese código es la base de la proactividad. El bloque `CronTrigger` permite una flexibilidad increíble. Podía programar tareas para que se ejecutaran cada hora, el primer domingo de cada mes, o combinaciones complejas.
+
+La mañana siguiente a implementar esto fue mágica. Estaba tomando el primer café del día, preparándome mentalmente para la jornada laboral, cuando el móvil vibró a las 08:30 en punto. Era un mensaje de Telegram de *mydevbot*:
+
+*"¡Buenos días jefe! Espero que hayas descansado. Aquí tienes el briefing de hoy: El repositorio ArceApps/PuzzleHub tiene actualmente 3 issues abiertos esperando tu atención y 1 Pull Request lista para revisión de merge. Parece que la comunidad ha estado activa esta noche. Recuerda que pequeños avances constantes construyen grandes proyectos. ¡A por el día!"*
+
+No tuve que abrir ninguna app. No tuve que acordarme de mirar. La información vino a mí, filtrada, formateada de manera agradable y en el momento exacto en que la necesitaba.
+
+A partir de ahí, las posibilidades de los "jobs" de APScheduler explotaron en mi cabeza. Empecé a añadir más tareas cron al arsenal de *mydevbot*:
+
+*   **Monitor de salud del servidor (Cada 6 horas):** Un script sencillo que lee el uso de CPU, RAM y disco del Mini PC. Si alguno de estos valores supera el 90%, el bot me envía una alerta urgente (usando un formato de texto rojo/negrita) a Telegram advirtiéndome del cuello de botella.
+*   **Limpieza de contenedores Docker (Domingos a las 3:00 AM):** Un script que ejecuta un `docker system prune -f` para liberar espacio, y luego me manda un mensaje confirmando los megabytes liberados.
+*   **Recordatorios de Stand-up (Lunes a las 10:00 AM):** Un ping rápido preguntándome cuáles son mis objetivos semanales para el proyecto devlog, obligándome a escribirlos y, por tanto, a comprometerme con ellos.
+
+### Reflexión: El salto cualitativo
+
+Pasar de un bot conversacional reactivo a un asistente proactivo integrado con la API de mis herramientas principales fue un salto cualitativo brutal. Ya no era solo una prueba de concepto divertida. Era una herramienta de productividad real, alojada en mi propio hardware (el heroico UM890 Pro), sin suscripciones mensuales recurrentes y con total privacidad de mis datos.
+
+Había resuelto el problema inicial. Ya podía gestionar mis repositorios desde el metro sin frustrarme con interfaces web móviles. Podía enterarme de los problemas de los servidores antes de que los usuarios se quejaran. Había logrado mi objetivo.
+
+Pero, como cualquier desarrollador sabe, un proyecto nunca está realmente terminado. Una vez que resuelves el problema principal, empiezas a ver nuevas oportunidades. El entorno era perfecto, el código base era sólido y la arquitectura modular me invitaba a soñar a lo grande.
+
+Si podía crear issues desde el móvil, ¿por qué no poder escribir código complejo? Si tenía un puerto OCuLink libre en el Mini PC, ¿por qué limitarme a la API en la nube si podía conectar una gráfica dedicada de escritorio y correr modelos enormes en local? Y si la configuración manual del código en Python se volvía tediosa para flujos muy complejos, ¿qué herramientas visuales podía integrar?
+
+Estas ambiciones marcarían la tercera y última fase de esta etapa de desarrollo. Una fase centrada en la evolución continua, en la automatización del propio código del bot (CI/CD) y en la exploración de las tecnologías más punteras (eGPUs, herramientas de automatización como n8n y el nuevo estándar MCP de Anthropic). Todo esto, junto con la ironía de cómo *mydevbot* se actualiza a sí mismo, será la historia que cerrará esta trilogía mañana.
+
+### La escalabilidad y el futuro inmediato de las Skills
+
+Antes de concluir esta entrada, creo que es fundamental reflexionar sobre lo que significa realmente esta arquitectura basada en Skills y Cron para el futuro de mi trabajo diario. Hemos pasado de un simple script que responde mensajes a un sistema operativo personal distribuido en la nube, pero anclado firmemente en el hardware de mi hogar.
+
+La modularidad de las funciones de Python, expuestas a través del SDK de Gemini, significa que el límite de lo que *mydevbot* puede hacer está definido únicamente por las APIs que decida integrar. Si mañana quiero que el bot gestione mis finanzas personales, solo tengo que crear un archivo `finance_skills.py`, integrar la API de mi banco, añadir la descripción correspondiente en el docstring y reiniciar el contenedor. Gemini entenderá inmediatamente su nuevo propósito y sus nuevas capacidades.
+
+Esta extensibilidad orgánica es el sueño húmedo de cualquier desarrollador de software. No hay que reescribir la interfaz de usuario, no hay que diseñar nuevos menús ni botones en Telegram. La interfaz es el lenguaje natural, y el lenguaje natural es universal.
+
+Además, el uso de APScheduler ha transformado mi relación con la información. Ya no soy yo quien persigue los datos de mis proyectos; son los datos los que vienen a mí cuando son relevantes. El resumen matutino es solo el principio. Imagino un futuro cercano donde *mydevbot* no solo me informa de los problemas, sino que, utilizando sus Skills de GitHub, propone y ejecuta soluciones automatizadas (como auto-asignarse PRs triviales, aprobar cambios de dependencias menores, o incluso reiniciar servidores que no responden) notificándome únicamente cuando la tarea se ha completado con éxito.
+
+El verdadero reto ahora no es técnico, sino conceptual. ¿Cuánta autonomía estoy dispuesto a darle a este sistema? ¿Hasta qué punto quiero que una IA gestione mis repositorios sin mi supervisión directa? Son preguntas fascinantes que iré respondiendo a medida que el proyecto madure. De momento, he construido los cimientos perfectos. Mañana exploraremos cómo escalar esta infraestructura y prepararla para el futuro.

--- a/src/content/devlog/es/2026-03-07-mydevbot-cicd-egpu-future.md
+++ b/src/content/devlog/es/2026-03-07-mydevbot-cicd-egpu-future.md
@@ -1,0 +1,139 @@
+---
+title: "La madurez de mydevbot - CI/CD, eGPUs y el futuro del desarrollo móvil"
+description: "La fase final. Cómo mydevbot se despliega a sí mismo usando GitHub Actions y Watchtower, programación desde el móvil con VS Code Server y la preparación del UM890 Pro para IA local extrema vía OCuLink."
+pubDate: 2026-03-07
+tags: ["devlog", "telegram", "mydevbot", "cicd", "oculink", "egpu", "vscode", "n8n"]
+heroImage: "/images/mydevbot-cicd-future-hero.svg"
+reference_id: "83523401-9392-426f-b039-f3ae73132d40"
+---
+
+Llegamos a la última entrada de esta trilogía sobre **mydevbot**. Si en el [primer artículo](2026-03-05-mydevbot-genesis-hardware) hablé de la odisea para encontrar el hardware perfecto (el Minisforum UM890 Pro) y en el [segundo](2026-03-06-mydevbot-github-cron-skills) detallé cómo le enseñé a usar la API de GitHub y a despertarme con resúmenes diarios, hoy toca hablar de escalabilidad, automatización y de la experiencia real de desarrollo.
+
+Porque aquí hay una paradoja fascinante: he construido un bot de Telegram para gestionar mi desarrollo de software mientras estoy fuera de casa... pero ¿qué pasa cuando quiero desarrollar o mejorar *el propio bot* mientras estoy fuera de casa?
+
+Si estoy en una cafetería, sin mi portátil, y de repente se me ocurre una nueva *Skill* genial para que mydevbot me formatee el código usando *black*, ¿cómo la implemento? No puedo enviarle un mensaje de voz al bot diciéndole "modifica tu propio código fuente", porque eso sería un riesgo de seguridad monumental (además de técnicamente suicida con la versión actual).
+
+Necesitaba cerrar el círculo. Necesitaba que el Mini PC que aloja a mydevbot se convirtiera no solo en un servidor de ejecución, sino en mi entorno de desarrollo remoto completo.
+
+### El entorno de desarrollo móvil: VS Code Server
+
+Escribir código en la pantalla de un móvil de 6 pulgadas es un dolor, lo admito. Pero en el año 2026, los móviles modernos (como mi Pixel) tienen modos de escritorio fantásticos cuando los conectas a un monitor externo o incluso a unas gafas de realidad mixta ligeras. Aún sin accesorios, con un buen teclado Bluetooth plegable, puedes apañarte muy bien.
+
+El problema histórico siempre ha sido el entorno. Configurar Git, Python, las dependencias y un editor decente en Android (usando Termux, por ejemplo) es factible pero tosco.
+
+La solución estaba ya en el propio Mini PC. El UM890 Pro, con sus 32GB de RAM, apenas estaba sudando con el contenedor de *mydevbot*. Decidí instalar **VS Code Server**.
+
+Para los que no lo conozcan, VS Code Server te permite ejecutar el backend de Visual Studio Code en tu servidor remoto y acceder a la interfaz de usuario completa y nativa a través de cualquier navegador web.
+
+Añadí un nuevo contenedor a mi `docker-compose.yml` en el Mini PC: un contenedor oficial de `code-server` de *linuxserver.io*. Lo configuré para mapear la carpeta donde vive el código de *mydevbot* como volumen de trabajo.
+
+Para acceder a él de forma segura desde fuera de casa sin abrir puertos al mundo (y exponerme a ataques de fuerza bruta), utilicé **Tailscale**. Instalé el cliente de Tailscale en el Mini PC y en mi móvil. Así, mi móvil formaba parte de una red privada virtual (VPN) cifrada tipo malla (Mesh) con el Mini PC.
+
+Ahora, el flujo es pura ciencia ficción:
+1.  Estoy en el tren.
+2.  Enciendo el teclado Bluetooth.
+3.  Abro el navegador de mi móvil (Brave) y tecleo la IP de Tailscale de mi Mini PC (ej. `http://100.80.x.x:8443`).
+4.  Aparece el editor completo de VS Code, con mis temas, mis atajos de teclado y acceso directo al código de *mydevbot*.
+
+Puedo escribir una nueva función de Python en el editor del navegador, guardar, e inmediatamente probarla ejecutando el script en la terminal integrada del navegador.
+
+Pero aquí surge un problema. Si cambio el código, necesito reiniciar el contenedor Docker de *mydevbot* para que tome los cambios. Y lo que es peor, esos cambios están "sueltos" en el servidor; necesito hacer commit y subirlos a GitHub para no perder el control de versiones.
+
+Podría hacerlo a mano desde la terminal del VS Code Server, pero si he construido un ecosistema automatizado, quería que el despliegue de mi bot fuera también automático.
+
+### CI/CD para un Bot casero: Watchtower al rescate
+
+Quería llegar a un punto donde yo simplemente hiciera `git push` (ya sea desde el VS Code Server en el móvil o desde mi portátil en casa) y el Mini PC se actualizara solo. Un pipeline de Continuous Integration / Continuous Deployment (CI/CD) en toda regla, pero para mi homelab.
+
+Tradicionalmente, en entornos empresariales, un GitHub Action se conectaría por SSH a mi servidor y ejecutaría un script de actualización. O usaría herramientas como ArgoCD. Pero esas opciones son complejas de mantener en un entorno doméstico donde mi IP pública puede cambiar (aunque use Tailscale).
+
+La respuesta más elegante para contenedores Docker es **Watchtower**.
+
+Watchtower es un contenedor cuyo único trabajo es vigilar a otros contenedores. Periódicamente (por ejemplo, cada 5 minutos), Watchtower consulta el registro de imágenes (Docker Hub, o GitHub Container Registry) para ver si hay una versión más nueva de la imagen de un contenedor que se está ejecutando actualmente. Si encuentra una imagen nueva, Watchtower detiene elegantemente el contenedor antiguo, descarga la nueva imagen y la arranca usando exactamente las mismas variables de entorno y volúmenes (`docker-compose` settings) que el contenedor original.
+
+El pipeline completo quedó configurado así:
+
+1.  **Desarrollo:** Modifico el código de `mydevbot` en el navegador (vía VS Code Server) o en local.
+2.  **Commit y Push:** Hago `git commit -m "Nueva skill de finanzas"` y `git push`.
+3.  **GitHub Actions (CI):** En GitHub, un Action detecta el push. Ejecuta un linter de Python (flake8), pasa los tests unitarios básicos que escribí, y si todo está verde, construye una nueva imagen Docker y la sube al GitHub Container Registry (GHCR) etiquetada como `latest`.
+4.  **Watchtower (CD):** En mi Mini PC, Watchtower, que está corriendo en segundo plano, detecta que hay una nueva imagen `latest` en el GHCR.
+5.  **Reinicio automático:** Watchtower mata el proceso antiguo de *mydevbot*, descarga la nueva imagen y la arranca.
+
+Todo esto ocurre en unos 3 minutos de reloj. Yo hago `push` desde el móvil, me tomo un sorbo de café, y cuando vuelvo a Telegram, le pregunto a *mydevbot* qué versión está corriendo, y me responde con el nuevo commit hash.
+
+Es la magia del DevOps aplicada a mi vida personal. Ya no hay fricción. Si el bot falla, lo corrijo, hago push, y me olvido.
+
+### El horizonte de la IA Local: El puerto OCuLink y las eGPUs
+
+Llegados a este punto, la arquitectura de software era sólida. Pero quiero hablar de hardware otra vez. De ese puerto OCuLink del que hablé en el primer artículo y que fue el factor decisivo para comprar el Minisforum UM890 Pro en lugar de alternativas más baratas.
+
+Actualmente, *mydevbot* usa la API de Gemini 1.5 Flash. Es rápida, es casi gratuita, y es brillante para programación. Pero sigue siendo "La Nube". Si mañana me quedo sin internet (y la red de fibra óptica de mi zona tiene cortes ocasionales), o si Google decide cambiar radicalmente los precios de su API, mi cerebro automatizado dejará de funcionar.
+
+La verdadera soberanía de la que hablaba al principio solo se consigue cuando el Modelo de Lenguaje corre físicamente en tu casa.
+
+Para tareas sencillas, el Ryzen 9 8945HS del Mini PC (con su CPU y su NPU) puede correr modelos locales pequeños (como un Llama 3 8B o un Phi-3) a una velocidad aceptable usando herramientas como **Ollama**. Pero si quiero un modelo que pueda leer mis repositorios enteros de código y hacer razonamientos complejos sobre la arquitectura del software, necesito modelos más grandes (de 30B a 70B parámetros).
+
+Y esos modelos devoran VRAM (Memoria de Vídeo).
+
+Aquí es donde el puerto OCuLink entra en juego. El plan para el Q3 de 2026 es adquirir una base eGPU (External GPU) que se conecte por OCuLink. Estas bases son, esencialmente, un zócalo PCIe desnudo con una fuente de alimentación.
+
+Mi objetivo es conectar una tarjeta gráfica dedicada de escritorio, como una **RTX 5070 Ti** o incluso una **RTX 5080** (cuando bajen de precio en el mercado de segunda mano o haya ofertas), directamente al Mini PC.
+
+A diferencia de Thunderbolt 4 o 5, que introducen latencia y cuellos de botella por su encapsulamiento de datos, OCuLink es PCIe puro. La pérdida de rendimiento es marginal (entre un 5% y un 10%).
+
+Con una gráfica de 16GB o 24GB de VRAM conectada a mi Mini PC de bajo consumo, la arquitectura de *mydevbot* evolucionará dramáticamente:
+1.  En el día a día, el Mini PC funcionará de forma autónoma con sus 15W de consumo base, gestionando el código, los cron jobs y usando modelos pequeños o la nube.
+2.  Cuando necesite que *mydevbot* haga un trabajo pesado (como un refactor automático masivo, o análisis de vulnerabilidades complejos), encenderé remotamente la fuente de alimentación de la eGPU.
+3.  El bot detectará la presencia de la tarjeta gráfica y cambiará su backend de inferencia desde la API de Gemini hacia un servidor Ollama/vLLM local corriendo en la eGPU.
+
+Esta hibridación (bajo consumo por defecto, potencia extrema bajo demanda) es el futuro de los servidores domésticos y de los agentes de IA personales.
+
+### Más allá de Python: Explorando n8n y MCP
+
+La construcción manual de Skills en Python es divertida y te da un control total. Pero admitámoslo: a veces quieres conectar dos servicios sin tener que escribir 50 líneas de código y manejar las excepciones de la API HTTP.
+
+Durante las últimas semanas de desarrollo de *mydevbot*, me he encontrado con casos de uso donde escribir código me parecía matar moscas a cañonazos. Por ejemplo, quería que si llegaba un email de facturación a una cuenta específica de Gmail, el bot me avisara por Telegram y lo guardara en una carpeta de Google Drive.
+
+Podía escribir una Skill en Python para Gmail y Drive. Pero es tedioso.
+
+Para solucionar esto, he empezado a integrar **n8n** en mi clúster del Mini PC.
+n8n es una herramienta de automatización visual de flujos de trabajo (similar a Zapier o Make, pero open-source y auto-alojable). Te permite conectar cientos de aplicaciones arrastrando y soltando nodos en una interfaz gráfica.
+
+Lo fascinante es que n8n no sustituye a *mydevbot*; lo complementa. He configurado Webhooks en n8n que *mydevbot* puede llamar como si fueran Skills.
+Así, si le digo al bot *"Oye, guarda este recibo en mi Drive de facturas"*, el bot invoca la Skill `trigger_n8n_workflow_invoice`, le pasa el archivo, y n8n se encarga visualmente de subirlo a Drive, renombrarlo y clasificarlo. Esta separación de responsabilidades (la IA gestiona la intención y el lenguaje, n8n gestiona la fontanería de las APIs) es extremadamente eficiente.
+
+Por último, el horizonte más prometedor a nivel de software es el **Model Context Protocol (MCP)**, el estándar impulsado por Anthropic.
+En lugar de yo tener que programar cada Skill de GitHub a mano (escribiendo código de PyGithub), MCP propone una arquitectura donde las aplicaciones (como GitHub, Notion, o bases de datos locales) exponen servidores MCP.
+
+El modelo de IA simplemente se conecta a esos servidores MCP de forma estándar y "descubre" automáticamente qué herramientas tiene disponibles y cómo usarlas.
+Cuando Gemini (o modelos locales como Claude/Llama) adopten MCP de forma universal, la cantidad de código "pegamento" que tendré que escribir para *mydevbot* se reducirá un 90%. El bot será simplemente el orquestador (el cerebro) que se conecta a los distintos órganos sensoriales y actuadores del sistema.
+
+### Epílogo: El fin de la tiranía del PC de sobremesa
+
+Ha sido un viaje intenso desde aquella frustración en el transporte público hasta la sofisticada red de contenedores, IAs e integraciones que tengo hoy en casa.
+
+La lección más importante que he aprendido es que la infraestructura personal debe adaptarse a nuestra forma de vida, no al revés. No tiene sentido estar encadenado a una torre ruidosa y devoradora de electricidad para desarrollar software en el año 2026.
+
+Con un Minisforum UM890 Pro, Tailscale, VS Code Server y un bot en Telegram súper inteligente impulsado por Gemini, he desacoplado el *dónde* estoy del *qué* puedo hacer.
+
+*mydevbot* me recibe cada mañana con un resumen de mis obligaciones, vigila mis servidores mientras duermo, revisa el código que escribo desde mi móvil, y se despliega a sí mismo en silencio cuando detecta mejoras.
+
+Ya no soy un desarrollador en solitario. Tengo un equipo de operaciones trabajando para mí 24/7. Y solo me costó un poco de investigación, algo de hardware compacto, y un fin de semana divertido programando en Python.
+
+El futuro del desarrollo es móvil, asistido, privado y extremadamente potente. Y gracias a proyectos como este, ese futuro ya está zumbando silenciosamente en una estantería de mi salón.
+
+### El impacto en la productividad real y reflexiones finales
+
+Si echo la vista atrás, al momento en que concebí la idea de *mydevbot* en aquel vagón de metro abarrotado, me doy cuenta de que el impacto real de este proyecto va mucho más allá de la mera conveniencia técnica. No se trata solo de poder hacer un `git push` desde el teléfono móvil, ni de recibir un mensaje automatizado cada mañana a las 8:30. Se trata de una transformación fundamental en la forma en que interactúo con mis propios proyectos y con mi carga de trabajo cognitivo.
+
+Antes de la llegada de *mydevbot*, el mantenimiento de mis repositorios personales y de mi infraestructura de servidor doméstico era, a menudo, una tarea pesada. Requería un cambio de contexto mental severo. Tenía que sentarme físicamente frente al ordenador de sobremesa, encender los monitores, abrir el navegador, navegar por múltiples pestañas de GitHub, revisar los logs de los contenedores Docker a través de SSH y, finalmente, intentar recordar qué era exactamente lo que quería hacer horas atrás. Ese proceso, lleno de fricción, a menudo resultaba en procrastinación. Los issues se acumulaban, las actualizaciones de dependencias se posponían y los pequeños bugs de la interfaz de usuario quedaban sin resolver durante semanas, simplemente porque "no valía la pena encender el PC solo para arreglar un padding de CSS".
+
+Hoy, la historia es completamente diferente. *mydevbot* ha democratizado el acceso a mi propio ecosistema de desarrollo, reduciendo la fricción a cero. Cuando encuentro un pequeño error visual mientras pruebo una aplicación en mi teléfono, no tomo una nota mental que inevitablemente olvidaré. Abro Telegram, le envío un mensaje de voz rápido a mi bot explicando el problema, y en cuestión de segundos, la IA ha interpretado mis palabras, ha interactuado con la API de GitHub y ha creado un issue perfectamente formateado, etiquetado y asignado. La tarea sale inmediatamente de mi cabeza y entra en el sistema de seguimiento de manera estructurada y procesable.
+
+Pero la verdadera magia radica en la proactividad impulsada por las tareas cron y APScheduler. El hecho de que el sistema me informe a mí, en lugar de que yo tenga que interrogar al sistema, cambia por completo la dinámica de responsabilidad. Si un disco duro de mi servidor alcanza el 90% de su capacidad, *mydevbot* me alerta inmediatamente en Telegram con un mensaje prioritario. Si un proceso crítico falla durante la noche, me despierto con un resumen detallado del error y, a menudo, con una sugerencia de la IA sobre cómo solucionarlo. Ya no sufro la ansiedad de "¿estará todo funcionando correctamente?". Confío en que mi asistente digital está vigilando y me avisará si mi atención es verdaderamente necesaria.
+
+Además, la integración de VS Code Server y Tailscale ha convertido cualquier dispositivo con un navegador web en una potente estación de trabajo de ingeniería de software. He corregido bugs críticos, revisado y fusionado Pull Requests complejas, e incluso he desplegado nuevas versiones de aplicaciones desde la sala de espera del dentista, utilizando únicamente un teclado Bluetooth plegable y la pantalla de mi smartphone. La sensación de libertad y de control absoluto sobre mi infraestructura es embriagadora.
+
+Mirando hacia el futuro, la hoja de ruta para *mydevbot* es tan ambiciosa como emocionante. La inminente integración de una eGPU a través del puerto OCuLink del Minisforum UM890 Pro abrirá las puertas a la ejecución local de modelos de lenguaje masivos, garantizando una privacidad absoluta y liberándome de la dependencia de las APIs en la nube. La adopción de n8n para la automatización visual de flujos de trabajo complejos reducirá drásticamente la cantidad de código personalizado que necesito escribir, permitiendo que el bot interactúe con cientos de servicios externos con solo unos pocos clics. Y la llegada del Model Context Protocol (MCP) estandarizará la forma en que las IAs descubren y utilizan las herramientas, convirtiendo a *mydevbot* en un orquestador universal capaz de manejar cualquier tarea que le proponga.
+
+En última instancia, *mydevbot* es mucho más que un proyecto de fin de semana divertido. Es una declaración de intenciones. Es la prueba de que, con el hardware adecuado (potente, eficiente y soberano), las herramientas de software modernas y una pizca de ingenio, un desarrollador en solitario puede construir y operar infraestructuras que rivalizan en sofisticación con las de las grandes empresas tecnológicas. La era de depender del PC de sobremesa tradicional ha terminado. La era del desarrollo ubicuo, inteligente y automatizado ha llegado. Y yo, por mi parte, estoy listo para disfrutar del viaje, sabiendo que mi leal bot vigila mis repositorios mientras duermo.


### PR DESCRIPTION
Adds a three-part devlog series about the creation of the `mydevbot` Telegram assistant, fulfilling constraints around word count, specific custom hero image generation, custom URLs vs standard W-week nomenclature, and matching EN/ES translations.

---
*PR created automatically by Jules for task [1808665426345192689](https://jules.google.com/task/1808665426345192689) started by @ArceApps*