### PR TITLE
🧪 Add unit tests for initServiceWorker in layout.ts

### DIFF
--- a/src/scripts/layout.test.ts
+++ b/src/scripts/layout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { initLayout } from './layout';
+import { initLayout, initServiceWorker } from './layout';
 
 describe('Layout Script', () => {
   let observeMock: any;
@@ -55,5 +55,59 @@ describe('Layout Script', () => {
     initLayout(); // Call again to simulate navigation
 
     expect(disconnectMock).toHaveBeenCalled();
+  });
+
+  describe('initServiceWorker', () => {
+    let registerMock: any;
+
+    beforeEach(() => {
+      registerMock = vi.fn();
+
+      // Mock navigator.serviceWorker
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: {
+          register: registerMock,
+        },
+        configurable: true,
+        writable: true,
+      });
+
+      // Mock console.log
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    it('should register service worker if supported', async () => {
+      registerMock.mockResolvedValue({ scope: '/' });
+
+      initServiceWorker();
+
+      expect(registerMock).toHaveBeenCalledWith('/sw.js');
+
+      // Wait for promise resolution
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(console.log).toHaveBeenCalledWith('SW registered: ', { scope: '/' });
+    });
+
+    it('should log error if registration fails', async () => {
+      const error = new Error('SW failed');
+      registerMock.mockRejectedValue(error);
+
+      initServiceWorker();
+
+      expect(registerMock).toHaveBeenCalledWith('/sw.js');
+
+      // Wait for promise resolution
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(console.log).toHaveBeenCalledWith('SW registration failed: ', error);
+    });
+
+    it('should not register if serviceWorker is not in navigator', () => {
+      // @ts-ignore
+      delete navigator.serviceWorker;
+
+      initServiceWorker();
+
+      expect(registerMock).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Address the testing gap in `src/scripts/layout.ts` by adding unit tests for the `initServiceWorker` function. Verified registration path and promise handling.

- Added tests for successful registration.
- Added tests for registration failure.
- Added tests for browsers without service worker support.
- Utilized Vitest mocks for `navigator.serviceWorker` and `console.log`.

---
*PR created automatically by Jules for task [7640235281551782413](https://jules.google.com/task/7640235281551782413) started by @ArceApps*