### PR TITLE
Fix deployment failure caused by missing `File` API in Node 18

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
This commit updates the Node.js version from '18' to '20' in `.github/workflows/deploy.yml` to resolve a deployment failure. The error (`ReferenceError: File is not defined` inside the `undici` library) is caused because certain newer dependencies require Node.js 20 or higher to access the native `File` API in the runtime environment.

---
*PR created automatically by Jules for task [627910234558307723](https://jules.google.com/task/627910234558307723) started by @ArceApps*