### PR TITLE
perf: remove redundant getCollection calls in blog pages

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -36,6 +36,20 @@ export async function getStaticPaths() {
        }
     }
 
+    // Related posts logic — precomputed in getStaticPaths using sortedPosts (no extra getCollection call)
+    const currentTags = post.data.tags || [];
+    const relatedPosts = sortedPosts
+      .filter(p => p.slug !== post.slug)
+      .map(p => {
+        const commonTags = (p.data.tags || []).filter(t => currentTags.includes(t)).length;
+        return { ...p, commonTags };
+      })
+      .sort((a, b) => {
+        if (b.commonTags !== a.commonTags) return b.commonTags - a.commonTags;
+        return b.data.pubDate.valueOf() - a.data.pubDate.valueOf();
+      })
+      .slice(0, 3);
+
     return {
       params: { slug: post.slug.split('/').pop() },
       props: {
@@ -49,12 +63,13 @@ export async function getStaticPaths() {
           title: nextPost.data.title
         } : undefined,
         translatedPath,
+        relatedPosts,
       },
     };
   });
 }
 
-const { post, prevPost, nextPost, translatedPath } = Astro.props;
+const { post, prevPost, nextPost, translatedPath, relatedPosts } = Astro.props;
 const { Content, headings } = await post.render();
 
 const wordCount = post.body.split(/\s+/g).length;
@@ -70,20 +85,7 @@ const formattedDate = post.data.pubDate.toLocaleDateString('en-US', {
 // Filter headings for TOC (H2 and H3 only)
 const tocHeadings = headings.filter(h => h.depth === 2 || h.depth === 3);
 
-// Related posts logic
-const allPosts = await getCollection('blog', ({ data, id }) => !data.draft && data.pubDate <= new Date() && id.startsWith('en/'));
-const currentTags = post.data.tags || [];
-const relatedPosts = allPosts
-  .filter(p => p.slug !== post.slug)
-  .map(p => {
-    const commonTags = (p.data.tags || []).filter(t => currentTags.includes(t)).length;
-    return { ...p, commonTags };
-  })
-  .sort((a, b) => {
-    if (b.commonTags !== a.commonTags) return b.commonTags - a.commonTags;
-    return b.data.pubDate.valueOf() - a.data.pubDate.valueOf();
-  })
-  .slice(0, 3);
+// Related posts — precomputed in getStaticPaths (no extra getCollection call needed)
 
 const breadcrumbItems = [
   { label: 'Home', href: '/' },

--- a/src/pages/es/blog/[...slug].astro
+++ b/src/pages/es/blog/[...slug].astro
@@ -30,6 +30,20 @@ export async function getStaticPaths() {
        }
     }
 
+    // Related posts logic — precomputed in getStaticPaths using sortedPosts (no extra getCollection call)
+    const currentTags = post.data.tags || [];
+    const relatedPosts = sortedPosts
+      .filter(p => p.slug !== post.slug)
+      .map(p => {
+        const commonTags = (p.data.tags || []).filter(t => currentTags.includes(t)).length;
+        return { ...p, commonTags };
+      })
+      .sort((a, b) => {
+        if (b.commonTags !== a.commonTags) return b.commonTags - a.commonTags;
+        return b.data.pubDate.valueOf() - a.data.pubDate.valueOf();
+      })
+      .slice(0, 3);
+
     return {
       params: { slug: post.slug.split('/').pop() },
       props: {
@@ -43,12 +57,13 @@ export async function getStaticPaths() {
           title: nextPost.data.title
         } : undefined,
         translatedPath,
+        relatedPosts,
       },
     };
   });
 }
 
-const { post, prevPost, nextPost, translatedPath } = Astro.props;
+const { post, prevPost, nextPost, translatedPath, relatedPosts } = Astro.props;
 const { Content, headings } = await post.render();
 
 const wordCount = post.body.split(/\s+/g).length;
@@ -64,20 +79,7 @@ const formattedDate = post.data.pubDate.toLocaleDateString('es-ES', {
 // Filter headings for TOC (H2 and H3 only)
 const tocHeadings = headings.filter(h => h.depth === 2 || h.depth === 3);
 
-// Related posts logic
-const allPosts = await getCollection('blog', ({ data, id }) => !data.draft && data.pubDate <= new Date() && id.startsWith('es/'));
-const currentTags = post.data.tags || [];
-const relatedPosts = allPosts
-  .filter(p => p.slug !== post.slug)
-  .map(p => {
-    const commonTags = (p.data.tags || []).filter(t => currentTags.includes(t)).length;
-    return { ...p, commonTags };
-  })
-  .sort((a, b) => {
-    if (b.commonTags !== a.commonTags) return b.commonTags - a.commonTags;
-    return b.data.pubDate.valueOf() - a.data.pubDate.valueOf();
-  })
-  .slice(0, 3);
+// Related posts — precomputed in getStaticPaths (no extra getCollection call needed)
 
 const breadcrumbItems = [
   { label: 'Inicio', href: '/es' },


### PR DESCRIPTION
## Summary
Performance optimization that moves the "related posts" computation from page render time into `getStaticPaths`, eliminating a redundant `getCollection('blog', ...)` call per blog page during build.

## What changed
- **EN blog (`[...slug].astro`)**: `relatedPosts` now precomputed in `getStaticPaths` from `sortedPosts` (already available) and passed via props
- **ES blog (`es/blog/[...slug].astro`)**: Same optimization
- Removed redundant `getCollection('blog', ...)` calls per page render

## Why
During static build, `getStaticPaths` runs once per page. The original code called `getCollection` again inside the page component for every page rendered. For N blog pages, this meant N extra `getCollection` calls. Now `relatedPosts` is computed once in `getStaticPaths` using the already-available `sortedPosts` array.

## Files
- `src/pages/blog/[...slug].astro` — precompute relatedPosts in getStaticPaths, remove duplicate getCollection call
- `src/pages/es/blog/[...slug].astro` — same

---
Jules session: 15537858505471907698