### PR TITLE
Correct Gemini model names and fix devlog internal links

### DIFF
--- a/src/content/devlog/en/2026-03-05-mydevbot-genesis-hardware.md
+++ b/src/content/devlog/en/2026-03-05-mydevbot-genesis-hardware.md
@@ -80,7 +80,7 @@ The CLI-based approach has several serious problems when you try to build a pers
 
 The decision was obvious: I had to use the **official Google GenAI SDK for Python** (`google-genai`).
 
-By integrating the SDK directly into my bot's code, I gained absolute control. I could initialize an instance of the **Gemini 3.1 Flash-Lite** model (I chose the 3.1 Flash-Lite version for being the fastest and most cost-efficient model in the 3 series, built for scale and perfect for a quick assistant). The SDK allows managing chat sessions with persistent state. I just have to instantiate a `ChatSession` object, pass it the user's new message, and the SDK takes care of sending all the previous context to the API and returning the response.
+By integrating the SDK directly into my bot's code, I gained absolute control. I could initialize an instance of the **Gemini 3.1** model (I chose the 3.1 version for being the fastest and most cost-efficient model in the 3 series, built for scale and perfect for a quick assistant). The SDK allows managing chat sessions with persistent state. I just have to instantiate a `ChatSession` object, pass it the user's new message, and the SDK takes care of sending all the previous context to the API and returning the response.
 
 The code was simplified enormously:
 
@@ -89,7 +89,7 @@ import google.generativeai as genai
 
 # Initial setup
 genai.configure(api_key=os.environ["GEMINI_API_KEY"])
-model = genai.GenerativeModel('gemini-3.1-flash-lite')
+model = genai.GenerativeModel('gemini-3.1')
 chat_session = model.start_chat(history=[])
 
 def handle_message(update, context):

--- a/src/content/devlog/en/2026-03-06-mydevbot-github-cron-skills.md
+++ b/src/content/devlog/en/2026-03-06-mydevbot-github-cron-skills.md
@@ -7,7 +7,7 @@ heroImage: "/images/mydevbot-skills-cron-hero.svg"
 reference_id: "0463727d-8058-4f3a-b565-1baec56b3470"
 ---
 
-Yesterday I left the story at a sweet spot. I had **mydevbot** running in its brand new home: a Minisforum UM890 Pro Mini PC with ridiculous power consumption and plenty of power. The bot could reply to Telegram messages in milliseconds thanks to the use of the native Google Gemini SDK (specifically, Gemini 3.1 Flash-Lite). It was fast, efficient, and private.
+Yesterday I left the story at a sweet spot. I had **mydevbot** running in its brand new home: a Minisforum UM890 Pro Mini PC with ridiculous power consumption and plenty of power. The bot could reply to Telegram messages in milliseconds thanks to the use of the native Google Gemini SDK (specifically, Gemini 3.1). It was fast, efficient, and private.
 
 But let's be honest: a bot that is only good for chatting, no matter how fast it is, is nothing more than a glorified ChatGPT with a different interface. For *mydevbot* to earn its name and truly revolutionize my workflow, I needed to give it hands. I needed it to be able to touch my repositories, read my code, manage my issues, and keep an eye on my infrastructure while I was busy with other things.
 
@@ -72,7 +72,7 @@ Reading data is fine, but the real power lies in acting. The next phase was to e
 I created a complete suite of tools for GitHub. Some of the most useful ones I implemented that same afternoon were:
 
 *   `create_github_issue(repo_name: str, title: str, body: str, labels: list)`: To report bugs on the fly. If I'm testing one of my apps on my phone and I find a UI error, I no longer have to open my laptop. I simply go to Telegram and tell mydevbot: *"Create an issue in the web repo indicating that the contact button in dark mode doesn't have enough contrast. Label it as bug and ui"*. The bot extracts the parameters perfectly and creates the ticket.
-*   `get_latest_pr_diff(repo_name: str)`: This was one of my favorites. It allows the bot to read the diff (the code changes) of the latest open Pull Request. And since Gemini has a huge context window (especially the 3.1 Pro version, although Flash-Lite also works very well for medium diffs), it can analyze that code and look for bugs.
+*   `get_latest_pr_diff(repo_name: str)`: This was one of my favorites. It allows the bot to read the diff (the code changes) of the latest open Pull Request. And since Gemini has a huge context window (especially the 3.1 Pro version, although 3.1 also works very well for medium diffs), it can analyze that code and look for bugs.
 *   `comment_on_pr(repo_name: str, pr_number: int, comment: str)`: The logical complement to the previous one. After the bot reads the diff, it can post a comment directly on GitHub.
 
 I remember the first time I tested the full flow. I had pushed a small patch from my laptop, but I wasn't sure if I had introduced a possible concurrency issue. I went to the couch, opened Telegram, and asked mydevbot to review the PR.

--- a/src/content/devlog/en/2026-03-07-mydevbot-cicd-egpu-future.md
+++ b/src/content/devlog/en/2026-03-07-mydevbot-cicd-egpu-future.md
@@ -7,7 +7,7 @@ heroImage: "/images/mydevbot-cicd-future-hero.svg"
 reference_id: "83523401-9392-426f-b039-f3ae73132d40"
 ---
 
-We have reached the last entry of this trilogy about **mydevbot**. If in the [first article](2026-03-05-mydevbot-genesis-hardware) I talked about the odyssey to find the perfect hardware (the Minisforum UM890 Pro) and in the [second](2026-03-06-mydevbot-github-cron-skills) I detailed how I taught it to use the GitHub API and wake me up with daily summaries, today it's time to talk about scalability, automation, and the real development experience.
+We have reached the last entry of this trilogy about **mydevbot**. If in the [first article](./2026-03-05-mydevbot-genesis-hardware) I talked about the odyssey to find the perfect hardware (the Minisforum UM890 Pro) and in the [second](./2026-03-06-mydevbot-github-cron-skills) I detailed how I taught it to use the GitHub API and wake me up with daily summaries, today it's time to talk about scalability, automation, and the real development experience.
 
 Because here is a fascinating paradox: I have built a Telegram bot to manage my software development while I am away from home... but what happens when I want to develop or improve *the bot itself* while I am away from home?
 
@@ -67,7 +67,7 @@ It's the magic of DevOps applied to my personal life. There is no more friction.
 
 At this point, the software architecture was solid. But I want to talk about hardware again. About that OCuLink port I mentioned in the first article and which was the decisive factor for buying the Minisforum UM890 Pro instead of cheaper alternatives.
 
-Currently, *mydevbot* uses the Gemini 3.1 Flash-Lite API. It is fast, it is almost free, and it is brilliant for programming. But it is still "The Cloud". If tomorrow I lose internet access (and the fiber optic network in my area has occasional outages), or if Google decides to radically change its API pricing, my automated brain will stop working.
+Currently, *mydevbot* uses the Gemini 3.1 API. It is fast, it is almost free, and it is brilliant for programming. But it is still "The Cloud". If tomorrow I lose internet access (and the fiber optic network in my area has occasional outages), or if Google decides to radically change its API pricing, my automated brain will stop working.
 
 The true sovereignty I spoke of at the beginning is only achieved when the Language Model runs physically in your home.
 

--- a/src/content/devlog/es/2026-03-05-mydevbot-genesis-hardware.md
+++ b/src/content/devlog/es/2026-03-05-mydevbot-genesis-hardware.md
@@ -80,7 +80,7 @@ El enfoque basado en CLI tiene varios problemas graves cuando intentas construir
 
 La decisión fue obvia: debía utilizar el **SDK oficial de Google GenAI para Python** (`google-genai`).
 
-Al integrar el SDK directamente en el código de mi bot, obtenía un control absoluto. Podía inicializar una instancia del modelo **Gemini 3.1 Flash-Lite** (elegí la versión 3.1 Flash-Lite por ser el modelo más rápido y eficiente en costes de la serie 3, diseñado para escalar y perfecto para un asistente rápido). El SDK permite manejar sesiones de chat con estado persistente. Solo tengo que instanciar un objeto `ChatSession`, pasarle el nuevo mensaje del usuario, y el SDK se encarga de enviar todo el contexto previo a la API y devolver la respuesta.
+Al integrar el SDK directamente en el código de mi bot, obtenía un control absoluto. Podía inicializar una instancia del modelo **Gemini 3.1** (elegí la versión 3.1 por ser el modelo más rápido y eficiente en costes de la serie 3, diseñado para escalar y perfecto para un asistente rápido). El SDK permite manejar sesiones de chat con estado persistente. Solo tengo que instanciar un objeto `ChatSession`, pasarle el nuevo mensaje del usuario, y el SDK se encarga de enviar todo el contexto previo a la API y devolver la respuesta.
 
 El código se simplificaba enormemente:
 
@@ -89,7 +89,7 @@ import google.generativeai as genai
 
 # Configuración inicial
 genai.configure(api_key=os.environ["GEMINI_API_KEY"])
-model = genai.GenerativeModel('gemini-3.1-flash-lite')
+model = genai.GenerativeModel('gemini-3.1')
 chat_session = model.start_chat(history=[])
 
 def handle_message(update, context):

--- a/src/content/devlog/es/2026-03-06-mydevbot-github-cron-skills.md
+++ b/src/content/devlog/es/2026-03-06-mydevbot-github-cron-skills.md
@@ -7,7 +7,7 @@ heroImage: "/images/mydevbot-skills-cron-hero.svg"
 reference_id: "0463727d-8058-4f3a-b565-1baec56b3470"
 ---
 
-Ayer dejé la historia en un punto dulce. Tenía a **mydevbot** funcionando en su nueva y flamante casa: un Mini PC Minisforum UM890 Pro con un consumo irrisorio y potencia de sobra. El bot podía responder mensajes en Telegram en milisegundos gracias al uso del SDK nativo de Google Gemini (específicamente, Gemini 3.1 Flash-Lite). Era rápido, eficiente y privado.
+Ayer dejé la historia en un punto dulce. Tenía a **mydevbot** funcionando en su nueva y flamante casa: un Mini PC Minisforum UM890 Pro con un consumo irrisorio y potencia de sobra. El bot podía responder mensajes en Telegram en milisegundos gracias al uso del SDK nativo de Google Gemini (específicamente, Gemini 3.1). Era rápido, eficiente y privado.
 
 Pero seamos sinceros: un bot que solo sirve para charlar, por muy rápido que sea, no es más que un ChatGPT glorificado con otra interfaz. Para que *mydevbot* se ganara su nombre y realmente revolucionara mi flujo de trabajo, necesitaba darle manos. Necesitaba que pudiera tocar mis repositorios, leer mi código, gestionar mis problemas y mantener un ojo en mi infraestructura mientras yo estaba ocupado en otras cosas.
 
@@ -72,7 +72,7 @@ Leer datos está bien, pero el verdadero poder reside en actuar. La siguiente fa
 Creé una suite completa de herramientas para GitHub. Algunas de las más útiles que implementé esa misma tarde fueron:
 
 *   `create_github_issue(repo_name: str, title: str, body: str, labels: list)`: Para reportar bugs sobre la marcha. Si estoy probando una de mis apps en el móvil y encuentro un error de UI, ya no tengo que abrir el portátil. Simplemente voy a Telegram y le digo a mydevbot: *"Crea un issue en el repo de la web indicando que el botón de contacto en modo oscuro no tiene suficiente contraste. Etiquétalo como bug y ui"*. El bot extrae los parámetros perfectamente y crea el ticket.
-*   `get_latest_pr_diff(repo_name: str)`: Esta fue una de mis favoritas. Le permite al bot leer el diff (los cambios de código) de la última Pull Request abierta. Y como Gemini tiene una ventana de contexto enorme (especialmente la versión 3.1 Pro, aunque en Flash-Lite también funciona muy bien para diffs medianos), puede analizar ese código y buscar errores.
+*   `get_latest_pr_diff(repo_name: str)`: Esta fue una de mis favoritas. Le permite al bot leer el diff (los cambios de código) de la última Pull Request abierta. Y como Gemini tiene una ventana de contexto enorme (especialmente la versión 3.1 Pro, aunque en la 3.1 también funciona muy bien para diffs medianos), puede analizar ese código y buscar errores.
 *   `comment_on_pr(repo_name: str, pr_number: int, comment: str)`: El complemento lógico de la anterior. Después de que el bot lee el diff, puede publicar un comentario directamente en GitHub.
 
 Recuerdo la primera vez que probé el flujo completo. Había subido un pequeño parche desde el portátil, pero no estaba seguro de si había introducido un posible problema de concurrencia. Me fui al sofá, abrí Telegram y le pedí a mydevbot que revisara el PR.

--- a/src/content/devlog/es/2026-03-07-mydevbot-cicd-egpu-future.md
+++ b/src/content/devlog/es/2026-03-07-mydevbot-cicd-egpu-future.md
@@ -7,7 +7,7 @@ heroImage: "/images/mydevbot-cicd-future-hero.svg"
 reference_id: "83523401-9392-426f-b039-f3ae73132d40"
 ---
 
-Llegamos a la última entrada de esta trilogía sobre **mydevbot**. Si en el [primer artículo](2026-03-05-mydevbot-genesis-hardware) hablé de la odisea para encontrar el hardware perfecto (el Minisforum UM890 Pro) y en el [segundo](2026-03-06-mydevbot-github-cron-skills) detallé cómo le enseñé a usar la API de GitHub y a despertarme con resúmenes diarios, hoy toca hablar de escalabilidad, automatización y de la experiencia real de desarrollo.
+Llegamos a la última entrada de esta trilogía sobre **mydevbot**. Si en el [primer artículo](./2026-03-05-mydevbot-genesis-hardware) hablé de la odisea para encontrar el hardware perfecto (el Minisforum UM890 Pro) y en el [segundo](./2026-03-06-mydevbot-github-cron-skills) detallé cómo le enseñé a usar la API de GitHub y a despertarme con resúmenes diarios, hoy toca hablar de escalabilidad, automatización y de la experiencia real de desarrollo.
 
 Porque aquí hay una paradoja fascinante: he construido un bot de Telegram para gestionar mi desarrollo de software mientras estoy fuera de casa... pero ¿qué pasa cuando quiero desarrollar o mejorar *el propio bot* mientras estoy fuera de casa?
 
@@ -67,7 +67,7 @@ Es la magia del DevOps aplicada a mi vida personal. Ya no hay fricción. Si el b
 
 Llegados a este punto, la arquitectura de software era sólida. Pero quiero hablar de hardware otra vez. De ese puerto OCuLink del que hablé en el primer artículo y que fue el factor decisivo para comprar el Minisforum UM890 Pro en lugar de alternativas más baratas.
 
-Actualmente, *mydevbot* usa la API de Gemini 3.1 Flash-Lite. Es rápida, es casi gratuita, y es brillante para programación. Pero sigue siendo "La Nube". Si mañana me quedo sin internet (y la red de fibra óptica de mi zona tiene cortes ocasionales), o si Google decide cambiar radicalmente los precios de su API, mi cerebro automatizado dejará de funcionar.
+Actualmente, *mydevbot* usa la API de Gemini 3.1. Es rápida, es casi gratuita, y es brillante para programación. Pero sigue siendo "La Nube". Si mañana me quedo sin internet (y la red de fibra óptica de mi zona tiene cortes ocasionales), o si Google decide cambiar radicalmente los precios de su API, mi cerebro automatizado dejará de funcionar.
 
 La verdadera soberanía de la que hablaba al principio solo se consigue cuando el Modelo de Lenguaje corre físicamente en tu casa.
 


### PR DESCRIPTION
- Removed the 'Flash-Lite' suffix from all mentions of 'Gemini 3.1' across English and Spanish translations of the mydevbot devlog trilogy, aligning with the expected 2026 tech lore context.
- Also updated a python code block initializing the model string to drop 'flash-lite'.
- Maintained mentions to 'Gemini 3.1 Pro' as requested.
- Fixed broken cross-links in the third devlog article that were pointing to bare markdown file names by prepending `./` so Astro correctly resolves the links relative to the current locale's generated devlog path.

---
*PR created automatically by Jules for task [1406386844389917312](https://jules.google.com/task/1406386844389917312) started by @ArceApps*