### PR TITLE
🧹 refactor: remove any from debounce utility

### DIFF
--- a/src/scripts/search.test.ts
+++ b/src/scripts/search.test.ts
@@ -35,6 +35,66 @@ describe('Search Script', () => {
     searchModule.initSearchComponent();
   });
 
+  describe('debounce', () => {
+    it('should delay function execution', () => {
+      vi.useFakeTimers();
+      const func = vi.fn();
+      const debouncedFunc = searchModule.debounce(func, 100);
+
+      debouncedFunc();
+      expect(func).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(50);
+      expect(func).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(50);
+      expect(func).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it('should only execute once for multiple calls', () => {
+      vi.useFakeTimers();
+      const func = vi.fn();
+      const debouncedFunc = searchModule.debounce(func, 100);
+
+      debouncedFunc();
+      debouncedFunc();
+      debouncedFunc();
+
+      vi.advanceTimersByTime(100);
+      expect(func).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it('should pass arguments to the function', () => {
+      vi.useFakeTimers();
+      const func = vi.fn();
+      const debouncedFunc = searchModule.debounce(func, 100);
+
+      debouncedFunc('test', 123);
+
+      vi.advanceTimersByTime(100);
+      expect(func).toHaveBeenCalledWith('test', 123);
+      vi.useRealTimers();
+    });
+
+    it('should preserve this context', () => {
+      vi.useFakeTimers();
+      const context = { value: 'test' };
+      let capturedContext: any;
+      const func = function(this: any) {
+        capturedContext = this;
+      };
+      const debouncedFunc = searchModule.debounce(func, 100);
+
+      debouncedFunc.call(context);
+
+      vi.advanceTimersByTime(100);
+      expect(capturedContext).toBe(context);
+      vi.useRealTimers();
+    });
+  });
+
   describe('escapeHtml', () => {
     it('should escape special characters', () => {
       expect(searchModule.escapeHtml('<script>alert("xss")</script>')).toBe('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');

--- a/src/scripts/search.ts
+++ b/src/scripts/search.ts
@@ -24,9 +24,12 @@ let searchResults: HTMLElement | null = null;
 let searchStatus: HTMLElement | null = null;
 
 // Utility: Debounce function to limit execution frequency
-export function debounce<T extends (...args: any[]) => void>(func: T, wait: number) {
+export function debounce<T extends (...args: unknown[]) => void>(
+  func: T,
+  wait: number
+) {
   let timeout: ReturnType<typeof setTimeout>;
-  return function(this: any, ...args: Parameters<T>) {
+  return function (this: ThisParameterType<T>, ...args: Parameters<T>) {
     clearTimeout(timeout);
     timeout = setTimeout(() => func.apply(this, args), wait);
   };


### PR DESCRIPTION
🎯 **What:** He refactorizado la función de utilidad `debounce` en `src/scripts/search.ts` para eliminar el uso de tipos `any`. He sustituido `any[]` por `unknown[]` en la restricción genérica y he utilizado `ThisParameterType<T>` para capturar correctamente el contexto `this`.

💡 **Why:** El uso de `any` debilita la seguridad de tipos de TypeScript. Al utilizar genéricos más precisos, aseguramos que la función devuelta por `debounce` mantenga la misma firma de parámetros y contexto que la función original, mejorando la mantenibilidad y reduciendo el riesgo de errores en tiempo de ejecución.

✅ **Verification:** Se han añadido pruebas unitarias exhaustivas en `src/scripts/search.test.ts` que verifican:
- El retraso correcto en la ejecución.
- Que múltiples llamadas consecutivas solo resulten en una única ejecución.
- El paso correcto de argumentos a la función original.
- La preservación del contexto `this`.

✨ **Result:** La utilidad `debounce` es ahora completamente segura desde el punto de vista de tipos, siguiendo las mejores prácticas de TypeScript en el proyecto.

---
*PR created automatically by Jules for task [15638714961695680232](https://jules.google.com/task/15638714961695680232) started by @ArceApps*