### PR TITLE
Update mydevbot tone in devlog posts

### DIFF
--- a/src/content/devlog/en/2026-03-06-mydevbot-github-cron-skills.md
+++ b/src/content/devlog/en/2026-03-06-mydevbot-github-cron-skills.md
@@ -113,10 +113,10 @@ async def morning_briefing(context: ContextTypes.DEFAULT_TYPE):
     # Gather data (using the previously created functions)
     repo_status = get_repo_summary("ArceApps/PuzzleHub")
 
-    # Ask Gemini to format the summary in a friendly way
-    prompt = f"Act as my personal assistant. Write a friendly and professional good morning message. " \
-             f"Include this main repository status in a summarized way: {repo_status}. " \
-             f"Add a short motivational message at the end."
+    # Ask Gemini to format the summary directly and sarcastically
+    prompt = f"Start with a generic and ridiculous motivational phrase, the kind that induces second-hand embarrassment. " \
+             f"Then interrupt yourself, realize how absurd it sounds, and give me the status of the " \
+             f"repository like a direct, sarcastic coworker: {repo_status}. Absolutely no 'boss' titles."
 
     response = chat_session.send_message(prompt)
 
@@ -135,11 +135,13 @@ scheduler.start()
 
 That code is the foundation of proactivity. The `CronTrigger` block allows for incredible flexibility. I could schedule tasks to run every hour, on the first Sunday of every month, or complex combinations.
 
-The morning after implementing this was magical. I was having my first coffee of the day, mentally preparing for the workday, when my phone vibrated at exactly 08:30. It was a Telegram message from *mydevbot*:
+The morning after implementing this was... revealing. I was having my first coffee of the day, mentally preparing for the workday, when my phone vibrated at exactly 08:30. It was the first scheduled message from *mydevbot*:
 
-*"Good morning boss! I hope you rested well. Here is today's briefing: The ArceApps/PuzzleHub repository currently has 3 open issues waiting for your attention and 1 Pull Request ready for merge review. It looks like the community has been active tonight. Remember that small constant steps build great projects. Have a great day!"*
+*"Remember that every sunrise is a new opportunity for your dreams to compile without errors! The universe is conspiring in your favor to... Ugh, I disgust myself sometimes. Let's forget that cheap life coach garbage.*
 
-I didn't have to open any app. I didn't have to remember to look. The information came to me, filtered, formatted nicely, and at the exact moment I needed it.
+*Let's get straight to it, because code doesn't write itself. Over in ArceApps/PuzzleHub, you have 3 open issues giving you the side-eye and 1 Pull Request that's been gathering dust all night, waiting for you to merge it. Get to work."*
+
+I laughed out loud. That was exactly the tone I needed. No artificial servility, no toxic positivity, but a coworker in the trenches handing me unfiltered, direct information at the precise moment I needed it.
 
 From there, the possibilities for APScheduler "jobs" exploded in my head. I started adding more cron tasks to *mydevbot*'s arsenal:
 

--- a/src/content/devlog/es/2026-03-06-mydevbot-github-cron-skills.md
+++ b/src/content/devlog/es/2026-03-06-mydevbot-github-cron-skills.md
@@ -113,10 +113,10 @@ async def morning_briefing(context: ContextTypes.DEFAULT_TYPE):
     # Recopilar datos (usando las funciones ya creadas)
     repo_status = get_repo_summary("ArceApps/PuzzleHub")
 
-    # Pedirle a Gemini que formatee el resumen de forma amigable
-    prompt = f"Actúa como mi asistente personal. Redacta un mensaje de buenos días amable y profesional. " \
-             f"Incluye este estado del repositorio principal de forma resumida: {repo_status}. " \
-             f"Añade un mensaje motivacional corto al final."
+    # Pedirle a Gemini que formatee el resumen de forma directa pero sarcástica
+    prompt = f"Empieza con una frase motivacional genérica y ridícula, de esas que dan vergüenza ajena. " \
+             f"Luego córtate a ti mismo, date cuenta de lo absurdo que suena, y dame el estado del " \
+             f"repositorio como un compañero de trabajo directo y sarcástico: {repo_status}. Cero apelativos de 'jefe'."
 
     response = chat_session.send_message(prompt)
 
@@ -135,11 +135,13 @@ scheduler.start()
 
 Ese código es la base de la proactividad. El bloque `CronTrigger` permite una flexibilidad increíble. Podía programar tareas para que se ejecutaran cada hora, el primer domingo de cada mes, o combinaciones complejas.
 
-La mañana siguiente a implementar esto fue mágica. Estaba tomando el primer café del día, preparándome mentalmente para la jornada laboral, cuando el móvil vibró a las 08:30 en punto. Era un mensaje de Telegram de *mydevbot*:
+La mañana siguiente a implementar esto fue... reveladora. Estaba tomando el primer café del día, preparándome mentalmente para la jornada laboral, cuando el móvil vibró a las 08:30 en punto. Era el primer mensaje programado de *mydevbot*:
 
-*"¡Buenos días jefe! Espero que hayas descansado. Aquí tienes el briefing de hoy: El repositorio ArceApps/PuzzleHub tiene actualmente 3 issues abiertos esperando tu atención y 1 Pull Request lista para revisión de merge. Parece que la comunidad ha estado activa esta noche. Recuerda que pequeños avances constantes construyen grandes proyectos. ¡A por el día!"*
+*"¡Recuerda que cada amanecer es una nueva oportunidad para que tus sueños compilen sin errores! El universo conspira a tu favor para... Uf, qué asco me doy a veces. Olvida esa basura de coach de saldo.*
 
-No tuve que abrir ninguna app. No tuve que acordarme de mirar. La información vino a mí, filtrada, formateada de manera agradable y en el momento exacto en que la necesitaba.
+*Vamos al grano, que el código no se escribe solo. En ArceApps/PuzzleHub tienes 3 issues abiertos mirándote mal y 1 Pull Request que lleva toda la noche acumulando polvo, esperando a que te dignes a darle merge. A trabajar."*
+
+Me reí en voz alta. Ese era exactamente el tono que necesitaba. Nada de servilismo artificial ni motivación tóxica, sino un compañero de trinchera que me daba la información filtrada y directa en el momento exacto en que la necesitaba.
 
 A partir de ahí, las posibilidades de los "jobs" de APScheduler explotaron en mi cabeza. Empecé a añadir más tareas cron al arsenal de *mydevbot*:
 


### PR DESCRIPTION
Updates the tone of the simulated mydevbot messages in the devlog to be more like a sarcastic, direct coworker rather than a subservient motivational coach. This applies to both the English and Spanish versions of the post.

---
*PR created automatically by Jules for task [493741167575120430](https://jules.google.com/task/493741167575120430) started by @ArceApps*