### PR TITLE
🧹 Remove 'any' type in tag iteration

### DIFF
--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -1,17 +1,22 @@
 ---
 import Layout from "../../../layouts/Layout.astro";
 import BlogCard from "../../../components/BlogCard.astro";
-import { getCollection } from "astro:content";
+import { getCollection, type CollectionEntry } from "astro:content";
 import { slugify } from "../../../utils/slugs";
 import { useTranslations } from "../../../i18n/utils";
 
 const t = useTranslations('en');
 
+interface TagGroup {
+  posts: Set<CollectionEntry<'blog'>>;
+  displayNames: Map<string, number>;
+}
+
 export async function getStaticPaths() {
   const allPosts = await getCollection("blog", ({ data, id }) => !data.draft && id.startsWith('en/'));
   
   // Group posts by slugified tag
-  const tagGroups = new Map();
+  const tagGroups = new Map<string, TagGroup>();
 
   allPosts.forEach(post => {
     const tags = post.data.tags || [];
@@ -25,7 +30,7 @@ export async function getStaticPaths() {
       }
 
       // Explicitly type the retrieved group
-      const group = tagGroups.get(slug) as { posts: Set<any>; displayNames: Map<string, number> };
+      const group = tagGroups.get(slug)!;
       group.posts.add(post);
 
       const count = group.displayNames.get(tag) || 0;
@@ -33,7 +38,7 @@ export async function getStaticPaths() {
     });
   });
   
-  return Array.from(tagGroups.entries()).map(([slug, data]: [string, any]) => {
+  return Array.from(tagGroups.entries()).map(([slug, data]) => {
     // Find the most frequent display name for this slug
     let bestDisplayName = "";
     let maxCount = -1;
@@ -45,7 +50,7 @@ export async function getStaticPaths() {
       }
     }
 
-    const filteredPosts = Array.from(data.posts as Set<any>).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+    const filteredPosts = Array.from(data.posts).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
     
     return {
       params: { tag: slug },
@@ -77,7 +82,7 @@ const { posts, tagName } = Astro.props;
     <div class="container mx-auto px-4">
       {posts.length > 0 ? (
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {posts.map((post: any) => (
+          {posts.map((post: CollectionEntry<'blog'>) => (
             <BlogCard post={post} />
           ))}
         </div>

--- a/src/pages/es/blog/tag/[tag].astro
+++ b/src/pages/es/blog/tag/[tag].astro
@@ -1,17 +1,22 @@
 ---
 import Layout from "../../../../layouts/Layout.astro";
 import BlogCard from "../../../../components/BlogCard.astro";
-import { getCollection } from "astro:content";
+import { getCollection, type CollectionEntry } from "astro:content";
 import { slugify } from "../../../../utils/slugs";
 import { useTranslations } from "../../../../i18n/utils";
 
 const t = useTranslations('es');
 
+interface TagGroup {
+  posts: Set<CollectionEntry<'blog'>>;
+  displayNames: Map<string, number>;
+}
+
 export async function getStaticPaths() {
   const allPosts = await getCollection("blog", ({ data, id }) => !data.draft && id.startsWith('es/'));
 
   // Group posts by slugified tag
-  const tagGroups = new Map();
+  const tagGroups = new Map<string, TagGroup>();
 
   allPosts.forEach(post => {
     const tags = post.data.tags || [];
@@ -25,7 +30,7 @@ export async function getStaticPaths() {
       }
 
       // Explicitly type the retrieved group
-      const group = tagGroups.get(slug) as { posts: Set<any>; displayNames: Map<string, number> };
+      const group = tagGroups.get(slug)!;
       group.posts.add(post);
 
       const count = group.displayNames.get(tag) || 0;
@@ -33,7 +38,7 @@ export async function getStaticPaths() {
     });
   });
 
-  return Array.from(tagGroups.entries()).map(([slug, data]: [string, any]) => {
+  return Array.from(tagGroups.entries()).map(([slug, data]) => {
     // Find the most frequent display name for this slug
     let bestDisplayName = "";
     let maxCount = -1;
@@ -45,7 +50,7 @@ export async function getStaticPaths() {
       }
     }
 
-    const filteredPosts = Array.from(data.posts as Set<any>).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+    const filteredPosts = Array.from(data.posts).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
     return {
       params: { tag: slug },
@@ -77,7 +82,7 @@ const { posts, tagName } = Astro.props;
     <div class="container mx-auto px-4">
       {posts.length > 0 ? (
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {posts.map((post: any) => (
+          {posts.map((post: CollectionEntry<'blog'>) => (
             <BlogCard post={post} />
           ))}
         </div>


### PR DESCRIPTION
Se ha eliminado el uso del tipo `any` en la lógica de iteración de etiquetas de las páginas del blog (`src/pages/blog/tag/[tag].astro` y `src/pages/es/blog/tag/[tag].astro`). 

Para ello:
1. Se ha definido una interfaz `TagGroup` que describe la estructura de datos utilizada para agrupar los posts por etiqueta.
2. Se ha tipado explícitamente el objeto `Map` que almacena estos grupos.
3. Se han actualizado las funciones de iteración y el renderizado del componente para utilizar los tipos correctos de la colección de Astro (`CollectionEntry<'blog'>`).

Estos cambios mejoran la legibilidad del código y proporcionan una mayor seguridad de tipos, facilitando el mantenimiento futuro sin alterar el comportamiento de la aplicación.

---
*PR created automatically by Jules for task [6095557317794160158](https://jules.google.com/task/6095557317794160158) started by @ArceApps*