### PR TITLE
Fix: Remove hardcoded app ratings and improve Google Play sync

### DIFF
--- a/scripts/update-play-images.js
+++ b/scripts/update-play-images.js
@@ -73,6 +73,10 @@ async function processFile(filePath) {
         data.rating = roundedScore;
         updated = true;
       }
+    } else if (data.rating !== undefined) {
+      // If there's no score in the store but we have a rating, remove it
+      delete data.rating;
+      updated = true;
     }
 
     // Update version

--- a/src/content/apps/en/2048-puzzle.md
+++ b/src/content/apps/en/2048-puzzle.md
@@ -29,9 +29,9 @@ screenshots:
     https://play-lh.googleusercontent.com/KrmYU2OSeU0unIo9ucuOM6sG6NRWhYf9QgTdycTg0BQjzc-Q8WCBwNaSqT1hzuoe8Ic
   - >-
     https://play-lh.googleusercontent.com/6W6dRSV0OmsGEpVnVTT2LYui-RGxwOwF3d8pwVHMMAGPDyy1bwIiFY95B0BliOKNYIpt
-rating: 4.5
 lastUpdated: 'Jul 23, 2025'
 version: 4.2.3
+rating: 4.5
 ---
 
 Welcome to the ultimate brain-teasing adventure of 2048!

--- a/src/content/apps/en/4line.md
+++ b/src/content/apps/en/4line.md
@@ -31,7 +31,6 @@ screenshots:
     https://play-lh.googleusercontent.com/Vfjp6vkCmYEb8U91U6goSl_5LlQ2heL6herjW3uyUuJdJVOVO7yK94PUN87Iwn9tq7k
   - >-
     https://play-lh.googleusercontent.com/M5wICC6b3Iq7qP3HY-c_WIEv78orgwH2tVDS20nOuPUvSgzi-4xnMXzNsjqr4CYhgg
-rating: 4.8
 lastUpdated: 'Jul 23, 2025'
 version: 2.1.1
 ---

--- a/src/content/apps/es/2048-puzzle.md
+++ b/src/content/apps/es/2048-puzzle.md
@@ -29,9 +29,9 @@ screenshots:
     https://play-lh.googleusercontent.com/-0meaaW-4C7fk7twCZXne_bL7udjilbPolCpwUZzqExK-_usCxJq3iNvLZNfKdgDp3Y
   - >-
     https://play-lh.googleusercontent.com/HKVxdNptNOMz7ky5-hXoN1ZRbzgaVs-SYGvmgx6UXXjiPB3UqJX0W4pSwYkXvB997A51
-rating: 4.5
 lastUpdated: 23 jul 2025
 version: 4.2.3
+rating: 4.5
 ---
 
 Welcome to the ultimate brain-teasing adventure of 2048!

--- a/src/content/apps/es/4line.md
+++ b/src/content/apps/es/4line.md
@@ -31,7 +31,6 @@ screenshots:
     https://play-lh.googleusercontent.com/cTQdMk8LHjYcyh5B7--W8lXIv4hxtIHvwi1bMErdWsAXnDIhZ8lekvwhp2ZnevelDw
   - >-
     https://play-lh.googleusercontent.com/F4EW0OQhMe91otWS8a9aBl0_8tHEDi8YY24Z4BR6W5s2UBKbDBxsVNgwMBSpGRHmN7rm
-rating: 4.8
 lastUpdated: 23 jul 2025
 version: 2.1.1
 ---


### PR DESCRIPTION
Eliminate hardcoded or invented app store ratings from the apps section. The sync script now automatically removes the rating field if the app does not have a public rating on Google Play.

---
*PR created automatically by Jules for task [1400725091265200039](https://jules.google.com/task/1400725091265200039) started by @ArceApps*