### PR TITLE
ci: fix github pages deploy crash by providing PUBLIC_CONTACT_EMAIL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,8 @@ jobs:
         run: pnpm install
       - name: Build
         run: pnpm run build
+        env:
+          PUBLIC_CONTACT_EMAIL: arceapps.dev@gmail.com
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact


### PR DESCRIPTION
Fixes the GitHub Actions build crash by providing the required `PUBLIC_CONTACT_EMAIL` environment variable to `pnpm run build` inside `.github/workflows/deploy.yml`. 
The `ContactForm.astro` has a strict check throwing an error during production builds when this variable is missing.

---
*PR created automatically by Jules for task [7005687512136555942](https://jules.google.com/task/7005687512136555942) started by @ArceApps*