### PR TITLE
Fix Dark Mode Contrast for Strong Text

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -152,8 +152,8 @@
       transition: font-variation-settings 0.3s ease-out;
   }
 
-  /* Force dark mode color for headings to ensure high contrast */
-  :is(.dark .prose) :is(h1, h2, h3, h4, h5, h6) {
+  /* Force dark mode color for headings and bold text to ensure high contrast */
+  :is(.dark .prose) :is(h1, h2, h3, h4, h5, h6, strong) {
       color: var(--color-dark-on-surface) !important;
   }
 


### PR DESCRIPTION
En modo oscuro, los textos en negrita (etiqueta `strong`) perdían contraste y eran difíciles de leer dentro de los contenedores `.prose`.

Se modificó `src/styles/global.css` para forzar que los elementos `strong` utilicen el mismo color de alto contraste que los encabezados (`var(--color-dark-on-surface) !important`) cuando el modo oscuro (`.dark`) está activo.

Esto garantiza que frases clave, como "ausencia de soporte para Docker", mantengan su legibilidad. Las pruebas unitarias locales y la verificación visual mediante Playwright confirmaron el resultado esperado.

---
*PR created automatically by Jules for task [678983441168342018](https://jules.google.com/task/678983441168342018) started by @ArceApps*