### PR TITLE
🔒 Corregir posible XSS en el DOM mediante metadatos JSON-LD

### DIFF
--- a/src/content/devlog/en/responsive-visual-hierarchy-2024.md
+++ b/src/content/devlog/en/responsive-visual-hierarchy-2024.md
@@ -460,6 +460,7 @@ import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import { ClientRouter } from "astro:transitions";
 import { getLangFromUrl } from "../i18n/utils";
+import { safeJsonLd } from "../utils/security";
 
 interface Props {
   title: string;
@@ -580,8 +581,9 @@ const socialImageURL = new URL(image, Astro.url);
 
     <!-- Schema.org -->
     <script
-      is:inline type="application/ld+json"
-      set:html={JSON.stringify({
+      is:inline
+      type="application/ld+json"
+      set:html={safeJsonLd({
         "@context": "https://schema.org",
         "@type": type === "article" ? "BlogPosting" : "WebSite",
         url: Astro.url,
@@ -597,7 +599,7 @@ const socialImageURL = new URL(image, Astro.url);
           datePublished: publishDate.toISOString(),
           dateModified: publishDate.toISOString(),
         }),
-      }).replace(/</g, "\\u003C")}
+      })}
     />
 
     <script is:inline>

--- a/src/content/devlog/es/responsive-visual-hierarchy-2024.md
+++ b/src/content/devlog/es/responsive-visual-hierarchy-2024.md
@@ -460,6 +460,7 @@ import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import { ClientRouter } from "astro:transitions";
 import { getLangFromUrl } from "../i18n/utils";
+import { safeJsonLd } from "../utils/security";
 
 interface Props {
   title: string;
@@ -580,8 +581,9 @@ const socialImageURL = new URL(image, Astro.url);
 
     <!-- Schema.org -->
     <script
-      is:inline type="application/ld+json"
-      set:html={JSON.stringify({
+      is:inline
+      type="application/ld+json"
+      set:html={safeJsonLd({
         "@context": "https://schema.org",
         "@type": type === "article" ? "BlogPosting" : "WebSite",
         url: Astro.url,
@@ -597,7 +599,7 @@ const socialImageURL = new URL(image, Astro.url);
           datePublished: publishDate.toISOString(),
           dateModified: publishDate.toISOString(),
         }),
-      }).replace(/</g, "\\u003C")}
+      })}
     />
 
     <script is:inline>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,7 @@ import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import { ClientRouter } from "astro:transitions";
 import { getLangFromUrl } from "../i18n/utils";
+import { safeJsonLd } from "../utils/security";
 
 interface Props {
   title: string;
@@ -127,8 +128,9 @@ const socialImageURL = new URL(image, Astro.url);
 
     <!-- Schema.org -->
     <script
-      is:inline type="application/ld+json"
-      set:html={JSON.stringify({
+      is:inline
+      type="application/ld+json"
+      set:html={safeJsonLd({
         "@context": "https://schema.org",
         "@type": type === "article" ? "BlogPosting" : "WebSite",
         url: Astro.url,
@@ -144,7 +146,7 @@ const socialImageURL = new URL(image, Astro.url);
           datePublished: publishDate.toISOString(),
           dateModified: publishDate.toISOString(),
         }),
-      }).replace(/</g, "\\u003C")}
+      })}
     />
 
     <script is:inline>

--- a/src/utils/security.test.ts
+++ b/src/utils/security.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { safeJsonLd } from './security';
+
+describe('security utils', () => {
+  describe('safeJsonLd', () => {
+    it('serializes a simple object correctly', () => {
+      const data = { name: 'ArceApps', type: 'WebSite' };
+      const result = safeJsonLd(data);
+      expect(result).toBe('{"name":"ArceApps","type":"WebSite"}');
+      // Verify it's still valid JSON
+      expect(JSON.parse(result)).toEqual(data);
+    });
+
+    it('escapes less-than and greater-than signs', () => {
+      const data = { script: '</script><script>alert(1)</script>' };
+      const result = safeJsonLd(data);
+      expect(result).not.toContain('</script>');
+      expect(result).toContain('\\u003c/script\\u003e');
+      expect(result).toContain('\\u003cscript\\u003e');
+      // Verify it's still valid JSON
+      expect(JSON.parse(result)).toEqual(data);
+    });
+
+    it('escapes ampersands', () => {
+      const data = { url: 'https://example.com?a=1&b=2' };
+      const result = safeJsonLd(data);
+      expect(result).toContain('\\u0026');
+      expect(result).not.toContain('&');
+      // Verify it's still valid JSON
+      expect(JSON.parse(result)).toEqual(data);
+    });
+
+    it('escapes line separators', () => {
+      const data = { text: '\u2028 and \u2029' };
+      const result = safeJsonLd(data);
+      expect(result).toContain('\\u2028');
+      expect(result).toContain('\\u2029');
+      // Verify it's still valid JSON
+      expect(JSON.parse(result)).toEqual(data);
+    });
+
+    it('handles nested objects and arrays', () => {
+      const data = {
+        outer: {
+          inner: '<b>bold</b>',
+          list: ['&', '>']
+        }
+      };
+      const result = safeJsonLd(data);
+      expect(result).toContain('\\u003cb\\u003ebold\\u003c/b\\u003e');
+      expect(result).toContain('\\u0026');
+      expect(result).toContain('\\u003e');
+      // Verify it's still valid JSON
+      expect(JSON.parse(result)).toEqual(data);
+    });
+  });
+});

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -1,0 +1,16 @@
+/**
+ * Safely serializes data to a JSON string for use in JSON-LD <script> tags.
+ * Escapes characters that could be used for script injection or that have
+ * special meaning in HTML, while preserving valid JSON.
+ *
+ * @param data The object to serialize
+ * @returns A safe JSON string
+ */
+export function safeJsonLd(data: any): string {
+  return JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}


### PR DESCRIPTION
🎯 **Qué:** Se ha corregido una vulnerabilidad potencial de XSS en el DOM en la inyección de metadatos JSON-LD de Schema.org en `src/layouts/Layout.astro`.
⚠️ **Riesgo:** El impacto potencial incluía la ejecución de JavaScript arbitrario si un atacante lograba controlar metadatos como el título o la descripción, permitiendo cerrar prematuramente el bloque de script.
🛡️ **Solución:** Se implementó la función `safeJsonLd` en `src/utils/security.ts` que utiliza escapes Unicode para caracteres sensibles (`<`, `>`, `&`, `\u2028`, `\u2029`), garantizando que el JSON sea seguro para su inserción directa en HTML. Se actualizó el layout principal y la documentación técnica en el devlog.

---
*PR created automatically by Jules for task [6086145896912536009](https://jules.google.com/task/6086145896912536009) started by @ArceApps*