### PR TITLE
🔒 [security] Fix email exposure in contact form

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: pnpm run build
         env:
-          PUBLIC_CONTACT_EMAIL: arceapps.dev@gmail.com
+          CONTACT_FORM_KEY: ${{ secrets.CONTACT_FORM_KEY }}
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact

--- a/agents/bitácora/bitacora_sentinel.md
+++ b/agents/bitácora/bitacora_sentinel.md
@@ -220,3 +220,16 @@
 **Cambios:**
 - Se actualizó `src/pages/rss.xml.js` añadiendo el filtro `({ data }) => !data.draft` a la llamada `getCollection('blog')`.
 **Aprendizaje (si aplica):** Los endpoints de generación de feeds y sitemaps deben aplicar los mismos filtros de visibilidad que las páginas de listado para evitar fugas de información.
+
+## 2026-03-29 - Mitigación de Exposición de Correo en Formulario
+**Estado:** Realizado
+**Análisis:**
+- Se identificó que la variable de entorno `PUBLIC_CONTACT_EMAIL` en `src/components/ContactForm.astro` utilizaba el prefijo `PUBLIC_`.
+- En Astro, las variables con este prefijo se exponen automáticamente al lado del cliente en el bundle de JavaScript generado.
+- Esto resultaba en la exposición directa del correo electrónico real del administrador en el código fuente del cliente y en el atributo `action` del formulario HTML.
+**Cambios:**
+- Se renombró la variable de entorno a `CONTACT_FORM_KEY` eliminando el prefijo `PUBLIC_`.
+- Se actualizó `src/components/ContactForm.astro` para usar la nueva variable, asegurando que solo esté disponible en el servidor (build time para SSG).
+- Se actualizó `.github/workflows/deploy.yml` con el nuevo nombre de la variable y se configuró para usar secretos de GitHub (`secrets.CONTACT_FORM_KEY`) en lugar de valores hardcodeados.
+- Se renombró la variable local a `formActionKey` para reflejar que FormSubmit permite usar un token opaco en lugar del correo electrónico.
+**Aprendizaje (si aplica):** Nunca usar el prefijo `PUBLIC_` para datos sensibles en Astro, incluso si parecen necesarios para el cliente (como un destino de formulario). Además, los secretos deben gestionarse mediante GitHub Secrets y no hardcodearse en los flujos de trabajo de CI/CD. FormSubmit permite tokens opacos para proteger la privacidad del correo electrónico en el HTML generado.

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -8,11 +8,13 @@ interface Props {
 const { lang = 'es' } = Astro.props;
 const t = useTranslations(lang);
 
-// Security: Use environment variable for email to prevent hardcoding secrets in repo
-const contactEmail = import.meta.env.PUBLIC_CONTACT_EMAIL;
+// Security: Use environment variable for the form key to avoid exposing the email address.
+// FormSubmit allows using a random string token instead of the email address directly.
+// We remove the "PUBLIC_" prefix to prevent Astro from exposing it to the client side.
+const formActionKey = import.meta.env.CONTACT_FORM_KEY;
 
-if (!contactEmail && import.meta.env.PROD) {
-  throw new Error("PUBLIC_CONTACT_EMAIL environment variable is not defined. Contact form will not work in production.");
+if (!formActionKey && import.meta.env.PROD) {
+  throw new Error("CONTACT_FORM_KEY environment variable is not defined. Contact form will not work in production.");
 }
 
 const nextUrl = lang === 'es'
@@ -22,7 +24,7 @@ const nextUrl = lang === 'es'
 
 <form
   id="contact-form"
-  action={`https://formsubmit.co/${contactEmail}`}
+  action={`https://formsubmit.co/${formActionKey}`}
   method="POST"
   class="bg-surface dark:bg-dark-surface p-6 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm"
   data-sending-text={t('contact.sending')}


### PR DESCRIPTION
### 🎯 What:
Fixed a security vulnerability where the contact email was exposed to the client side and hardcoded in the repository.

### ⚠️ Risk:
The use of the `PUBLIC_` prefix in Astro environment variables causes them to be bundled into the client-side JavaScript. This, combined with hardcoding the email in the deployment workflow, exposed the administrator's email address to anyone visiting the site and anyone with access to the source code.

### 🛡️ Solution:
1. **Removed the `PUBLIC_` prefix:** Renamed `PUBLIC_CONTACT_EMAIL` to `CONTACT_FORM_KEY`. Astro only exposes variables prefixed with `PUBLIC_` to the client.
2. **GitHub Secrets:** Replaced the hardcoded email in `deploy.yml` with a reference to `${{ secrets.CONTACT_FORM_KEY }}`.
3. **FormSubmit Tokens:** The code now uses `CONTACT_FORM_KEY`, which allows the user to provide a FormSubmit random string token instead of a raw email address, further protecting their privacy in the generated HTML.
4. **Improved Error Handling:** Added a clearer build-time error message if the key is missing in production.

---
*PR created automatically by Jules for task [2830555942058508216](https://jules.google.com/task/2830555942058508216) started by @ArceApps*