### PR TITLE
🔒 [security fix] Remove hardcoded email fallback in ContactForm

### DIFF
--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -9,8 +9,11 @@ const { lang = 'es' } = Astro.props;
 const t = useTranslations(lang);
 
 // Security: Use environment variable for email to prevent hardcoding secrets in repo
-const contactEmail =
-  import.meta.env.PUBLIC_CONTACT_EMAIL || "arce.com.apps@gmail.com";
+const contactEmail = import.meta.env.PUBLIC_CONTACT_EMAIL;
+
+if (!contactEmail && import.meta.env.PROD) {
+  throw new Error("PUBLIC_CONTACT_EMAIL environment variable is not defined. Contact form will not work in production.");
+}
 
 const nextUrl = lang === 'es'
   ? "https://arceapps.github.io/es/about-me"


### PR DESCRIPTION
Este cambio elimina la dirección de correo electrónico "hardcodeada" en el componente `ContactForm.astro`, mitigando el riesgo de exposición de información sensible en el repositorio. 

Se ha implementado lo siguiente:
- Dependencia exclusiva de la variable de entorno `PUBLIC_CONTACT_EMAIL`.
- Validación en tiempo de compilación (Astro) que lanza un error si la variable no está definida en entornos de producción, garantizando la correcta configuración del sitio antes del despliegue.
- Eliminación de la vulnerabilidad identificada sin comprometer la funcionalidad para el usuario final.

---
*PR created automatically by Jules for task [5138553798756669787](https://jules.google.com/task/5138553798756669787) started by @ArceApps*