### PR TITLE
🧪 [testing improvement] Add unit tests for haptics.ts

### DIFF
--- a/src/scripts/haptics.test.ts
+++ b/src/scripts/haptics.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { triggerHapticFeedback } from './haptics';
+
+describe('triggerHapticFeedback', () => {
+  const originalNavigator = global.navigator;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.navigator = originalNavigator;
+  });
+
+  it('should call navigator.vibrate with default duration (50ms)', () => {
+    const vibrateMock = vi.fn();
+    vi.stubGlobal('navigator', {
+      vibrate: vibrateMock,
+    });
+
+    triggerHapticFeedback();
+
+    expect(vibrateMock).toHaveBeenCalledWith(50);
+  });
+
+  it('should call navigator.vibrate with custom duration', () => {
+    const vibrateMock = vi.fn();
+    vi.stubGlobal('navigator', {
+      vibrate: vibrateMock,
+    });
+
+    triggerHapticFeedback(100);
+
+    expect(vibrateMock).toHaveBeenCalledWith(100);
+  });
+
+  it('should not throw if navigator is undefined', () => {
+    vi.stubGlobal('navigator', undefined);
+
+    expect(() => triggerHapticFeedback()).not.toThrow();
+  });
+
+  it('should not throw if navigator.vibrate is not a function', () => {
+    vi.stubGlobal('navigator', {});
+
+    expect(() => triggerHapticFeedback()).not.toThrow();
+  });
+});


### PR DESCRIPTION
🎯 **Qué:** Se ha abordado la falta de pruebas para la utilidad `triggerHapticFeedback` en `src/scripts/haptics.ts`.
📊 **Cobertura:** Los escenarios ahora probados incluyen: duración por defecto (50ms), duración personalizada, entornos donde `navigator` no está definido y casos donde la API `vibrate` no existe.
✨ **Resultado:** Mejora en la cobertura de pruebas de la utilidad de haptics, garantizando que maneje correctamente entornos que no son de navegador o navegadores no compatibles.

---
*PR created automatically by Jules for task [14683361155075410427](https://jules.google.com/task/14683361155075410427) started by @ArceApps*