### PR TITLE
🧹 cleanup: remove dead code in ContactForm.astro

### DIFF
--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -136,9 +136,6 @@ const nextUrl = lang === 'es'
       // Get the translated text from data attribute
       const sendingText = form.getAttribute('data-sending-text') || 'Sending...';
 
-      // Remove any existing listener to avoid duplicates if called multiple times (though page-load usually cleans up DOM)
-      // Actually, since the DOM element 'form' is new on navigation, we don't need to remove old listeners on it.
-
       form.addEventListener("submit", () => {
         // Disable button
         btn.disabled = true;


### PR DESCRIPTION
Se han eliminado comentarios obsoletos y discusiones técnicas internas que no aportaban valor en `src/components/ContactForm.astro`. Esta limpieza mejora la legibilidad y mantenibilidad del componente sin alterar su funcionalidad.

---
*PR created automatically by Jules for task [15711574648439421302](https://jules.google.com/task/15711574648439421302) started by @ArceApps*