### PR TITLE
Fix double slashes in generated path in Header.astro

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -43,13 +43,13 @@ if (!nextPath) {
   // Note: This works perfectly for structural pages. For content with different slugs (blog posts),
   // it might lead to 404s if slugs don't match.
   // Ideally, we would map exact content paths, but for now this covers the main navigation.
+  const segments = pathname.split('/').filter(Boolean);
   if (currentLang === 'es') {
-    nextPath = pathname.replace(/^\/es/, '') || '/';
+    if (segments[0] === 'es') segments.shift();
   } else {
-    nextPath = '/es' + pathname;
+    segments.unshift('es');
   }
-  // Fix double slashes just in case
-  nextPath = nextPath.replace(/\/\//g, '/');
+  nextPath = '/' + segments.join('/');
 }
 ---
 


### PR DESCRIPTION
He refactorizado la lógica de generación de rutas en el componente `Header.astro` para corregir la creación de dobles barras al cambiar de idioma. 

La solución anterior dependía de concatenaciones simples y un parche posterior con `.replace(/\/\//g, '/')`, lo cual era frágil. La nueva implementación divide la ruta en segmentos, filtra los elementos vacíos y reconstruye la ruta de forma limpia. Esto no solo soluciona las dobles barras sino que también asegura que no haya barras finales innecesarias (ej. `/es` en lugar de `/es/`).

Se ha verificado la lógica mediante un script de prueba independiente que cubre casos como `/`, `/apps`, `/es`, `/es/apps` y rutas con barras accidentales.

---
*PR created automatically by Jules for task [9318938520851969011](https://jules.google.com/task/9318938520851969011) started by @ArceApps*