### PR TITLE
🧪 [testing improvement] Add error path test for clipboard writeText failure

### DIFF
--- a/src/scripts/code-copy.test.ts
+++ b/src/scripts/code-copy.test.ts
@@ -70,5 +70,25 @@ describe('Code Copy Script', () => {
         const buttons = document.querySelectorAll('.copy-code-btn');
         expect(buttons.length).toBe(1);
     });
+
+    it('should log error if clipboard write fails', async () => {
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const error = new Error('Clipboard fail');
+        (navigator.clipboard.writeText as any).mockRejectedValue(error);
+
+        document.body.innerHTML = '<pre><code>test code</code></pre>';
+        copyModule.setupCopyButtons();
+        const btn = document.querySelector('.copy-code-btn') as HTMLButtonElement;
+
+        if (btn) {
+            btn.click();
+        }
+
+        // Wait for promise rejection to be handled
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(consoleSpy).toHaveBeenCalledWith('Failed to copy:', error);
+        consoleSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
Esta tarea mejora la suite de pruebas del script de copiado de código (`src/scripts/code-copy.ts`) al añadir cobertura para el caso en que la API `navigator.clipboard.writeText` falla.

**Cambios:**
- Se ha actualizado `src/scripts/code-copy.test.ts` con un nuevo caso de prueba: `should log error if clipboard write fails`.
- Se utiliza un espía (`vi.spyOn`) en `console.error` para verificar que el error se registra correctamente en la consola cuando la promesa de copiado es rechazada.
- Se ha implementado un mock de rechazo asíncrono para simular el fallo de la API del portapapeles.

**Verificación:**
- Los cambios fueron revisados mediante una solicitud de revisión de código, obteniendo una evaluación de `#Correct#`.
- Aunque la ejecución local de las pruebas falló debido a problemas de red persistentes con el gestor de paquetes `pnpm` en el entorno actual, la implementación sigue estrictamente los patrones de prueba establecidos y exitosos de la suite de pruebas existente.

---
*PR created automatically by Jules for task [17823459647543854568](https://jules.google.com/task/17823459647543854568) started by @ArceApps*