### PR TITLE
Fix dark mode link colors in prose

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -184,10 +184,16 @@
 
   /* Links */
   .prose a {
-    @apply text-primary dark:text-teal-200 font-semibold no-underline transition-colors;
+    @apply text-primary font-semibold no-underline transition-colors;
   }
   .prose a:hover {
     @apply text-secondary underline;
+  }
+  :is(.dark .prose) a {
+    color: var(--color-secondary) !important;
+  }
+  :is(.dark .prose) a:hover {
+    color: var(--color-primary) !important;
   }
 
   /* Strong */


### PR DESCRIPTION
Fixes an issue where links within the content of blog posts and devlogs (`.prose a`) were difficult or impossible to see when dark mode was active. The change applies the project's secondary orange color to links in dark mode, and changes them to primary teal when hovered.

---
*PR created automatically by Jules for task [3574871735828484690](https://jules.google.com/task/3574871735828484690) started by @ArceApps*