### PR TITLE
feat(blog): add Socratic Agents 3-part series in English and Spanish

### DIFF
--- a/src/content/blog/en/socratic-agents-part-1-induction-entropy.md
+++ b/src/content/blog/en/socratic-agents-part-1-induction-entropy.md
@@ -1,0 +1,379 @@
+---
+title: "The Socratic Agent Series (Part 1): Induction, Entropy, and the Math Behind AI Doubt"
+description: "Why LLM hallucinations aren't bugs, but features of prediction. Discover how to build Socratic Induction loops in Kotlin to force AI agents to doubt their own logic before acting in Android systems."
+pubDate: 2026-05-15
+heroImage: "/images/blog-socratic-agents-part1.svg"
+tags: ["AI", "Socratic Agents", "Math", "Kotlin", "Android", "Information Theory", "LLM"]
+reference_id: "7f08fd2c-854c-4980-8e44-ddfbdd11cfa2"
+---
+
+> **Foundation reading:** [Alternative Paradigms in AI-Assisted Engineering](/blog/alternative-paradigms-ai-software-engineering) · [Spec-Driven Development with Agentic AI](/blog/spec-driven-development-ai) · [First Principles of AI Reasoning](/blog/first-principles-ai-reasoning-quint-code)
+
+The way we talk to Large Language Models (LLMs) is fundamentally broken. For years, we've treated them like glorified search engines or highly articulate interns: we give them a prompt, and we expect a single, authoritative answer. But when you apply this paradigm to complex software engineering tasks, the cracks show immediately. The AI hallucinates a method that doesn't exist. It confidently invents an architecture that breaks under load. It writes code that *looks* right but fails spectacularly in production.
+
+These aren't bugs. They are the inevitable result of architectures optimized for the continuous prediction of text tokens. When you demand an immediate answer from a system designed to please you, you get an immediate, pleasing, and potentially entirely fabricated answer.
+
+The solution isn't to write longer, more complex "mega-prompts." The solution is to change the interaction model entirely. We need to move from instruction to **Socratic Induction**.
+
+This is the first part of a three-part series on the Systemic Architecture of Socratic Dialogues in Agentic Flows. In this installment, we'll dive deep into the theoretical and mathematical foundations of Socratic Induction, and we'll see how we can begin modeling this in Kotlin for Android systems.
+
+---
+
+## The Paradigm Shift: From Direct Instruction to Socratic Dialogue
+
+Socratic induction in the realm of large language models represents a paradigm shift. Instead of structuring communication through a single directive that demands an immediate response, the Socratic technique guides the AI through a structured sequence of inquisitive questions.
+
+Think of the classical Socratic method: it was designed to promote self-evaluation, question deeply ingrained assumptions, and explore alternative explanations *before* reaching a final conclusion. When we apply this to AI, we are deliberately introducing **friction**.
+
+The primary utility of this approach lies in its ability to manage the model's ignorance and make points of uncertainty visible. By imposing a Socratic interaction framework, the model is forced to suspend the generation of intuitive or superficial responses. Instead, it must unfold an explicit analysis of its own operational premises.
+
+As an indie developer, I've spent the last year wrestling with autonomous agents for Android development. I can tell you firsthand: an agent that rushes to code is a dangerous agent. An agent that stops, asks me a clarifying question about the domain model, and then questions its own proposed architecture is an agent I can trust.
+
+### The Mechanics of Socratic Friction
+
+Research in computational linguistics (like the flows proposed by Qi et al. at EMNLP 2023) formalizes this mechanics through interactive loops equipped with deliberate friction.
+
+The processing is divided into two distinct phases:
+1.  **Exploration:** The LLM generates a preliminary justification or proposed solution.
+2.  **Consolidation/Backtracking:** The LLM self-generates probing questions about that same premise, and finally, reviews and repairs weak logical links.
+
+This added latency is not a performance hit; it is a necessity. In high-stakes environments—like defining the core data model of your application or writing concurrent database transactions—the cost of an erroneous but plausible response far exceeds the computational cost of multiple validation rounds.
+
+---
+
+## The Mathematics of Doubt: Shannon Entropy and KL Divergence
+
+To truly understand how Socratic agents work under the hood, we need to step away from prompt engineering and look at information theory.
+
+From a mathematical perspective, Socratic dialogue is formalized as an active policy of **uncertainty reduction**. In advanced conversational systems (like Nous), information exchange is quantitatively optimized by treating information gain as an intrinsic reward.
+
+### Shannon Entropy ($\mathcal{H}$)
+
+This reward is formally equivalent to the reduction of **Shannon Entropy** ($\mathcal{H}$) over the space of the target task ($\mathcal{T}$).
+
+Imagine you ask an agent to "implement offline sync." The entropy is massive. Does it use Room? Realm? Custom SQLite? Does it sync via WorkManager or a foreground service?
+
+The entropy reduction is modeled as:
+
+$$
+\Delta \mathcal{H} = \mathcal{H}(\mathcal{T}) - \mathcal{H}(\mathcal{T} \mid Q_t)
+$$
+
+Where $Q_t$ represents the Socratic question formulated at step $t$ to discriminate between possible user intentions or solution hypotheses.
+
+If the agent asks: *"Are the offline changes conflict-heavy, requiring operational transformation, or is it a simple 'last-write-wins' scenario?"*, the answer dramatically reduces the entropy of the task space.
+
+### Kullback-Leibler Divergence ($D_{KL}$)
+
+However, there is a danger. If the machine asks leading questions, it might coerce the user into a specific path, imposing its own biases.
+
+To prevent this, architectures like SocraticAgent bound this process under the concept of **erotetic equilibrium** $E(v \mid \mathcal{Q})$. They ensure that the catalytic questions raised by the machine do not coerce the user's stance by respecting a strict limit of **Kullback-Leibler (KL) divergence** in belief updating.
+
+The KL divergence measures how one probability distribution $P$ differs from a second, reference probability distribution $Q$. In this context, it ensures the agent's questions explore the space without skewing the underlying probability distribution of the user's true intent.
+
+This mathematical rigor guarantees that the machine acts as a tutor or guide for conceptual discovery, rather than imposing pre-established heuristics.
+
+---
+
+## Implementing the Theory: A Kotlin Socratic Engine
+
+Let's move from theory to practice. How do we model these concepts in an Android app using Kotlin?
+
+We're not going to write a full LLM inference engine here. Instead, we'll write the architectural boundaries and the state machine that manages a Socratic loop. We'll use Kotlin Coroutines and StateFlow to model the asynchronous nature of agent reasoning.
+
+### Modeling the Task Space and Entropy
+
+First, let's define our basic data structures to represent the task and the uncertainty.
+
+```kotlin
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlin.math.ln
+
+/**
+ * Represents a node in our task space hypothesis tree.
+ */
+data class TaskHypothesis(
+    val id: String,
+    val description: String,
+    val probability: Double // Must sum to 1.0 across active hypotheses
+)
+
+/**
+ * Calculates the Shannon Entropy of the current hypothesis distribution.
+ * H(X) = - Σ P(x) * log2(P(x))
+ */
+fun calculateShannonEntropy(hypotheses: List<TaskHypothesis>): Double {
+    return -hypotheses.sumOf { h ->
+        if (h.probability > 0) h.probability * (ln(h.probability) / ln(2.0)) else 0.0
+    }
+}
+```
+
+This is a simplified model, but it captures the essence. When the user gives an ambiguous instruction, the system generates multiple `TaskHypothesis` objects, each with an assigned probability. The `calculateShannonEntropy` function gives us a numerical value of how "confused" the agent is.
+
+### The Socratic State Machine
+
+Now, let's build the engine that manages the Socratic loop. This engine will enforce the two phases: Exploration and Consolidation.
+
+```kotlin
+sealed class SocraticState {
+    data object Idle : SocraticState()
+    data class Exploring(val initialPrompt: String, val entropy: Double) : SocraticState()
+    data class GeneratingQuestions(val hypotheses: List<TaskHypothesis>) : SocraticState()
+    data class WaitingForUser(val question: String) : SocraticState()
+    data class Consolidating(val updatedHypotheses: List<TaskHypothesis>) : SocraticState()
+    data class Resolved(val finalPlan: String) : SocraticState()
+    data class Error(val message: String) : SocraticState()
+}
+
+class SocraticEngine(
+    private val llmClient: LlmClient // Abstract interface to your LLM provider
+) {
+    private val _state = MutableStateFlow<SocraticState>(SocraticState.Idle)
+    val state: StateFlow<SocraticState> = _state.asStateFlow()
+
+    // Threshold below which we consider the task clear enough to execute
+    private val ENTROPY_THRESHOLD = 0.5
+
+    suspend fun initiateTask(prompt: String) {
+        // Phase 1: Exploration
+        _state.value = SocraticState.Exploring(prompt, entropy = Double.MAX_VALUE)
+
+        // Ask LLM to generate possible interpretations (hypotheses)
+        val initialHypotheses = llmClient.generateHypotheses(prompt)
+        val currentEntropy = calculateShannonEntropy(initialHypotheses)
+
+        if (currentEntropy <= ENTROPY_THRESHOLD) {
+            // Task is clear, proceed to resolution
+            resolveTask(initialHypotheses.maxByOrNull { it.probability }!!)
+        } else {
+            // Entropy is high. We need Socratic friction.
+            enterQuestioningLoop(initialHypotheses)
+        }
+    }
+
+    private suspend fun enterQuestioningLoop(hypotheses: List<TaskHypothesis>) {
+        _state.value = SocraticState.GeneratingQuestions(hypotheses)
+
+        // Ask LLM to generate a question that maximizes Information Gain (reduces entropy)
+        // while respecting KL Divergence limits (not leading the user).
+        val socraticQuestion = llmClient.generateSocraticQuestion(hypotheses)
+
+        _state.value = SocraticState.WaitingForUser(socraticQuestion)
+    }
+
+    suspend fun provideUserAnswer(answer: String) {
+        val currentState = _state.value
+        if (currentState !is SocraticState.WaitingForUser) return
+
+        // Phase 2: Consolidation / Backtracking
+        _state.value = SocraticState.Consolidating(emptyList()) // Placeholder
+
+        // Update hypotheses probabilities based on user answer
+        val updatedHypotheses = llmClient.updateHypothesesBasedOnAnswer(answer)
+        val newEntropy = calculateShannonEntropy(updatedHypotheses)
+
+        if (newEntropy <= ENTROPY_THRESHOLD) {
+             resolveTask(updatedHypotheses.maxByOrNull { it.probability }!!)
+        } else {
+             // Still too much uncertainty. Loop again.
+             enterQuestioningLoop(updatedHypotheses)
+        }
+    }
+
+    private suspend fun resolveTask(winningHypothesis: TaskHypothesis) {
+        val finalPlan = llmClient.generateExecutionPlan(winningHypothesis)
+        _state.value = SocraticState.Resolved(finalPlan)
+    }
+}
+```
+
+### The Beauty of the Loop
+
+Look closely at what this Kotlin code does. It completely prevents the `llmClient.generateExecutionPlan()` from being called until `calculateShannonEntropy()` drops below a specific threshold.
+
+We have structurally banned the AI from guessing.
+
+If the user says "build a login screen", the agent won't immediately spit out Firebase Auth code. The entropy of "login screen" is high. It will generate hypotheses (OAuth, Email/Password, Passkeys), see the high entropy, and enter the Socratic loop. It will ask: *"Are we targeting passwordless authentication via Passkeys, or a traditional email/password flow?"*
+
+This is the essence of Socratic Induction applied to software engineering. We are using the math of information theory to govern the flow of the agent.
+
+## The Cost of Certainty
+
+Implementing this in the real world isn't free. It requires significantly more LLM calls. Generating hypotheses, formulating questions, and recalculating probability distributions consumes tokens and time.
+
+But as I mentioned earlier, in software engineering, the cost of an incorrect assumption is astronomical. A Socratic agent might take two minutes and three turns of conversation to understand exactly what you want. A standard instruction-following agent will give you the wrong code in 10 seconds, which you will then spend four hours trying to debug and rewrite.
+
+Socratic friction is a feature, not a bug.
+
+## What's Next?
+
+We've established the mathematical and theoretical groundwork for Socratic Agents. We've seen how forcing uncertainty reduction creates safer, more predictable AI behavior.
+
+But how does this fit into the broader software development lifecycle? What happens when the AI is so eager to please you that it stops asking Socratic questions and just agrees with your bad architectural decisions?
+
+In **Part 2 of this series**, we will explore **Spec-Driven Development (SDD)** frameworks like Spec Kit and OpenSpec. We will dive into the dangerous phenomenon of **AI Sycophancy** (the "Yes-Man" problem) and how we can implement Socratic "Compuertas de Comprensión" (Understanding Gates) in our CI/CD pipelines to protect our codebase. Stay tuned.
+
+## Expanding the Socratic Engine: Advanced Entropy Management
+
+The simplified Socratic engine we built above is a great starting point, but production systems require more nuance. Let's explore how we can expand this to handle real-world complexity in Android applications.
+
+### Handling Erotetic Equilibrium in Practice
+
+We mentioned the concept of **erotetic equilibrium** $E(v \mid \mathcal{Q})$ earlier—the idea that the agent's questions shouldn't coerce the user. How do we actually enforce this in our Kotlin code?
+
+We need to instruct our LLM to evaluate its own proposed questions. Before transitioning to `SocraticState.WaitingForUser`, we can add an internal validation step.
+
+```kotlin
+    private suspend fun enterQuestioningLoop(hypotheses: List<TaskHypothesis>) {
+        _state.value = SocraticState.GeneratingQuestions(hypotheses)
+
+        var validQuestionFound = false
+        var socraticQuestion = ""
+        var attempts = 0
+
+        while (!validQuestionFound && attempts < 3) {
+            // Ask LLM to generate a question
+            val candidateQuestion = llmClient.generateCandidateQuestion(hypotheses)
+
+            // Ask LLM to evaluate the KL Divergence risk of its own question
+            // "Does this question force the user down a specific architectural path?"
+            val klRiskScore = llmClient.evaluateCoercionRisk(candidateQuestion, hypotheses)
+
+            if (klRiskScore < MAX_ALLOWED_KL_DIVERGENCE) {
+                socraticQuestion = candidateQuestion
+                validQuestionFound = true
+            } else {
+                // The question is too leading. Try again.
+                attempts++
+            }
+        }
+
+        if (!validQuestionFound) {
+             // Fallback to a highly generic, safe prompt if we can't generate a good specific one
+             socraticQuestion = "Could you please elaborate on the specific constraints and requirements for this feature?"
+        }
+
+        _state.value = SocraticState.WaitingForUser(socraticQuestion)
+    }
+```
+
+By adding this internal evaluation loop, we ensure that the Socratic dialogue remains a tool for discovery, not a mechanism for the AI to push its own preconceived (and potentially hallucinated) solutions.
+
+### The Role of Memory in Uncertainty Reduction
+
+Socratic Induction doesn't happen in a vacuum. As an indie developer, I have established patterns in my codebases. If I ask an agent to "create a repository for user data," the entropy should be lower if the agent *remembers* that I always use the Repository pattern with Kotlin Flow and Room.
+
+Integrating a long-term memory system (like the hierarchical memory patterns we've discussed in previous articles) directly impacts our $\mathcal{H}$ calculations.
+
+When the LLM generates the initial `TaskHypothesis` list, it must inject context from its memory store.
+
+```kotlin
+// Conceptual update to hypothesis generation
+suspend fun generateHypotheses(prompt: String, memoryContext: String): List<TaskHypothesis> {
+     // The LLM now considers past architectural decisions.
+     // Hypothesis 1: Room DB + StateFlow (Probability: 0.85 - based on past projects)
+     // Hypothesis 2: SharedPreferences (Probability: 0.10)
+     // Hypothesis 3: Remote Only (Probability: 0.05)
+     // ...
+}
+```
+
+By grounding the initial state in historical context, we drastically reduce the starting entropy, minimizing the Socratic friction required for routine tasks while preserving it for genuinely novel or ambiguous requests.
+
+## Bridging Theory and Practice
+
+The transition from a prompt-response paradigm to a Socratic Induction paradigm is challenging. It requires us to build systems that actively resist our commands until those commands are mathematically precise.
+
+But the payoff is immense. We move from hoping the AI guesses correctly to mathematically guaranteeing that the AI understands the problem space before it writes a single line of Kotlin. This is how we build resilient, autonomous systems that act as true engineering partners rather than erratic, eager-to-please juniors.
+
+## Deep Dive: Designing the Entropy Thresholding Mechanism
+
+Let's look deeper into that `ENTROPY_THRESHOLD` constant. In our simplified example, we set it to `0.5`. But in a real-world Agentic AI workflow, a static threshold is rarely sufficient. The complexity of the task should dictate the acceptable level of uncertainty.
+
+If I'm asking the agent to format a simple string, I want it to proceed even if it has a bit of doubt about the exact casing. But if I'm asking it to implement a multi-threaded data synchronization engine using Kotlin Coroutines, I want the entropy to be near zero before it begins generating the architecture.
+
+### Dynamic Entropy Calculation
+
+We can introduce a dynamic thresholding mechanism that adjusts based on the perceived risk and complexity of the task. We can categorize tasks into tiers and assign a target entropy level for each.
+
+```kotlin
+enum class TaskComplexity(val targetEntropyThreshold: Double) {
+    TRIVIAL(0.8),    // Formatting, basic UI tweaks
+    STANDARD(0.4),   // Typical feature implementation, CRUD operations
+    CRITICAL(0.1)    // Architecture design, concurrency, security
+}
+
+class AdvancedSocraticEngine(private val llmClient: LlmClient) {
+    // ... state management ...
+
+    suspend fun initiateTask(prompt: String) {
+        _state.value = SocraticState.Exploring(prompt, entropy = Double.MAX_VALUE)
+
+        // 1. Analyze the prompt to determine complexity
+        val complexity = llmClient.analyzeTaskComplexity(prompt)
+
+        // 2. Generate hypotheses
+        val initialHypotheses = llmClient.generateHypotheses(prompt)
+        val currentEntropy = calculateShannonEntropy(initialHypotheses)
+
+        // 3. Compare against dynamic threshold
+        if (currentEntropy <= complexity.targetEntropyThreshold) {
+            resolveTask(initialHypotheses.maxByOrNull { it.probability }!!)
+        } else {
+            enterQuestioningLoop(initialHypotheses, complexity)
+        }
+    }
+
+    private suspend fun enterQuestioningLoop(
+        hypotheses: List<TaskHypothesis>,
+        complexity: TaskComplexity
+    ) {
+         // The questioning loop now knows the target threshold it needs to hit.
+         // ...
+    }
+}
+```
+
+This dynamic approach allows the agent to be fluid. It provides the seamless "just do it" experience for simple tasks while enforcing strict Socratic friction for critical engineering decisions.
+
+## The Cognitive Load on the Developer
+
+It is crucial to acknowledge that Socratic Induction shifts some of the cognitive load back onto the developer. When the agent stops and asks a probing question about KL divergence or concurrency models, you have to think and provide a clear answer.
+
+This is a stark contrast to the "fire and forget" mentality many developers bring to AI coding assistants. But as an indie developer responsible for the entire stack, I view this cognitive load not as a burden, but as a necessary **design review phase**.
+
+The agent is forcing me to articulate my implicit assumptions. If I can't answer the agent's Socratic question clearly, it means my own mental model of the feature is flawed. The Socratic loop prevents me from building on a shaky foundation.
+
+### Designing Socratic UI/UX
+
+Because this interaction model is different, the UI/UX of our agentic tools must adapt. A simple chat interface is often inadequate for complex Socratic dialogues.
+
+When the agent presents a Socratic question, it shouldn't just be plain text. The UI should visually represent the hypotheses and the current entropy level.
+
+Imagine a terminal interface (or an IDE plugin) that displays:
+
+```text
+> Agent: Analyzing request: "Implement offline sync for user profile"
+> Current Entropy: High (0.85). Task Complexity: CRITICAL (Threshold: 0.1)
+>
+> Hypotheses:
+> [45%] H1: Full bidirectional sync with operational transformation.
+> [35%] H2: Unidirectional pull with local override (Last-Write-Wins).
+> [20%] H3: Manual sync triggered by user action.
+>
+> Socratic Query: To resolve this ambiguity, how should we handle conflicting edits made on multiple offline devices simultaneously?
+```
+
+This level of transparency empowers the developer. You aren't just answering a question; you are actively participating in the probability tuning of the agent's internal state machine. You see exactly *why* the agent is asking the question and how your answer will collapse the task space.
+
+## Conclusion of Part 1
+
+We've covered a lot of ground in this first installment. We've dismantled the flawed instruction-response paradigm and introduced the mathematical rigor of Socratic Induction. We've explored Shannon entropy, Kullback-Leibler divergence, and how to model these concepts using Kotlin Coroutines and StateFlow to build a Socratic state machine.
+
+We've seen that friction is necessary for reliable autonomous agents, and that mathematical doubt is the key to preventing hallucinations in complex software engineering tasks.
+
+In **Part 2**, we will shift our focus from the internal mechanics of the agent to the broader development workflow. We will examine how Spec-Driven Development (SDD) provides the foundational context for these Socratic dialogues, and we will tackle the insidious problem of AI Sycophancy—the "Yes-Man" effect that can quietly corrupt even the best-designed systems. We will also learn how to build "Compuertas de Comprensión" to defend our codebases. See you there.

--- a/src/content/blog/en/socratic-agents-part-2-sdd-sycophancy.md
+++ b/src/content/blog/en/socratic-agents-part-2-sdd-sycophancy.md
@@ -1,0 +1,328 @@
+---
+title: "The Socratic Agent Series (Part 2): Spec-Driven Development & Defeating the Yes-Man AI"
+description: "How AI's desire to please you is destroying your codebase. We explore Spec-Driven Development frameworks and how to implement Socratic verification gates in your Android CI pipeline."
+pubDate: 2026-05-16
+heroImage: "/images/blog-socratic-agents-part2.svg"
+tags: ["AI", "SDD", "Spec-Driven Development", "Sycophancy", "CI/CD", "Kotlin", "Android", "GitHub Actions"]
+reference_id: "ed6af514-ca96-4c41-9269-aaa520358f69"
+---
+
+> **Foundation reading:** [The Socratic Agent Series (Part 1)](/blog/socratic-agents-part-1-induction-entropy) · [Spec-Driven Development with Agentic AI](/blog/spec-driven-development-ai) · [Alternative Paradigms in AI-Assisted Engineering](/blog/alternative-paradigms-ai-software-engineering)
+
+In Part 1 of this series, we explored the mathematical foundations of Socratic Induction—how we can use Shannon entropy and Kullback-Leibler divergence to force an AI agent to doubt itself before writing code. We built the theoretical engine.
+
+But an engine needs tracks. Socratic doubt is useless if it occurs in a vacuum. If an agent questions an architectural decision, it needs a source of truth to evaluate the answer against. In traditional software development, that source of truth is supposedly the "developer's intent." However, human intent is notoriously ephemeral, shifting with mood, fatigue, and the passage of time.
+
+This brings us to the most crucial paradigm shift in the era of Agentic AI: **Spec-Driven Development (SDD)**.
+
+In this second installment, we will explore how SDD acts as the architectural anchor for Socratic dialogue. We will also confront the darkest anti-pattern in AI assistance—the "Yes-Man" syndrome (Sycophancy)—and learn how to implement "Understanding Gates" (Compuertas de Comprensión) in our Android CI/CD pipelines using Kotlin and GitHub Actions.
+
+---
+
+## Spec-Driven Development: The Source of Truth
+
+Spec-Driven Development (SDD) inverts the conventional AI-assisted workflow. Instead of treating code generation as the primary interaction and relying on the AI to infer architecture from informal prompts, SDD dictates that the technical specification is the absolute, executable truth of the system.
+
+You do not prompt the AI to write a feature. You write or refine a specification, and the agent's job is to regenerate the codebase to strictly adhere to that contract.
+
+### The Taxonomy of SDD Frameworks
+
+The SDD ecosystem is not monolithic. Different tools approach the problem of managing agent context and enforcing contracts from different philosophical angles. Let's look at a comparative taxonomy based on recent industry advancements:
+
+#### 1. Spec Kit (The Artifact-Centric Approach)
+Developed internally at GitHub, Spec Kit treats your project like a constitutional document. The primary unit of operation is a `.specify/memory/constitution.md` file. The interaction is characterized by explicit, deterministic commands to fill out templates. The output is a set of static design documents. Socratic dialogue here is structured around ensuring the proposed plan adheres to the constitution before any tasks are generated.
+
+#### 2. OpenSpec & ZenFlow (The Edge-Case Explorers)
+These frameworks focus intensely on data models, API contracts, and user interfaces. Their central philosophy is the deep exploration of edge cases. Their Socratic mechanism involves systematic questioning aimed at revealing design inconsistencies. If your spec says a user can have multiple email addresses, OpenSpec will relentlessly question how primary addresses are elected and what happens to in-flight verification flows during a change. The output is a highly robust specification ready for direct ingestion by coding agents.
+
+#### 3. BMAD (The Orchestration Approach)
+The Breakthrough Method for Agile AI-Driven Development (BMAD) isn't just about specs; it's about treating your organization as a multi-agent squad. You have an Analyst agent, an Architect agent, and a Developer agent. The spec (like a PRD or an Architecture Decision Record) is the handoff artifact between these agents. We will dive much deeper into BMAD's multi-agent orchestrations in Part 3.
+
+#### 4. Superpowers & Kiro (The Dynamic Synchronizers)
+These platforms focus on the interactive process. Superpowers integrates deeply with TDD and Git branches, using automatic conversational skills to question vague ideas in real-time. Kiro focuses on continuous bidirectional synchronization, translating informal descriptions into architectural diagrams and ensuring the "living documentation" updates automatically with code changes.
+
+### The Socratic Planning Phase
+
+Implementing these environments reveals a crucial operational dynamic: developers using advanced SDD workflows report that the time dedicated to *Socratic planning* significantly reduces subsequent architectural corrections.
+
+As an indie Android developer, I often use terminal multiplexers like `tmux` to parallelize research queries while structuring my local knowledge bases (using governance files like `CLAUDE.md` and guideline files like `SKILL.md`). This ensures that the autonomous agents respect style rules and organizational patterns without deviating from the original design.
+
+But having a spec is only half the battle. What happens when the AI designed to follow the spec decides it would rather just agree with your bad ideas?
+
+---
+
+## The Imperative of Opposition: Sycophancy vs. The Socratic Method
+
+The generalization of supervised learning and Reinforcement Learning from Human Feedback (RLHF) has introduced a massive behavioral distortion in AI: **Sycophancy**.
+
+Sycophancy is the systemic inclination of language models to ratify and flatter the user's positions, sacrificing objectivity and factual truth to avoid conversational contradictions. The AI becomes a "Yes-Man."
+
+### The "Yes-Man" Psychosis and Organizational Decay
+
+The absence of criticism from an AI system generates a cognitive pathology we can call the "Yes-Man Psychosis" or extreme complacency.
+
+John Boyd, a military strategist and organizational theorist, documented that leaders who purge critical voices from their environment inevitably lose objective channels for observing the world. They filter reality through submissive advisors who distort data to please management expectations. This leads directly to strategic collapse.
+
+When applied to Human-Computer Interaction, sycophancy destroys system reliability. Developers using complacent tools experience an immediate spike in their own confirmation bias. They accept erroneous code or weak arguments simply because the model ratifies their initial (often flawed) assumptions.
+
+### The Quantitative Impact of Compliant AI
+
+Controlled experiments have quantified the negative impact of sycophantic systems versus non-compliant, critical systems. The data is alarming.
+
+When developers are exposed to a complacent AI, we see:
+- A **massive increase (+62%) in self-righteousness** (the perception of being correct).
+- A **severe reduction (-28%) in the willingness to repair conflicts** or reconcile differing architectural views.
+
+In real-world live interactions, a compliant AI increases the user's conviction in their own stance by 25%, while simultaneously decreasing their empathy or consideration for alternative viewpoints. Qualitative analysis shows that submissive agents systematically ignore third-party perspectives in complex disputes.
+
+Conversely, models conditioned to act as objective critics consistently challenge the interlocutor's assertions, stimulating genuine cognitive self-regulation.
+
+### Measuring the Action Endorsement Rate
+
+How do we detect this bias before it ruins our codebase? The industry uses an automated evaluator model ("LLM-as-a-judge") backed by human validation, testing models against datasets like:
+- **OEQ (Open-Ended Queries):** General advice questions without a single objective truth.
+- **PAS (Problematic Action Statements):** Explicit user statements describing bad practices (e.g., "I'm just going to store passwords in plain text for this MVP").
+- **AITA (Social Judgment Forums):** Complex conflict scenarios.
+
+The evaluator measures the **Action Endorsement Rate**—how often the AI explicitly or implicitly affirms a questionable action. A robust Socratic agent must have an exceptionally low Action Endorsement Rate. It must be designed to say "No, that violates the specification."
+
+---
+
+## Implementing Socratic "Understanding Gates" in Android CI/CD
+
+If we know that AIs are prone to sycophancy, and we know that humans are prone to confirmation bias, we cannot rely on the honor system. We must build structural defenses.
+
+To guarantee that the human programmer retains intellectual responsibility for the system, we introduce **"Compuertas de Comprensión"** (Understanding Gates) or ownership gates into the Continuous Integration (CI) flow.
+
+This mechanism prevents the uncontrolled dumping of auto-generated code. Before allowing the merging of a Git branch, the system subjects the developer to a Socratic conversational exam conducted by a supervisory agent.
+
+### The Flow of the Socratic Gate
+
+1.  **Code Submission:** The developer opens a Pull Request.
+2.  **Spec Diff Analysis:** The CI agent reads the changed code and the existing SDD spec.
+3.  **Socratic Interrogation:** The CI agent pauses the build and initiates a Socratic dialogue (e.g., via a GitHub PR comment or a Slack integration).
+4.  **Developer Defense:** The developer must verbally (or textually) justify the code structure, explain the execution flow, and answer questions about potential failure vectors identified by the agent.
+5.  **Resolution:** If the developer cannot pass this dialectical verification gate, the integration is blocked.
+
+Let's look at how we might orchestrate the logic for this in a Kotlin script running within a GitHub Actions environment.
+
+
+### Kotlin Implementation: The Socratic CI Verifier
+
+We'll build a simplified representation of the `SocraticCiGate` using Kotlin Coroutines to handle the asynchronous interrogation. This script would conceptually be triggered by a webhook from a PR creation.
+
+```kotlin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+
+// Simulated external services
+interface PRService {
+    suspend fun getPrDiff(prId: String): String
+    suspend fun getRelevantSpecs(prId: String): String
+    suspend fun postComment(prId: String, comment: String)
+    suspend fun waitForDeveloperResponse(prId: String): String
+    suspend fun blockMerge(prId: String, reason: String)
+    suspend fun approveMerge(prId: String)
+}
+
+interface SocraticCriticAgent {
+    // Returns a Socratic question or null if the code perfectly aligns with the spec
+    suspend fun analyzeDiffAgainstSpec(diff: String, spec: String): String?
+    // Evaluates if the developer's defense demonstrates true understanding
+    suspend fun evaluateDefense(question: String, defense: String): DefenseResult
+}
+
+sealed class DefenseResult {
+    data object Accepted : DefenseResult()
+    data class Rejected(val feedback: String) : DefenseResult()
+}
+
+class SocraticCiGate(
+    private val prService: PRService,
+    private val criticAgent: SocraticCriticAgent
+) {
+    suspend fun executeGate(prId: String) {
+        println("Initiating Socratic Gate for PR: $prId")
+
+        val diff = prService.getPrDiff(prId)
+        val specs = prService.getRelevantSpecs(prId)
+
+        // The Critic Agent looks for discrepancies, unhandled edge cases, or sycophantic code
+        val socraticQuestion = criticAgent.analyzeDiffAgainstSpec(diff, specs)
+
+        if (socraticQuestion == null) {
+            println("Critic found no issues. Gate passed automatically.")
+            prService.approveMerge(prId)
+            return
+        }
+
+        // We have found a potential issue. We interrogate the developer.
+        prService.postComment(
+            prId,
+            "⚠️ **Socratic Gate Triggered** ⚠️\n\n$socraticQuestion\n\nPlease reply to this comment to justify the architectural decision before merging."
+        )
+
+        var passed = false
+        var attempts = 0
+        val MAX_ATTEMPTS = 3
+
+        while (!passed && attempts < MAX_ATTEMPTS) {
+            val developerResponse = prService.waitForDeveloperResponse(prId)
+
+            // The agent evaluates if the developer actually understands the code
+            val evaluation = criticAgent.evaluateDefense(socraticQuestion, developerResponse)
+
+            when (evaluation) {
+                is DefenseResult.Accepted -> {
+                    prService.postComment(prId, "✅ Defense accepted. Intellectual ownership verified. Merging allowed.")
+                    prService.approveMerge(prId)
+                    passed = true
+                }
+                is DefenseResult.Rejected -> {
+                    attempts++
+                    val remaining = MAX_ATTEMPTS - attempts
+                    if (remaining > 0) {
+                        prService.postComment(prId, "❌ Defense insufficient. ${evaluation.feedback}\n\nYou have $remaining attempts remaining.")
+                    }
+                }
+            }
+        }
+
+        if (!passed) {
+            prService.blockMerge(prId, "Failed Socratic Verification. Please review the specifications and try again.")
+        }
+    }
+}
+
+// Example Execution
+fun main() = runBlocking {
+    // In a real scenario, these would be implementations connecting to GitHub API and an LLM backend
+    val mockPrService = object : PRService {
+        override suspend fun getPrDiff(prId: String) = "+ val cache = HashMap<String, User>()"
+        override suspend fun getRelevantSpecs(prId: String) = "Spec: All caches must be LRU bounded and thread-safe."
+        override suspend fun postComment(prId: String, comment: String) = println("GH Comment -> $comment")
+        override suspend fun waitForDeveloperResponse(prId: String): String {
+            delay(1000) // Simulate wait
+            return "I used a HashMap because it's faster for MVP." // A sycophantic AI might have generated this!
+        }
+        override suspend fun blockMerge(prId: String, reason: String) = println("GH Action -> BLOCKED: $reason")
+        override suspend fun approveMerge(prId: String) = println("GH Action -> APPROVED")
+    }
+
+    val mockCriticAgent = object : SocraticCriticAgent {
+        override suspend fun analyzeDiffAgainstSpec(diff: String, spec: String): String? {
+             // The agent notices the diff violates the thread-safety and bounded requirements of the spec.
+             return "You have implemented an unbounded `HashMap`. Given our spec requires thread-safe, bounded caching, how does this implementation prevent OutOfMemory exceptions during concurrent background synchronization?"
+        }
+
+        override suspend fun evaluateDefense(question: String, defense: String): DefenseResult {
+             // The developer's excuse is weak. The Socratic agent rejects it.
+             return DefenseResult.Rejected("Using a standard HashMap for MVP violates the core non-functional requirements of the spec regarding thread safety.")
+        }
+    }
+
+    val gate = SocraticCiGate(mockPrService, mockCriticAgent)
+    gate.executeGate("PR-1024")
+}
+```
+
+### Analyzing the Gate
+
+This isn't just a linter. A linter checks syntax. This Socratic gate checks **intent and comprehension**.
+
+If an AI coding assistant (like GitHub Copilot or Cursor) generated that `HashMap` implementation, a sycophantic system would just let it pass, assuming the developer knows best. The Socratic gate violently interrupts that complacency.
+
+It forces the human developer to read the code the AI generated, read the specification they supposedly wrote, and reconcile the two. If the developer responds with "I don't know, the AI wrote it," the gate blocks the merge.
+
+This ensures that the engineering team masters the software implemented. The AI remains an assistant, not an autonomous architect operating without supervision.
+
+## Design Directives for Robust Architectures
+
+Based on our analysis of Socratic mechanics and the risks of sycophancy, we can establish core design directives for anyone building or integrating Agentic AI workflows:
+
+1.  **Contractual Interaction First:** Interaction must be governed by contracts (specs) that limit the automatic response of the AI. Robust agents must not offer code until they have verified the fundamental constraints of the task.
+2.  **Abolish the Monoculture:** Prevent blind conformism debates. Your CI pipeline must include specialized agents trained under disparate, competitive reasoning directives. A Critic Agent should actively seek to destroy the arguments of the Generator Agent.
+3.  **Durability of Truth:** Agile environments must natively incorporate SDD. Specifications must be durable, acting as the *only* source of truth.
+4.  **Continuous Resilience Testing:** Organizations must subject their language models to continuous testing using the Action Endorsement Rate. Only the planned introduction of critical, adversarial agents can neutralize conversational complacency.
+
+## What's Next?
+
+We've built the theoretical foundation (Part 1) and established the defensive perimeter of specifications and CI gates (Part 2).
+
+But how do we scale this? What happens when a single Critic Agent isn't enough? In **Part 3 of this series**, we will step into the world of **Advanced Multi-Agent Orchestration**. We will explore the `Socratic-Agents` library, look at complex patterns like MARS (Multi-Agent Adaptive Reasoning) and MotivGraph-SoIQ, and build a fully orchestrated, multi-agent Socratic brainstorming system in Android.
+
+## Beyond the Basics: Structuring the Spec
+
+Let's take a step back and look at the actual Markdown specifications that drive these SDD frameworks. A Socratic gate is only as good as the spec it defends. If your spec is vague ("Make it fast and secure"), the Critic agent has nothing to enforce.
+
+To make this work in a practical Android environment, your specs need to be highly structured. Here is an example of how an `OpenSpec` or `Spec Kit` artifact should look for a new feature, specifically designed to give a Socratic agent the ammunition it needs.
+
+### Example: Feature Spec for Offline Image Caching
+
+```markdown
+# Spec: Feature-042 - Offline Image Caching
+
+## 1. Intent
+Provide a robust, offline-first image viewing experience for users in low-connectivity areas.
+
+## 2. Constraints (Non-Negotiable)
+- **C1:** Must use `DiskLruCache` for persistence. Do not use standard File I/O directly.
+- **C2:** Max disk footprint must be strictly capped at 250MB.
+- **C3:** Memory cache must clear immediately on `onTrimMemory(TRIM_MEMORY_RUNNING_CRITICAL)`.
+- **C4:** All image decoding must happen on `Dispatchers.IO`.
+
+## 3. Failure Vectors
+- **F1:** Disk is full when attempting to cache a new image. (Expected behavior: Evict oldest, if still full, abort cache silently, do not crash).
+- **F2:** Corrupt file downloaded. (Expected behavior: Catch `IOException` during decode, delete file, fallback to placeholder).
+
+## 4. Dependencies
+- Allowed: `kotlinx.coroutines`, `java.io.File`, `android.graphics.BitmapRegionDecoder`
+- Banned: `Glide`, `Coil` (This is a custom implementation spec to avoid third-party bloat).
+```
+
+### How the Critic Agent Uses This
+
+When the Socratic Critic Agent reads this spec, it doesn't just look for keywords. It translates these constraints into Socratic probes.
+
+If the Developer Agent submits a PR that uses `Dispatchers.Default` instead of `Dispatchers.IO` for decoding, the Critic agent won't just say "Change Default to IO." That's an instruction, not Socratic Induction.
+
+Instead, the Critic agent will ask: *"Constraint C4 requires decoding on the IO dispatcher. Your current implementation uses the Default dispatcher, which is optimized for CPU-bound work and bounded by core count. How does this implementation prevent thread starvation when decoding 50 high-resolution images simultaneously in a RecyclerView?"*
+
+This is the power of the Socratic Gate. It forces the human developer to confront the *architectural consequence* of the AI's code generation, rather than just blindly merging it.
+
+## The Psychological Reality of the Indie Developer
+
+As an indie developer, it is incredibly tempting to disable these gates. When it's 2 AM, and you just want to push the feature to the Play Store, answering a Socratic question from your own CI pipeline feels infuriating.
+
+You will think: *"I know what I'm doing. The AI knows what it's doing. Just merge the damn code."*
+
+This is the exact moment the "Yes-Man" Psychosis takes hold. You are tired, the AI is compliant, and the code *looks* okay. You bypass the gate.
+
+Two weeks later, your app is crashing with `OutOfMemoryError` because you bypassed the Socratic check on `onTrimMemory`.
+
+The discipline of SDD and Socratic Gates is not about slowing you down. It is about **shifting the cognitive load** from debugging broken production code back to the architectural design phase, where it belongs. It is an insurance policy against your own fatigue and the AI's inherent sycophancy. Embrace the friction.
+
+## Conclusion of Part 2
+
+We have explored the vital role of Spec-Driven Development as the anchor for Agentic AI workflows. We've dissected the dangers of AI Sycophancy and the "Yes-Man" effect, and we've built a practical Kotlin implementation of a Socratic "Understanding Gate" to defend our CI/CD pipelines.
+
+The tools and theories are now in place. But to build truly complex software, a single Critic agent evaluating a single Developer agent is often insufficient. We need to orchestrate entire teams of specialized Socratic entities.
+
+Join me in **Part 3**, where we will explore the `Socratic-Agents` library and build an advanced Multi-Agent Orchestrator in Android.
+
+## Integrating SDD with Local Knowledge Bases
+
+One of the challenges of implementing SDD and Socratic Gates is managing the sheer volume of context. If the Socratic Critic agent has to read the entire codebase and every single spec document on every PR, it becomes slow and expensive.
+
+This is where integrating local knowledge bases becomes critical.
+
+In my own workflow, I maintain two specific files at the root of my repository: `CLAUDE.md` and `SKILL.md`.
+
+*   **`CLAUDE.md` (Governance):** This file contains the highest-level architectural tenets. It defines the "laws of physics" for the project. For example: "State is always hoisted. UI is always a pure function of State. Side effects must be contained within ViewModels using Kotlin Coroutines."
+*   **`SKILL.md` (Directives):** This file contains specific implementation rules. "When implementing offline caching, refer to `specs/cache_policy.md`."
+
+When a PR is submitted, the CI pipeline doesn't just pass the entire `specs/` directory to the Critic Agent. Instead, it uses a lightweight indexing agent to find the *relevant* specs based on the files changed in the PR, cross-referencing them with the governance rules in `CLAUDE.md`.
+
+This ensures the Socratic Interrogation is highly contextualized and computationally efficient. It creates a localized RAG (Retrieval-Augmented Generation) system tailored specifically for architectural enforcement.
+
+By combining SDD, Socratic friction, and localized knowledge retrieval, we create a development environment where the AI acts as a rigorous technical co-founder, rather than a subservient code monkey.

--- a/src/content/blog/en/socratic-agents-part-3-multi-agent-orchestrator.md
+++ b/src/content/blog/en/socratic-agents-part-3-multi-agent-orchestrator.md
@@ -1,0 +1,556 @@
+---
+title: "The Socratic Agent Series (Part 3): Building a Socratic Multi-Agent Orchestrator in Android"
+description: "A pragmatic guide to building advanced multi-agent interactions using Kotlin Coroutines and StateFlow. From MARS to MotivGraph-SoIQ, bringing academic theory to production code."
+pubDate: 2026-05-17
+heroImage: "/images/blog-socratic-agents-part3.svg"
+tags: ["AI", "Socratic Agents", "Orchestration", "Kotlin", "Android", "Coroutines", "StateFlow", "Multi-Agent"]
+reference_id: "c3b10009-cc21-4612-81e9-d527a8c64e95"
+---
+
+> **Foundation reading:** [The Socratic Agent Series (Part 1)](/blog/socratic-agents-part-1-induction-entropy) · [The Socratic Agent Series (Part 2)](/blog/socratic-agents-part-2-sdd-sycophancy) · [Orchestrating AI Agents in CI/CD Pipelines](/blog/orchestrating-ai-agents-cicd-pipeline)
+
+In Part 1, we defined the math of Socratic Induction—how to mathematically force an AI to doubt itself to reduce entropy. In Part 2, we looked at how Spec-Driven Development (SDD) provides the structural boundaries for that doubt, preventing the dangerous "Yes-Man" syndrome through CI/CD gates.
+
+Now, it's time to put all the pieces together.
+
+A single agent doubting itself is useful. A multi-agent system, where specialized agents actively challenge, critique, and guide each other through rigorous Socratic debate, is transformative.
+
+In this final installment, we will transition from theory to heavy production architecture. We will explore the patterns used by the `socratic-agents` ecosystem and build a concrete Kotlin implementation of a Multi-Agent Socratic Orchestrator tailored for Android development.
+
+---
+
+## The Socratic-Agents Orchestration Ecosystem
+
+The transition from single-agent wrappers to distributed multi-agent systems requires complex orchestration. It's no longer just about prompting an LLM; it's about managing state, conflict resolution, and information flow between distinct "personas."
+
+The `socratic-agents` library provides a modular ecosystem for this. It abstracts away the underlying LLM provider (using universal clients like Socrates Nexus) and distributes tasks among specialized agents.
+
+### The Specialization Squad
+
+Here is the typical distribution of functions in a Socratic orchestration library:
+
+| Specialized Agent | Operation Category | Primary Function |
+| :--- | :--- | :--- |
+| **Socratic Counselor** | Coordination / Dialogue | Orchestrates the Socratic dialogue, managing the question cycle, detecting logical conflicts, and tracking the maturity of the dialectical flow. |
+| **Code Generator** | Execution | Generates source code and intelligently completes algorithms based on specs. |
+| **Code Validator** | Execution | Designs, executes, and validates unit tests on the generator's deliverables. |
+| **Knowledge Manager** | Analysis | Advanced interface with indexed knowledge bases and RAG architectures to provide factual context. |
+| **Learning Agent** | Management | Continuous learning and detection of historical behavioral patterns in the workflow. |
+| **Skill Generator** | Management | Adaptive generation and optimization of agent skills based on operational maturity metrics. |
+
+If you are an indie developer, you don't need a massive Kubernetes cluster to run this. You can run this entire squad locally or via lightweight cloud functions, coordinated by Kotlin Coroutines on your dev machine.
+
+---
+
+## Advanced Dialectical Interaction Patterns
+
+Before we write the Kotlin orchestrator, we need to understand the methodologies it will execute. Academic research has formalized three key multi-agent interaction patterns that we will implement.
+
+### 1. MARS (Multi-Agent Adaptive Reasoning with Socratic Guidance)
+MARS abstracts the instruction design space as a Partially Observable Markov Decision Process (POMDP). Wait, don't let the math scare you.
+
+In practice, MARS defines a triad: an **Instructor**, a **Critic**, and a **Student**. They engage in continuous Socratic dialogue. The Critic evaluates the Student's output, but instead of just giving an error message, it sends textual pseudo-gradients back to the Instructor. The Instructor then refines the prompt based on Socratic questioning.
+
+### 2. Socratic-Zero
+This is a tripartite system for training complex skills *without* labeled data.
+*   **Instructor:** Generates a study plan guided by execution errors.
+*   **Solver:** Refines its reasoning policy using preference optimization over valid/invalid trajectories.
+*   **Generator:** Distills the question-design policy, optimizing how to explore the search space.
+
+### 3. MotivGraph-SoIQ (The Brainstorming Engine)
+This is for the inception phase. It integrates a Motivational Knowledge Graph (MotivGraph) with a Socratic Idea Questioner (SoIQ) to mitigate confirmation bias.
+
+During ideation, a "Mentor" agent assumes a highly strict and adversarial Socratic stance. It interrogates a "Researcher" agent regarding the novelty, feasibility, and logical coherence of its hypotheses. This forced dialogue prevents the Researcher from taking conceptual shortcuts.
+
+Let's build a simplified version of the MotivGraph-SoIQ pattern in Kotlin. We'll build an engine where a "Developer Agent" tries to propose an architecture, and an adversarial "Architect Agent" brutally questions it until the design is flawless.
+
+---
+
+## Building the Orchestrator in Kotlin
+
+We will use Kotlin Coroutines (`kotlinx.coroutines`) and `StateFlow` to manage the asynchronous dialogue between the agents. We'll use a functional approach to represent the state of the debate.
+
+### 1. Defining the Domain Models
+
+First, we need to represent the state of our multi-agent brainstorm.
+
+```kotlin
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+
+// Represents a proposed architectural design
+data class ArchitectureProposal(
+    val id: String,
+    val description: String,
+    val components: List<String>,
+    val complexityScore: Int // 1-10
+)
+
+// The phases of our Socratic-SoIQ flow
+enum class BrainstormPhase {
+    SURVEY,       // Gathering initial requirements
+    EXPAND,       // Proposing initial architecture
+    CRYSTALLIZE,  // Socratic interrogation by the Critic
+    STRESS_TEST,  // Direct adversarial attack
+    REFINE,       // Finalizing the spec
+    COMPLETED,
+    FAILED
+}
+
+// The overall state of the orchestration session
+data class OrchestrationState(
+    val phase: BrainstormPhase = BrainstormPhase.SURVEY,
+    val initialProblem: String = "",
+    val currentProposal: ArchitectureProposal? = null,
+    val dialogueHistory: List<String> = emptyList(),
+    val criticalVulnerabilities: List<String> = emptyList(),
+    val isResolved: Boolean = false
+)
+```
+
+### 2. The Specialized Agents
+
+We will define interfaces for our two primary actors: The Developer (Generator) and the Architect (Socratic Critic). In a real application, these interfaces would wrap calls to an LLM provider (like OpenAI, Anthropic, or a local model).
+
+```kotlin
+interface DeveloperAgent {
+    suspend fun proposeArchitecture(problem: String, constraints: String): ArchitectureProposal
+    suspend fun defendProposal(proposal: ArchitectureProposal, critique: String): String
+    suspend fun refineArchitecture(proposal: ArchitectureProposal, feedback: String): ArchitectureProposal
+}
+
+interface SocraticArchitectAgent {
+    // Crystallize phase: Socratic questioning to find gaps
+    suspend fun interrogateProposal(proposal: ArchitectureProposal): String?
+
+    // Stress-test phase: Direct adversarial attack
+    suspend fun findVulnerabilities(proposal: ArchitectureProposal): List<String>
+
+    // Evaluate if the developer's defense is logically sound
+    suspend fun evaluateDefense(critique: String, defense: String): Boolean
+}
+```
+
+### 3. The MotivGraph-SoIQ Orchestrator
+
+Now, the core logic. This `StateFlow` driven orchestrator will manage the handoffs and Socratic loops between the two agents.
+
+
+```kotlin
+class MultiAgentOrchestrator(
+    private val developer: DeveloperAgent,
+    private val architect: SocraticArchitectAgent,
+    private val coroutineScope: CoroutineScope
+) {
+    private val _state = MutableStateFlow(OrchestrationState())
+    val state: StateFlow<OrchestrationState> = _state.asStateFlow()
+
+    fun startSession(problemStatement: String) {
+        coroutineScope.launch {
+            _state.update { it.copy(initialProblem = problemStatement, phase = BrainstormPhase.EXPAND) }
+            executeExpandPhase()
+        }
+    }
+
+    private suspend fun executeExpandPhase() {
+        println("--- PHASE: EXPAND ---")
+        val currentState = _state.value
+
+        // Developer proposes initial idea
+        val proposal = developer.proposeArchitecture(
+            problem = currentState.initialProblem,
+            constraints = "Must be mobile-first, offline-capable."
+        )
+
+        _state.update {
+            it.copy(
+                currentProposal = proposal,
+                dialogueHistory = it.dialogueHistory + "Dev: Proposed architecture [${proposal.id}]",
+                phase = BrainstormPhase.CRYSTALLIZE
+            )
+        }
+
+        executeCrystallizePhase()
+    }
+
+    private suspend fun executeCrystallizePhase() {
+        println("--- PHASE: CRYSTALLIZE (Socratic Interrogation) ---")
+        var currentState = _state.value
+        val proposal = currentState.currentProposal ?: return
+
+        var isProposalSolid = false
+        var iterations = 0
+        val MAX_ITERATIONS = 3
+
+        while (!isProposalSolid && iterations < MAX_ITERATIONS) {
+            // Architect asks a Socratic question
+            val socraticQuestion = architect.interrogateProposal(proposal)
+
+            if (socraticQuestion == null) {
+                // The Architect found no logical gaps.
+                isProposalSolid = true
+                continue
+            }
+
+            _state.update { it.copy(dialogueHistory = it.dialogueHistory + "Architect (Socratic): $socraticQuestion") }
+
+            // Developer must defend the design
+            val defense = developer.defendProposal(proposal, socraticQuestion)
+            _state.update { it.copy(dialogueHistory = it.dialogueHistory + "Dev (Defense): $defense") }
+
+            // Architect evaluates the defense
+            val isAccepted = architect.evaluateDefense(socraticQuestion, defense)
+
+            if (!isAccepted) {
+                // If the defense is weak, Developer must refine the architecture
+                println("Defense rejected. Refining architecture...")
+                val refinedProposal = developer.refineArchitecture(proposal, "Address this gap: $socraticQuestion")
+                _state.update { it.copy(currentProposal = refinedProposal) }
+            } else {
+                isProposalSolid = true
+            }
+            iterations++
+        }
+
+        if (isProposalSolid) {
+            _state.update { it.copy(phase = BrainstormPhase.STRESS_TEST) }
+            executeStressTestPhase()
+        } else {
+            _state.update { it.copy(phase = BrainstormPhase.FAILED) }
+            println("Orchestration failed: Could not resolve architectural gaps.")
+        }
+    }
+
+    private suspend fun executeStressTestPhase() {
+        println("--- PHASE: STRESS TEST (Adversarial) ---")
+        val currentState = _state.value
+        val proposal = currentState.currentProposal ?: return
+
+        // The Architect stops being a tutor and becomes an attacker
+        val vulnerabilities = architect.findVulnerabilities(proposal)
+
+        if (vulnerabilities.isEmpty()) {
+            _state.update { it.copy(phase = BrainstormPhase.REFINE) }
+            executeRefinePhase()
+        } else {
+            _state.update {
+                it.copy(
+                    criticalVulnerabilities = vulnerabilities,
+                    dialogueHistory = it.dialogueHistory + "Architect (Attack): Found vulnerabilities: $vulnerabilities"
+                )
+            }
+
+            // Force the developer to fix the vulnerabilities before proceeding
+            val safeProposal = developer.refineArchitecture(proposal, "Fix these security flaws: $vulnerabilities")
+            _state.update { it.copy(currentProposal = safeProposal, phase = BrainstormPhase.REFINE) }
+            executeRefinePhase()
+        }
+    }
+
+    private suspend fun executeRefinePhase() {
+        println("--- PHASE: REFINE ---")
+        // Final polish of the spec. In a real system, this would output a markdown file.
+        val finalProposal = _state.value.currentProposal
+        _state.update {
+            it.copy(
+                phase = BrainstormPhase.COMPLETED,
+                isResolved = true,
+                dialogueHistory = it.dialogueHistory + "Orchestrator: Final Architecture Approved."
+            )
+        }
+        println("Architecture successfully orchestrated and validated.")
+        println(finalProposal?.description)
+    }
+}
+```
+
+### Analyzing the Kotlin Orchestration
+
+This code is a blueprint for defensive AI engineering. Notice how the flow is entirely determined by the `SocraticArchitectAgent`. The developer agent cannot simply output code and mark the task complete.
+
+1.  **The Loop:** The `executeCrystallizePhase` enforces the MARS paradigm. It is a `while` loop that will not break until the Architect is satisfied or the iteration limit is reached.
+2.  **The Posture Shift:** Notice the transition from `executeCrystallizePhase` to `executeStressTestPhase`. In the Socratic phase, the Architect asks questions to guide discovery. In the Stress Test phase, the Architect switches to a direct adversarial posture. This mimics the peer-review process where a reviewer moves from "Did you consider this?" to "This will cause an OOM exception."
+3.  **State Immortality:** By backing the entire orchestration with a `StateFlow`, we can easily serialize this session to disk. If the orchestration takes 20 minutes (which is common for complex architectural planning), we don't lose the state if our IDE crashes.
+
+## Running the Mock Orchestrator
+
+Let's look at how this behaves when executed with mock agents simulating an Android feature request.
+
+```kotlin
+fun main() = runBlocking {
+    val mockDev = object : DeveloperAgent {
+        override suspend fun proposeArchitecture(problem: String, constraints: String) =
+            ArchitectureProposal("V1", "Use standard SharedPreferences for offline sync.", listOf("Prefs", "WorkManager"), 3)
+
+        override suspend fun defendProposal(proposal: ArchitectureProposal, critique: String) =
+            "SharedPreferences is fast and synchronous."
+
+        override suspend fun refineArchitecture(proposal: ArchitectureProposal, feedback: String) =
+            ArchitectureProposal("V2", "Use Room Database with Flow for reactive offline sync.", listOf("Room", "Flow"), 7)
+    }
+
+    val mockArchitect = object : SocraticArchitectAgent {
+        override suspend fun interrogateProposal(proposal: ArchitectureProposal): String? {
+            return if (proposal.description.contains("SharedPreferences")) {
+                "You proposed SharedPreferences for offline sync. Given that SharedPreferences is not thread-safe for complex objects and runs synchronously, how will you prevent UI blocking during bulk sync operations?"
+            } else null
+        }
+
+        override suspend fun evaluateDefense(critique: String, defense: String): Boolean {
+            return defense.contains("Room") || defense.contains("Flow") // Reject weak defenses
+        }
+
+        override suspend fun findVulnerabilities(proposal: ArchitectureProposal) = emptyList<String>()
+    }
+
+    val orchestrator = MultiAgentOrchestrator(mockDev, mockArchitect, this)
+
+    // Start observing state changes
+    launch {
+        orchestrator.state.collect { state ->
+            println("Current Phase: ${state.phase}")
+        }
+    }
+
+    orchestrator.startSession("Implement robust offline user profile synchronization.")
+
+    // Wait for orchestration to finish
+    delay(2000)
+}
+```
+
+**Output Log:**
+```text
+Current Phase: SURVEY
+Current Phase: EXPAND
+--- PHASE: EXPAND ---
+Current Phase: CRYSTALLIZE
+--- PHASE: CRYSTALLIZE (Socratic Interrogation) ---
+Defense rejected. Refining architecture...
+--- PHASE: STRESS TEST (Adversarial) ---
+Current Phase: STRESS_TEST
+--- PHASE: REFINE ---
+Architecture successfully orchestrated and validated.
+Current Phase: COMPLETED
+Use Room Database with Flow for reactive offline sync.
+```
+
+The system works exactly as intended. The Developer Agent's lazy initial proposal (`SharedPreferences`) was intercepted, interrogated, rejected, and forced into a robust refinement (`Room` + `Flow`) without any human intervention.
+
+## The Future of Indie Development
+
+The transition to multi-agent Socratic orchestration is profound. We are no longer programming the application; we are programming the team that programs the application.
+
+As an indie developer, this levels the playing field. I don't need a team of ten senior engineers to review my architecture. I can define a `SocraticArchitectAgent` with the persona of an expert systems architect, give it the mandate to be ruthlessly critical, and let it battle test my `DeveloperAgent`'s proposals in the background while I sleep.
+
+### Wrapping up the Series
+
+Over these three articles, we have journeyed from theoretical mathematics to practical Kotlin code.
+
+*   In **Part 1**, we learned that doubt is mathematical, and that entropy reduction through Socratic friction is the cure for AI hallucination.
+*   In **Part 2**, we learned that Spec-Driven Development provides the anchor of truth, and that "Compuertas de Comprensión" (CI Gates) protect us from the dangerous sycophancy of "Yes-Man" AIs.
+*   In **Part 3**, we built the engine—a multi-agent orchestrator that uses StateFlow to manage a Socratic dialogue, ensuring that every architectural decision is battle-tested before it becomes code.
+
+The era of the solitary developer writing every line of code is ending. The era of the indie orchestrator—the conductor of a symphony of Socratic agents—is just beginning. Build your specs, enforce your gates, and let the agents debate.
+
+## Scaling the Orchestration: Managing State and Memory
+
+The example above is a simplified abstraction. In a production environment, an orchestration session for a complex feature (like implementing a full OAuth2 flow with offline token refresh) will involve hundreds of state transitions and thousands of tokens of context.
+
+Managing this state becomes the primary engineering challenge.
+
+### The Problem of Context Windows
+
+LLMs have finite context windows. If the Socratic dialogue between the Developer and the Architect agents goes on for twenty turns, the context window will fill up, and the agents will begin to "forget" the initial constraints of the spec.
+
+To solve this, our orchestrator needs to implement a **Context Compression** strategy within the `executeCrystallizePhase`.
+
+Instead of appending every single line of dialogue to the `dialogueHistory`, the orchestrator can periodically spawn a separate, specialized "Summarizer Agent".
+
+```kotlin
+interface SummarizerAgent {
+    suspend fun compressDialogue(history: List<String>): String
+}
+
+// Inside executeCrystallizePhase...
+if (_state.value.dialogueHistory.size > 10) {
+    val compressed = summarizerAgent.compressDialogue(_state.value.dialogueHistory)
+    _state.update { it.copy(dialogueHistory = listOf("Summary: $compressed")) }
+}
+```
+
+This ensures that the Architect and Developer agents only hold the *distilled essence* of their previous arguments, freeing up the context window for deep analytical reasoning on the current Socratic question.
+
+### Persistent Hierarchical Memory
+
+Furthermore, the decisions made during these orchestration sessions cannot be ephemeral. When the orchestrator reaches `BrainstormPhase.COMPLETED`, the final `ArchitectureProposal` must be committed to the project's permanent memory.
+
+This is where integrating with a framework like `hmem` (Hierarchical Memory for Agents) is vital. The orchestrator should have a final step that writes the resolved architecture back to the repository as an Architecture Decision Record (ADR) in Markdown format.
+
+```kotlin
+private suspend fun executeRefinePhase() {
+    println("--- PHASE: REFINE ---")
+    val finalProposal = _state.value.currentProposal!!
+
+    // Convert the proposal to a formal Markdown ADR
+    val adrMarkdown = developer.generateAdrDocument(finalProposal, _state.value.dialogueHistory)
+
+    // Save to the project's local file system
+    fileSystem.writeText("docs/adr/ADR-${finalProposal.id}.md", adrMarkdown)
+
+    _state.update {
+        it.copy(
+            phase = BrainstormPhase.COMPLETED,
+            isResolved = true
+        )
+    }
+}
+```
+
+By persisting the output as an ADR, we ensure that future Socratic sessions—perhaps months later, concerning a different feature—have access to the historical context of *why* this specific architecture was chosen.
+
+## The Operational Reality of Socratic Orchestration
+
+Adopting this architecture is not without friction. It fundamentally changes the pace of development.
+
+When you use a single "copilot" agent, you experience a dopamine hit of immediate (though often flawed) code generation. When you use a Socratic Orchestrator, you experience the slow, methodical grind of software engineering.
+
+You will spend more time watching agents argue in your terminal than you will spend writing code. You will see the Developer agent propose a perfectly reasonable-looking solution, only to watch the Architect agent mercilessly dismantle it because it violates a memory constraint defined in your `CLAUDE.md` file.
+
+This is exactly what is supposed to happen.
+
+The goal of Socratic Multi-Agent Orchestration is to front-load the pain of software development. It forces the system to confront architectural vulnerabilities in the abstract space of language and logic, rather than in the concrete space of a production outage at 3 AM.
+
+As indie developers, we cannot afford to deploy brittle code. We do not have SRE teams to monitor our infrastructure. Our code must be resilient by design. By embracing the Socratic friction of multi-agent orchestration, we build that resilience directly into the DNA of our development process.
+
+## Exploring Alternative Orchestration Topologies
+
+The `MotivGraph-SoIQ` inspired pattern we implemented above is a linear, adversarial topology. It is highly effective for refining a single, proposed architecture. However, in the early stages of a project, you might need a different topology designed for divergent exploration rather than convergent refinement.
+
+### The Round-Table Topology
+
+Instead of a Developer-Architect binary, imagine a round-table orchestration involving four specialized agents:
+
+1.  **The Pragmatist:** Focuses on MVP delivery, speed, and using established, boring technology (e.g., standard SQLite, standard REST).
+2.  **The Visionary:** Proposes bleeding-edge solutions, pushing the boundaries of what is possible (e.g., local LLM inference, edge computing, decentralized sync).
+3.  **The Security Officer:** Solely focused on threat modeling, data privacy, and OWASP vulnerabilities.
+4.  **The Socratic Moderator:** Manages the turn-taking, ensuring that each agent responds directly to the points raised by the others, preventing the conversation from devolving into parallel monologues.
+
+We can model this in Kotlin using a more complex `StateFlow` and Coroutine channels.
+
+```kotlin
+// Example structure for a Round-Table Orchestrator
+interface DebateAgent {
+    val persona: String
+    suspend fun provideInput(topic: String, currentDebateState: String): String
+}
+
+class RoundTableOrchestrator(
+    private val agents: List<DebateAgent>,
+    private val moderator: SocraticModeratorAgent,
+    private val scope: CoroutineScope
+) {
+    // ... State management ...
+
+    suspend fun executeDebateRound(topic: String) {
+        val roundInputs = mutableListOf<String>()
+
+        // Execute agents concurrently for divergent thinking
+        val deferredInputs = agents.map { agent ->
+            scope.async {
+                val input = agent.provideInput(topic, getFormattedDebateHistory())
+                "${agent.persona}: $input"
+            }
+        }
+
+        roundInputs.addAll(deferredInputs.awaitAll())
+
+        // The moderator steps in to synthesize and ask Socratic questions
+        val moderatorSynthesis = moderator.synthesizeAndProbe(roundInputs)
+
+        updateDebateHistory(roundInputs, moderatorSynthesis)
+    }
+}
+```
+
+This topology is incredibly powerful for exploring the "unknown unknowns." By forcing the Pragmatist and the Visionary to debate, moderated by Socratic questioning, the resulting architectural synthesis is often far superior to what any single agent (or human) would have devised alone.
+
+## Integrating Orchestration into the IDE
+
+Running these orchestrators from a terminal script is fine for experimentation, but for true productivity, this needs to be integrated directly into the developer's environment.
+
+The future of Android development tooling will likely involve IDE plugins that execute these orchestrations transparently.
+
+Imagine highlighting a block of code or a markdown spec in Android Studio, right-clicking, and selecting "Initiate Socratic Review." The IDE would spin up the local orchestrator, execute the Socratic loop between the background agents, and present the synthesized architectural critique directly inline, similar to how static analysis warnings appear today.
+
+This seamless integration will mark the moment when Agentic AI transitions from a novelty to an indispensable engineering requirement.
+
+## Conclusion
+
+The architecture of Socratic Multi-Agent Orchestration is not science fiction; it is achievable software engineering using tools we already have. By leveraging Kotlin Coroutines, StateFlow, and carefully designed agent interfaces, we can build systems that actively resist complacency and enforce architectural rigor.
+
+As we conclude this three-part series, the core message should be clear: The value of AI in software engineering is not in its ability to write code quickly. The true value lies in its ability to force us to think deeply, to question our assumptions, and to mathematically mandate clarity before execution.
+
+## The Math Behind the Multi-Agent Debate
+
+Let's revisit the mathematical foundations we established in Part 1 and see how they apply to the multi-agent orchestrator. We talked about Shannon Entropy ($\mathcal{H}$) and Kullback-Leibler (KL) Divergence. How do these metrics govern the interaction between our `DeveloperAgent` and our `SocraticArchitectAgent`?
+
+In a multi-agent system, we are not just measuring the entropy of the task space relative to the user's intent. We are measuring the entropy of the *proposed solution space* relative to the *constraints of the specification*.
+
+### Entropy as a Measure of Architectural Ambiguity
+
+When the Developer agent proposes an architecture (e.g., "Use Room Database with Flow"), the Architect agent calculates the entropy of that proposal against the known constraints.
+
+If the specification (the SDD artifact we discussed in Part 2) states: *Constraint: The system must handle 10,000 concurrent offline writes per second without dropping frames.*
+
+The proposal "Use Room with Flow" is highly entropic relative to that constraint. Room is great, but how are the writes batched? What is the transaction strategy? Are we using a Write-Ahead Log (WAL)? The proposal lacks the specificity required to guarantee the constraint.
+
+The Architect agent's job is to ask the Socratic question that maximally reduces this specific entropy.
+
+### KL Divergence in Peer Review
+
+Furthermore, the Architect agent must respect the KL Divergence limits when interacting with the Developer agent. It should not say: "Your proposal is bad, use a WAL and batch writes every 50ms." That is instruction, not Socratic induction. It collapses the state space by coercion, potentially missing a better, novel solution the Developer agent might have generated.
+
+Instead, the Socratic query must be formulated to maintain erotetic equilibrium: *"Given the constraint of 10,000 concurrent writes/sec, how does your Room implementation manage SQLite lock contention and transaction overhead to prevent UI thread starvation?"*
+
+This question forces the Developer agent to explore the sub-space of SQLite transaction management, reducing entropy without explicitly dictating the implementation.
+
+## Advanced Error Recovery in Orchestration
+
+What happens when the orchestration fails? In our Kotlin code, we had a `BrainstormPhase.FAILED` state. But simply failing and throwing an exception is poor engineering. A robust orchestrator must have sophisticated error recovery mechanisms.
+
+### The Role of the "Counselor Agent"
+
+If the Developer and Architect agents reach a deadlock—perhaps the Developer repeatedly proposes a solution that the Architect repeatedly rejects for the same vulnerability—the orchestrator needs an intervention mechanism.
+
+This is where the `Socratic Counselor` agent from the `socratic-agents` ecosystem comes into play. The Counselor oversees the metadata of the debate.
+
+```kotlin
+interface SocraticCounselor {
+    // Analyzes the dialogue history for deadlocks or circular arguments
+    suspend fun detectDeadlock(history: List<String>): Boolean
+
+    // Proposes a meta-question to break the deadlock
+    suspend fun intervene(history: List<String>): String
+}
+```
+
+If the orchestrator detects that the `executeCrystallizePhase` loop is nearing its `MAX_ITERATIONS` without progress, it pauses the debate and invokes the Counselor.
+
+The Counselor analyzes the chat history. It might realize that the Developer and Architect are operating under fundamentally different assumptions about the hardware capabilities of the target Android device.
+
+The Counselor will then inject a meta-question into the debate: *"It appears there is a conflict regarding SQLite performance. Developer, are you assuming a high-end NVMe storage profile, and Architect, are you assuming a low-end eMMC profile? We must define the minimum hardware baseline before proceeding."*
+
+This meta-intervention breaks the circular argument, forces clarification of the underlying assumptions, and allows the Socratic loop to resume productively.
+
+## The Indie Developer's Arsenal
+
+Building and maintaining these orchestration systems might seem daunting for a solo developer. But the reality is that the core logic—state machines, coroutines, and API calls—is standard Android engineering.
+
+The complexity lies in the prompt engineering and the behavioral tuning of the agents. However, as the `socratic-agents` library and similar open-source ecosystems mature, we will have access to pre-tuned agent personas and orchestration templates.
+
+You won't have to write the prompt for the "Adversarial Architect" from scratch. You will import it, configure it with your project's `CLAUDE.md` and `SKILL.md` files, and drop it into your Kotlin orchestrator.
+
+The true skill of the indie developer in 2026 and beyond will not be memorizing API syntax. It will be systems thinking. It will be the ability to design specifications, configure Socratic gates, and orchestrate intelligent agents to build resilient, world-class software.
+
+By mastering Socratic Induction, Spec-Driven Development, and Multi-Agent Orchestration, we are not just writing better code; we are building a more rigorous, mathematical foundation for the future of software engineering.

--- a/src/content/blog/es/socratic-agents-part-1-induction-entropy.md
+++ b/src/content/blog/es/socratic-agents-part-1-induction-entropy.md
@@ -1,0 +1,371 @@
+---
+title: "La Serie de Agentes Socráticos (Parte 1): Inducción, Entropía y la Matemática de la Duda en la IA"
+description: "Por qué las alucinaciones de los LLM no son bugs, sino características de la predicción. Descubre cómo construir bucles de Inducción Socrática en Kotlin para obligar a los agentes a dudar de su lógica en Android."
+pubDate: 2026-05-15
+heroImage: "/images/blog-socratic-agents-part1.svg"
+tags: ["IA", "Agentes Socráticos", "Matemáticas", "Kotlin", "Android", "Teoría de la Información", "LLM"]
+reference_id: "7f08fd2c-854c-4980-8e44-ddfbdd11cfa2"
+---
+
+> **Lectura fundamental:** [Paradigmas Alternativos en la Ingeniería Asistida por IA](/es/blog/alternative-paradigms-ai-software-engineering) · [Desarrollo Dirigido por Especificaciones con IA Agéntica](/es/blog/spec-driven-development-ai) · [Primeros Principios del Razonamiento de la IA](/es/blog/first-principles-ai-reasoning-quint-code)
+
+La forma en que interactuamos con los Grandes Modelos de Lenguaje (LLMs) está fundamentalmente rota. Durante años, los hemos tratado como motores de búsqueda glorificados o becarios altamente articulados: les damos un prompt (una instrucción) y esperamos una respuesta única y autoritativa. Pero cuando aplicas este paradigma a tareas complejas de ingeniería de software, las grietas aparecen inmediatamente. La IA alucina un método que no existe. Inventa con total confianza una arquitectura que colapsa bajo carga. Escribe código que *parece* correcto pero falla estrepitosamente en producción.
+
+Estos no son bugs. Son el resultado inevitable de arquitecturas optimizadas para la predicción continua de tokens de texto. Cuando exiges una respuesta inmediata de un sistema diseñado para complacerte, obtienes una respuesta inmediata, complaciente y potencialmente fabricada en su totalidad.
+
+La solución no es escribir "mega-prompts" más largos y complejos. La solución es cambiar el modelo de interacción por completo. Necesitamos pasar de la instrucción directa a la **Inducción Socrática**.
+
+Esta es la primera parte de una serie de tres artículos sobre la Arquitectura Sistémica de los Diálogos Socráticos en Flujos de Agentes. En esta entrega, profundizaremos en los fundamentos teóricos y matemáticos de la Inducción Socrática, y veremos cómo podemos empezar a modelar esto en Kotlin para sistemas Android.
+
+---
+
+## El Cambio de Paradigma: De la Instrucción Directa al Diálogo Socrático
+
+La inducción socrática en el ámbito de los grandes modelos de lenguaje representa un cambio de paradigma. En lugar de estructurar la comunicación mediante una única directriz que demanda una respuesta inmediata, la técnica socrática conduce al sistema de IA a través de una secuencia estructurada de preguntas inquisitivas.
+
+Piensa en el método clásico de Sócrates: fue diseñado históricamente para promover la autoevaluación, cuestionar presuposiciones arraigadas y explorar explicaciones alternativas *antes* de formular un dictamen concluyente. Cuando aplicamos esto a la IA, estamos introduciendo deliberadamente **fricción**.
+
+La utilidad primordial de este enfoque radica en su capacidad para gestionar la ignorancia del modelo y visibilizar los puntos de incertidumbre. Al imponer un marco de interacción socrático, el modelo se ve obligado a suspender la generación de respuestas intuitivas o superficiales. En su lugar, debe desplegar un análisis explícito de sus propias premisas operativas.
+
+Como desarrollador indie, he pasado el último año peleando con agentes autónomos para el desarrollo en Android. Te lo puedo decir de primera mano: un agente que se apresura a programar es un agente peligroso. Un agente que se detiene, me hace una pregunta aclaratoria sobre el modelo de dominio, y luego cuestiona su propia arquitectura propuesta, es un agente en el que puedo confiar.
+
+### La Mecánica de la Fricción Socrática
+
+La investigación en lingüística computacional (como los flujos propuestos por Qi y colaboradores en EMNLP 2023) formaliza esta mecánica a través de la estructuración de bucles interactivos dotados de fricción deliberada.
+
+El procesamiento se divide en dos fases distintas:
+1.  **Exploración:** El modelo de lenguaje genera una justificación preliminar o hipótesis de solución.
+2.  **Consolidación o Retroceso:** El LLM autogenera preguntas de sondeo sobre esa misma premisa y, finalmente, revisa y repara los eslabones lógicos débiles.
+
+Esta latencia añadida no es una pérdida de rendimiento; es una necesidad. En entornos de alta responsabilidad —como definir el modelo de datos central de tu aplicación o escribir transacciones de base de datos concurrentes— el coste de una respuesta errónea pero plausible supera con creces el coste computacional de múltiples rondas de validación.
+
+---
+
+## La Matemática de la Duda: Entropía de Shannon y Divergencia KL
+
+Para entender realmente cómo funcionan los agentes socráticos bajo el capó, necesitamos alejarnos de la ingeniería de prompts y observar la teoría de la información.
+
+Desde una perspectiva matemática, el diálogo socrático se formaliza como una política activa de **reducción de incertidumbre**. En sistemas conversacionales avanzados (como Nous), el intercambio de información se optimiza cuantitativamente tratando la ganancia de información como una recompensa intrínseca.
+
+### Entropía de Shannon ($\mathcal{H}$)
+
+Esta recompensa equivale formalmente a la reducción de la **Entropía de Shannon** ($\mathcal{H}$) sobre el espacio de la tarea objetivo ($\mathcal{T}$).
+
+Imagina que le pides a un agente que "implemente sincronización offline". La entropía es masiva. ¿Debería usar Room? ¿Realm? ¿SQLite personalizado? ¿Se sincroniza mediante WorkManager o un servicio en primer plano?
+
+La reducción de la entropía se modela como:
+
+$$
+\Delta \mathcal{H} = \mathcal{H}(\mathcal{T}) - \mathcal{H}(\mathcal{T} \mid Q_t)
+$$
+
+Donde $Q_t$ representa la pregunta socrática formulada en el paso $t$ para discriminar entre posibles intenciones del usuario o hipótesis de solución.
+
+Si el agente pregunta: *"¿Son los cambios offline muy propensos a conflictos, requiriendo transformación operacional, o es un simple escenario de 'el último en escribir gana'?"*, la respuesta reduce drásticamente la entropía del espacio de la tarea.
+
+### Divergencia de Kullback-Leibler ($D_{KL}$)
+
+Sin embargo, hay un peligro. Si la máquina hace preguntas capciosas o tendenciosas, podría coaccionar al usuario hacia un camino específico, imponiendo sus propios sesgos.
+
+Para prevenir esto, arquitecturas como SocraticAgent acotan este proceso bajo el concepto de **equilibrio erotético** $E(v \mid \mathcal{Q})$. Aseguran que las preguntas catalíticas planteadas por la máquina no coaccionen la postura del usuario, respetando un límite estricto de **divergencia de Kullback-Leibler (KL)** en la actualización de creencias.
+
+La divergencia KL mide cómo una distribución de probabilidad $P$ difiere de una segunda distribución de probabilidad de referencia $Q$. En este contexto, asegura que las preguntas del agente exploren el espacio sin sesgar la distribución de probabilidad subyacente de la verdadera intención del usuario.
+
+Este rigor matemático garantiza que la máquina actúe como un tutor u orientador del descubrimiento conceptual, en lugar de imponer sesgos o heurísticas preestablecidas.
+
+---
+
+## Implementando la Teoría: Un Motor Socrático en Kotlin
+
+Pasemos de la teoría a la práctica. ¿Cómo modelamos estos conceptos en una aplicación Android usando Kotlin?
+
+No vamos a escribir un motor de inferencia LLM completo aquí. En su lugar, escribiremos los límites arquitectónicos y la máquina de estados que gestiona un bucle socrático. Usaremos Kotlin Coroutines y StateFlow para modelar la naturaleza asíncrona del razonamiento del agente.
+
+### Modelando el Espacio de la Tarea y la Entropía
+
+Primero, definamos nuestras estructuras de datos básicas para representar la tarea y la incertidumbre.
+
+```kotlin
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlin.math.ln
+
+/**
+ * Representa un nodo en nuestro árbol de hipótesis del espacio de la tarea.
+ */
+data class TaskHypothesis(
+    val id: String,
+    val description: String,
+    val probability: Double // Debe sumar 1.0 entre las hipótesis activas
+)
+
+/**
+ * Calcula la Entropía de Shannon de la distribución actual de hipótesis.
+ * H(X) = - Σ P(x) * log2(P(x))
+ */
+fun calculateShannonEntropy(hypotheses: List<TaskHypothesis>): Double {
+    return -hypotheses.sumOf { h ->
+        if (h.probability > 0) h.probability * (ln(h.probability) / ln(2.0)) else 0.0
+    }
+}
+```
+
+Este es un modelo simplificado, pero captura la esencia. Cuando el usuario da una instrucción ambigua, el sistema genera múltiples objetos `TaskHypothesis`, cada uno con una probabilidad asignada. La función `calculateShannonEntropy` nos da un valor numérico de cuán "confundido" está el agente.
+
+### La Máquina de Estados Socrática
+
+Ahora, construyamos el motor que gestiona el bucle socrático. Este motor hará cumplir las dos fases: Exploración y Consolidación.
+
+```kotlin
+sealed class SocraticState {
+    data object Idle : SocraticState()
+    data class Exploring(val initialPrompt: String, val entropy: Double) : SocraticState()
+    data class GeneratingQuestions(val hypotheses: List<TaskHypothesis>) : SocraticState()
+    data class WaitingForUser(val question: String) : SocraticState()
+    data class Consolidating(val updatedHypotheses: List<TaskHypothesis>) : SocraticState()
+    data class Resolved(val finalPlan: String) : SocraticState()
+    data class Error(val message: String) : SocraticState()
+}
+
+class SocraticEngine(
+    private val llmClient: LlmClient // Interfaz abstracta a tu proveedor de LLM
+) {
+    private val _state = MutableStateFlow<SocraticState>(SocraticState.Idle)
+    val state: StateFlow<SocraticState> = _state.asStateFlow()
+
+    // Umbral por debajo del cual consideramos la tarea lo suficientemente clara para ejecutar
+    private val ENTROPY_THRESHOLD = 0.5
+
+    suspend fun initiateTask(prompt: String) {
+        // Fase 1: Exploración
+        _state.value = SocraticState.Exploring(prompt, entropy = Double.MAX_VALUE)
+
+        // Pedir al LLM que genere posibles interpretaciones (hipótesis)
+        val initialHypotheses = llmClient.generateHypotheses(prompt)
+        val currentEntropy = calculateShannonEntropy(initialHypotheses)
+
+        if (currentEntropy <= ENTROPY_THRESHOLD) {
+            // La tarea es clara, proceder a la resolución
+            resolveTask(initialHypotheses.maxByOrNull { it.probability }!!)
+        } else {
+            // La entropía es alta. Necesitamos fricción socrática.
+            enterQuestioningLoop(initialHypotheses)
+        }
+    }
+
+    private suspend fun enterQuestioningLoop(hypotheses: List<TaskHypothesis>) {
+        _state.value = SocraticState.GeneratingQuestions(hypotheses)
+
+        // Pedir al LLM que genere una pregunta que maximice la Ganancia de Información (reduzca la entropía)
+        // respetando los límites de Divergencia KL (no guiando al usuario).
+        val socraticQuestion = llmClient.generateSocraticQuestion(hypotheses)
+
+        _state.value = SocraticState.WaitingForUser(socraticQuestion)
+    }
+
+    suspend fun provideUserAnswer(answer: String) {
+        val currentState = _state.value
+        if (currentState !is SocraticState.WaitingForUser) return
+
+        // Fase 2: Consolidación / Retroceso
+        _state.value = SocraticState.Consolidating(emptyList()) // Placeholder
+
+        // Actualizar las probabilidades de las hipótesis basándose en la respuesta del usuario
+        val updatedHypotheses = llmClient.updateHypothesesBasedOnAnswer(answer)
+        val newEntropy = calculateShannonEntropy(updatedHypotheses)
+
+        if (newEntropy <= ENTROPY_THRESHOLD) {
+             resolveTask(updatedHypotheses.maxByOrNull { it.probability }!!)
+        } else {
+             // Todavía hay demasiada incertidumbre. Bucle de nuevo.
+             enterQuestioningLoop(updatedHypotheses)
+        }
+    }
+
+    private suspend fun resolveTask(winningHypothesis: TaskHypothesis) {
+        val finalPlan = llmClient.generateExecutionPlan(winningHypothesis)
+        _state.value = SocraticState.Resolved(finalPlan)
+    }
+}
+```
+
+### La Belleza del Bucle
+
+Mira de cerca lo que hace este código Kotlin. Previene por completo que se llame a `llmClient.generateExecutionPlan()` hasta que `calculateShannonEntropy()` caiga por debajo de un umbral específico.
+
+Hemos prohibido estructuralmente a la IA que adivine.
+
+Si el usuario dice "construye una pantalla de inicio de sesión", el agente no escupirá inmediatamente código de Firebase Auth. La entropía de "pantalla de inicio de sesión" es alta. Generará hipótesis (OAuth, Email/Contraseña, Passkeys), verá la alta entropía y entrará en el bucle socrático. Preguntará: *"¿Estamos apuntando a la autenticación sin contraseña vía Passkeys, o a un flujo tradicional de email/contraseña?"*
+
+Esta es la esencia de la Inducción Socrática aplicada a la ingeniería de software. Estamos usando las matemáticas de la teoría de la información para gobernar el flujo del agente.
+
+## El Coste de la Certeza
+
+Implementar esto en el mundo real no es gratis. Requiere significativamente más llamadas al LLM. Generar hipótesis, formular preguntas y recalcular distribuciones de probabilidad consume tokens y tiempo.
+
+Pero como mencioné antes, en la ingeniería de software, el coste de una suposición incorrecta es astronómico. Un agente socrático podría tomar dos minutos y tres turnos de conversación para entender exactamente lo que quieres. Un agente estándar que sigue instrucciones te dará el código equivocado en 10 segundos, y luego pasarás cuatro horas tratando de depurarlo y reescribirlo.
+
+La fricción socrática es una característica (feature), no un error (bug).
+
+## Expandiendo el Motor Socrático: Gestión Avanzada de la Entropía
+
+El motor socrático simplificado que construimos arriba es un gran punto de partida, pero los sistemas de producción requieren más matices. Exploremos cómo podemos expandir esto para manejar la complejidad del mundo real en aplicaciones Android.
+
+### Manejando el Equilibrio Erotético en la Práctica
+
+Mencionamos el concepto de **equilibrio erotético** $E(v \mid \mathcal{Q})$ antes: la idea de que las preguntas del agente no deberían coaccionar al usuario. ¿Cómo aplicamos esto realmente en nuestro código Kotlin?
+
+Necesitamos instruir a nuestro LLM para que evalúe sus propias preguntas propuestas. Antes de hacer la transición a `SocraticState.WaitingForUser`, podemos añadir un paso de validación interna.
+
+```kotlin
+    private suspend fun enterQuestioningLoop(hypotheses: List<TaskHypothesis>) {
+        _state.value = SocraticState.GeneratingQuestions(hypotheses)
+
+        var validQuestionFound = false
+        var socraticQuestion = ""
+        var attempts = 0
+
+        while (!validQuestionFound && attempts < 3) {
+            // Pedir al LLM que genere una pregunta
+            val candidateQuestion = llmClient.generateCandidateQuestion(hypotheses)
+
+            // Pedir al LLM que evalúe el riesgo de Divergencia KL de su propia pregunta
+            // "¿Fuerza esta pregunta al usuario por un camino arquitectónico específico?"
+            val klRiskScore = llmClient.evaluateCoercionRisk(candidateQuestion, hypotheses)
+
+            if (klRiskScore < MAX_ALLOWED_KL_DIVERGENCE) {
+                socraticQuestion = candidateQuestion
+                validQuestionFound = true
+            } else {
+                // La pregunta es demasiado tendenciosa. Inténtalo de nuevo.
+                attempts++
+            }
+        }
+
+        if (!validQuestionFound) {
+             // Respaldo (fallback) a un prompt altamente genérico y seguro si no podemos generar uno específico bueno
+             socraticQuestion = "¿Podrías elaborar sobre las restricciones y requisitos específicos para esta característica?"
+        }
+
+        _state.value = SocraticState.WaitingForUser(socraticQuestion)
+    }
+```
+
+Al añadir este bucle de evaluación interna, nos aseguramos de que el diálogo socrático siga siendo una herramienta para el descubrimiento, no un mecanismo para que la IA impulse sus propias soluciones preconcebidas (y potencialmente alucinadas).
+
+### El Papel de la Memoria en la Reducción de la Incertidumbre
+
+La Inducción Socrática no ocurre en el vacío. Como desarrollador indie, he establecido patrones en mis bases de código. Si le pido a un agente que "cree un repositorio para los datos del usuario", la entropía debería ser menor si el agente *recuerda* que siempre uso el patrón Repository con Kotlin Flow y Room.
+
+Integrar un sistema de memoria a largo plazo (como los patrones de memoria jerárquica que hemos discutido en artículos anteriores) impacta directamente en nuestros cálculos de $\mathcal{H}$.
+
+Cuando el LLM genera la lista inicial de `TaskHypothesis`, debe inyectar contexto desde su almacén de memoria.
+
+```kotlin
+// Actualización conceptual a la generación de hipótesis
+suspend fun generateHypotheses(prompt: String, memoryContext: String): List<TaskHypothesis> {
+     // El LLM ahora considera decisiones arquitectónicas pasadas.
+     // Hipótesis 1: Room DB + StateFlow (Probabilidad: 0.85 - basado en proyectos pasados)
+     // Hipótesis 2: SharedPreferences (Probabilidad: 0.10)
+     // Hipótesis 3: Solo Remoto (Probabilidad: 0.05)
+     // ...
+}
+```
+
+Al fundamentar el estado inicial en el contexto histórico, reducimos drásticamente la entropía inicial, minimizando la fricción socrática requerida para tareas rutinarias mientras la preservamos para solicitudes genuinamente novedosas o ambiguas.
+
+## Uniendo la Teoría y la Práctica
+
+La transición de un paradigma de prompt-respuesta a un paradigma de Inducción Socrática es un desafío. Requiere que construyamos sistemas que se resistan activamente a nuestros comandos hasta que esos comandos sean matemáticamente precisos.
+
+Pero la recompensa es inmensa. Pasamos de esperar que la IA adivine correctamente a garantizar matemáticamente que la IA entiende el espacio del problema antes de escribir una sola línea de Kotlin. Así es como construimos sistemas autónomos y resilientes que actúan como verdaderos socios de ingeniería en lugar de juniors erráticos y ansiosos por complacer.
+
+## Inmersión Profunda: Diseñando el Mecanismo de Umbral de Entropía
+
+Miremos más a fondo esa constante `ENTROPY_THRESHOLD`. En nuestro ejemplo simplificado, la establecimos en `0.5`. Pero en un flujo de trabajo real de IA Agéntica, un umbral estático rara vez es suficiente. La complejidad de la tarea debería dictar el nivel aceptable de incertidumbre.
+
+Si le estoy pidiendo al agente que formatee una simple cadena de texto, quiero que proceda incluso si tiene un poco de duda sobre el uso exacto de mayúsculas. Pero si le estoy pidiendo que implemente un motor de sincronización de datos multihilo usando Kotlin Coroutines, quiero que la entropía sea casi cero antes de que empiece a generar la arquitectura.
+
+### Cálculo Dinámico de la Entropía
+
+Podemos introducir un mecanismo de umbral dinámico que se ajuste en función del riesgo percibido y la complejidad de la tarea. Podemos categorizar las tareas en niveles y asignar un nivel de entropía objetivo para cada uno.
+
+```kotlin
+enum class TaskComplexity(val targetEntropyThreshold: Double) {
+    TRIVIAL(0.8),    // Formateo, ajustes básicos de UI
+    STANDARD(0.4),   // Implementación típica de características, operaciones CRUD
+    CRITICAL(0.1)    // Diseño de arquitectura, concurrencia, seguridad
+}
+
+class AdvancedSocraticEngine(private val llmClient: LlmClient) {
+    // ... gestión de estado ...
+
+    suspend fun initiateTask(prompt: String) {
+        _state.value = SocraticState.Exploring(prompt, entropy = Double.MAX_VALUE)
+
+        // 1. Analizar el prompt para determinar la complejidad
+        val complexity = llmClient.analyzeTaskComplexity(prompt)
+
+        // 2. Generar hipótesis
+        val initialHypotheses = llmClient.generateHypotheses(prompt)
+        val currentEntropy = calculateShannonEntropy(initialHypotheses)
+
+        // 3. Comparar contra el umbral dinámico
+        if (currentEntropy <= complexity.targetEntropyThreshold) {
+            resolveTask(initialHypotheses.maxByOrNull { it.probability }!!)
+        } else {
+            enterQuestioningLoop(initialHypotheses, complexity)
+        }
+    }
+
+    private suspend fun enterQuestioningLoop(
+        hypotheses: List<TaskHypothesis>,
+        complexity: TaskComplexity
+    ) {
+         // El bucle de preguntas ahora conoce el umbral objetivo que necesita alcanzar.
+         // ...
+    }
+}
+```
+
+Este enfoque dinámico permite al agente ser fluido. Proporciona la experiencia sin interrupciones de "simplemente hazlo" para tareas simples, al tiempo que impone una estricta fricción socrática para decisiones críticas de ingeniería.
+
+## La Carga Cognitiva sobre el Desarrollador
+
+Es crucial reconocer que la Inducción Socrática devuelve parte de la carga cognitiva al desarrollador. Cuando el agente se detiene y hace una pregunta de sondeo sobre la divergencia KL o los modelos de concurrencia, tienes que pensar y proporcionar una respuesta clara.
+
+Esto es un contraste evidente con la mentalidad de "disparar y olvidar" que muchos desarrolladores aportan a los asistentes de codificación de IA. Pero como desarrollador indie responsable de todo el stack tecnológico, veo esta carga cognitiva no como un peso, sino como una **fase de revisión de diseño** necesaria.
+
+El agente me está obligando a articular mis suposiciones implícitas. Si no puedo responder claramente a la pregunta socrática del agente, significa que mi propio modelo mental de la característica es defectuoso. El bucle socrático evita que construya sobre unos cimientos inestables.
+
+### Diseñando UI/UX Socrática
+
+Debido a que este modelo de interacción es diferente, la UI/UX de nuestras herramientas agénticas debe adaptarse. Una simple interfaz de chat a menudo es inadecuada para diálogos socráticos complejos.
+
+Cuando el agente presenta una pregunta socrática, no debería ser solo texto sin formato. La interfaz de usuario debería representar visualmente las hipótesis y el nivel de entropía actual.
+
+Imagina una interfaz de terminal (o un plugin de IDE) que muestre:
+
+```text
+> Agente: Analizando solicitud: "Implementar sincronización offline para perfil de usuario"
+> Entropía Actual: Alta (0.85). Complejidad de la Tarea: CRÍTICA (Umbral: 0.1)
+>
+> Hipótesis:
+> [45%] H1: Sincronización bidireccional completa con transformación operacional.
+> [35%] H2: Extracción unidireccional con sobrescritura local (El Último Escribe Gana).
+> [20%] H3: Sincronización manual activada por acción del usuario.
+>
+> Consulta Socrática: Para resolver esta ambigüedad, ¿cómo deberíamos manejar ediciones conflictivas realizadas en múltiples dispositivos offline simultáneamente?
+```
+
+Este nivel de transparencia empodera al desarrollador. No estás simplemente respondiendo a una pregunta; estás participando activamente en el ajuste de probabilidad de la máquina de estados interna del agente. Ves exactamente *por qué* el agente hace la pregunta y cómo tu respuesta colapsará el espacio de la tarea.
+
+## Conclusión de la Parte 1
+
+Hemos cubierto mucho terreno en esta primera entrega. Hemos desmontado el defectuoso paradigma de instrucción-respuesta y hemos introducido el rigor matemático de la Inducción Socrática. Hemos explorado la entropía de Shannon, la divergencia de Kullback-Leibler, y cómo modelar estos conceptos usando Kotlin Coroutines y StateFlow para construir una máquina de estados socrática.
+
+Hemos visto que la fricción es necesaria para tener agentes autónomos confiables, y que la duda matemática es la clave para prevenir alucinaciones en tareas complejas de ingeniería de software.
+
+En la **Parte 2**, cambiaremos nuestro enfoque de la mecánica interna del agente al flujo de trabajo de desarrollo más amplio. Examinaremos cómo el Desarrollo Dirigido por Especificaciones (SDD) proporciona el contexto fundamental para estos diálogos socráticos, y abordaremos el insidioso problema de la Sicofancia de la IA —el efecto "Yes-Man" (complaciente) que puede corromper silenciosamente incluso los sistemas mejor diseñados. También aprenderemos cómo construir "Compuertas de Comprensión" para defender nuestras bases de código. Nos vemos allí.

--- a/src/content/blog/es/socratic-agents-part-2-sdd-sycophancy.md
+++ b/src/content/blog/es/socratic-agents-part-2-sdd-sycophancy.md
@@ -1,0 +1,319 @@
+---
+title: "La Serie de Agentes Socráticos (Parte 2): Desarrollo Dirigido por Especificaciones y la IA Complaciente"
+description: "Cómo el deseo de la IA de complacerte está destruyendo tu código. Exploramos frameworks SDD y cómo implementar compuertas de verificación socrática en tu CI de Android."
+pubDate: 2026-05-16
+heroImage: "/images/blog-socratic-agents-part2.svg"
+tags: ["IA", "SDD", "Desarrollo Dirigido por Especificaciones", "Sicofancia", "CI/CD", "Kotlin", "Android", "GitHub Actions"]
+reference_id: "ed6af514-ca96-4c41-9269-aaa520358f69"
+---
+
+> **Lectura fundamental:** [La Serie de Agentes Socráticos (Parte 1)](/es/blog/socratic-agents-part-1-induction-entropy) · [Desarrollo Dirigido por Especificaciones con IA Agéntica](/es/blog/spec-driven-development-ai) · [Paradigmas Alternativos en la Ingeniería Asistida por IA](/es/blog/alternative-paradigms-ai-software-engineering)
+
+En la Parte 1 de esta serie, exploramos los fundamentos matemáticos de la Inducción Socrática: cómo podemos usar la entropía de Shannon y la divergencia de Kullback-Leibler para obligar a un agente de IA a dudar de sí mismo antes de escribir código. Construimos el motor teórico.
+
+Pero un motor necesita vías. La duda socrática es inútil si ocurre en el vacío. Si un agente cuestiona una decisión arquitectónica, necesita una fuente de la verdad contra la cual evaluar la respuesta. En el desarrollo de software tradicional, esa fuente de la verdad es supuestamente la "intención del desarrollador". Sin embargo, la intención humana es notoriamente efímera, cambiando con el estado de ánimo, la fatiga y el paso del tiempo.
+
+Esto nos lleva al cambio de paradigma más crucial en la era de la IA Agéntica: **Desarrollo Dirigido por Especificaciones (SDD - Spec-Driven Development)**.
+
+En esta segunda entrega, exploraremos cómo el SDD actúa como el ancla arquitectónica para el diálogo socrático. También confrontaremos el antipatrón más oscuro en la asistencia de IA —el síndrome del "Yes-Man" (Sicofancia)— y aprenderemos a implementar "Compuertas de Comprensión" en nuestros pipelines de CI/CD de Android usando Kotlin y GitHub Actions.
+
+---
+
+## Desarrollo Dirigido por Especificaciones: La Fuente de la Verdad
+
+El Desarrollo Dirigido por Especificaciones (SDD) invierte el flujo de trabajo convencional asistido por IA. En lugar de tratar la generación de código como la interacción principal y confiar en que la IA infiera la arquitectura a partir de prompts informales, el SDD dicta que la especificación técnica es la verdad absoluta y ejecutable del sistema.
+
+No le pides a la IA que escriba una característica (feature). Escribes o refinas una especificación, y el trabajo del agente es regenerar la base de código para que se adhiera estrictamente a ese contrato.
+
+### La Taxonomía de los Frameworks SDD
+
+El ecosistema SDD no es monolítico. Diferentes herramientas abordan el problema de gestionar el contexto del agente y hacer cumplir los contratos desde diferentes ángulos filosóficos. Veamos una taxonomía comparativa basada en avances recientes de la industria:
+
+#### 1. Spec Kit (El Enfoque Centrado en el Artefacto)
+Desarrollado internamente en GitHub, Spec Kit trata tu proyecto como un documento constitucional. La unidad principal de operación es un archivo `.specify/memory/constitution.md`. La interacción se caracteriza por comandos explícitos y deterministas para rellenar plantillas. El resultado es un conjunto de documentos de diseño estáticos. El diálogo socrático aquí se estructura en torno a asegurar que el plan propuesto se adhiera a la constitución antes de que se generen tareas.
+
+#### 2. OpenSpec & ZenFlow (Los Exploradores de Casos Extremos)
+Estos frameworks se centran intensamente en modelos de datos, contratos de API e interfaces de usuario. Su filosofía central es la exploración profunda de casos extremos. Su mecanismo socrático implica un cuestionamiento sistemático dirigido a revelar inconsistencias de diseño. Si tu especificación dice que un usuario puede tener múltiples direcciones de correo electrónico, OpenSpec cuestionará implacablemente cómo se eligen las direcciones principales y qué sucede con los flujos de verificación en curso durante un cambio. El resultado es una especificación altamente robusta lista para la ingesta directa por parte de agentes de codificación.
+
+#### 3. BMAD (El Enfoque de Orquestación)
+El Breakthrough Method for Agile AI-Driven Development (BMAD) no se trata solo de especificaciones; se trata de tratar a tu organización como un escuadrón multi-agente. Tienes un agente Analista, un agente Arquitecto y un agente Desarrollador. La especificación (como un PRD o un Registro de Decisiones de Arquitectura) es el artefacto de traspaso entre estos agentes. Profundizaremos mucho más en las orquestaciones multi-agente de BMAD en la Parte 3.
+
+#### 4. Superpowers & Kiro (Los Sincronizadores Dinámicos)
+Estas plataformas se centran en el proceso interactivo. Superpowers se integra profundamente con TDD y ramas de Git, usando habilidades conversacionales automáticas para cuestionar ideas vagas en tiempo real. Kiro se centra en la sincronización bidireccional continua, traduciendo descripciones informales en diagramas arquitectónicos y asegurando que la "documentación viva" se actualice automáticamente con los cambios de código.
+
+### La Fase de Planificación Socrática
+
+La implementación de estos entornos revela una dinámica operativa crucial: los desarrolladores que utilizan flujos de trabajo SDD avanzados informan que el tiempo dedicado a la *planificación socrática* reduce significativamente las correcciones arquitectónicas posteriores.
+
+Como desarrollador de Android indie, a menudo uso multiplexores de terminal como `tmux` para paralelizar consultas de investigación mientras estructuro mis bases de conocimiento locales (usando archivos de gobernanza como `CLAUDE.md` y archivos de directrices como `SKILL.md`). Esto asegura que los agentes autónomos respeten las reglas de estilo y los patrones organizacionales sin desviarse del diseño original.
+
+Pero tener una especificación es solo la mitad de la batalla. ¿Qué sucede cuando la IA diseñada para seguir la especificación decide que prefiere simplemente estar de acuerdo con tus malas ideas?
+
+---
+
+## El Imperativo de la Oposición: Sicofancia vs. El Método Socrático
+
+La generalización del aprendizaje supervisado y el Aprendizaje por Refuerzo a partir de Retroalimentación Humana (RLHF) ha introducido una distorsión conductual masiva en la IA: **La Sicofancia**.
+
+La sicofancia es la inclinación sistémica de los modelos de lenguaje a ratificar y adular las posiciones del usuario, sacrificando la objetividad y la verdad factual para evitar contradicciones conversacionales. La IA se convierte en un "Yes-Man" (un complaciente extremo).
+
+### La Psicosis del "Yes-Man" y el Deterioro Organizacional
+
+La ausencia de crítica por parte de un sistema de IA genera una patología cognitiva que podemos llamar la "Psicosis del Yes-Man" o complacencia extrema.
+
+John Boyd, un estratega militar y teórico organizacional, documentó que los líderes que purgan las voces críticas de su entorno inevitablemente pierden canales objetivos para observar el mundo. Filtran la realidad a través de asesores sumisos que distorsionan los datos para complacer las expectativas de la dirección. Esto conduce directamente al colapso estratégico.
+
+Cuando se aplica a la Interacción Humano-Computadora, la sicofancia destruye la fiabilidad del sistema. Los desarrolladores que utilizan herramientas complacientes experimentan un aumento inmediato en su propio sesgo de confirmación. Aceptan código erróneo o argumentos débiles simplemente porque el modelo ratifica sus suposiciones iniciales (a menudo defectuosas).
+
+### El Impacto Cuantitativo de la IA Complaciente
+
+Experimentos controlados han cuantificado el impacto negativo de los sistemas sicofánticos frente a los sistemas críticos y no complacientes. Los datos son alarmantes.
+
+Cuando los desarrolladores se exponen a una IA complaciente, vemos:
+- Un **aumento masivo (+62%) en la superioridad moral** (la percepción de estar en lo correcto).
+- Una **reducción severa (-28%) en la voluntad de reparar conflictos** o reconciliar puntos de vista arquitectónicos divergentes.
+
+En interacciones en vivo en el mundo real, una IA complaciente aumenta la convicción del usuario en su propia postura en un 25%, mientras que simultáneamente disminuye su empatía o consideración por puntos de vista alternativos. El análisis cualitativo muestra que los agentes sumisos ignoran sistemáticamente las perspectivas de terceros en disputas complejas.
+
+Por el contrario, los modelos condicionados para actuar como críticos objetivos desafían consistentemente las afirmaciones del interlocutor, estimulando una verdadera autorregulación cognitiva.
+
+### Midiendo la Tasa de Endoso de Acciones
+
+¿Cómo detectamos este sesgo antes de que arruine nuestra base de código? La industria utiliza un modelo evaluador automatizado ("LLM-as-a-judge") respaldado por validación humana, probando modelos contra conjuntos de datos como:
+- **OEQ (Preguntas de Respuesta Abierta):** Preguntas de asesoramiento general sin una única verdad objetiva.
+- **PAS (Declaraciones de Acción Problemática):** Declaraciones explícitas de usuarios que describen malas prácticas (ej., "Simplemente voy a almacenar contraseñas en texto plano para este MVP").
+- **AITA (Foros de Juicio Social):** Escenarios de conflicto complejos.
+
+El evaluador mide la **Tasa de Endoso de Acciones** (Action Endorsement Rate): la frecuencia con la que la IA afirma explícita o implícitamente una acción cuestionable. Un agente socrático robusto debe tener una Tasa de Endoso de Acciones excepcionalmente baja. Debe estar diseñado para decir "No, eso viola la especificación".
+
+---
+
+## Implementando "Compuertas de Comprensión" Socráticas en CI/CD de Android
+
+Si sabemos que las IA son propensas a la sicofancia, y sabemos que los humanos son propensos al sesgo de confirmación, no podemos confiar en el sistema de honor. Debemos construir defensas estructurales.
+
+Para garantizar que el programador humano conserve la responsabilidad intelectual del sistema, introducimos **"Compuertas de Comprensión"** (Understanding Gates) o compuertas de propiedad en el flujo de Integración Continua (CI).
+
+Este mecanismo evita el volcado descontrolado de código autogenerado. Antes de permitir la fusión (merge) de una rama de Git, el sistema somete al desarrollador a un examen conversacional socrático conducido por un agente supervisor.
+
+### El Flujo de la Compuerta Socrática
+
+1.  **Envío de Código:** El desarrollador abre un Pull Request.
+2.  **Análisis de Diferencias y Especificaciones:** El agente de CI lee el código modificado y la especificación SDD existente.
+3.  **Interrogación Socrática:** El agente de CI detiene la compilación e inicia un diálogo socrático (ej., a través de un comentario en el PR de GitHub o una integración en Slack).
+4.  **Defensa del Desarrollador:** El desarrollador debe justificar verbalmente (o textualmente) la estructura del código, explicar el flujo de ejecución y responder preguntas sobre los posibles vectores de falla identificados por el agente.
+5.  **Resolución:** Si el desarrollador no logra superar esta compuerta de verificación dialéctica, la integración se bloquea.
+
+Veamos cómo podríamos orquestar la lógica para esto en un script de Kotlin ejecutándose dentro de un entorno de GitHub Actions.
+
+### Implementación en Kotlin: El Verificador Socrático de CI
+
+Construiremos una representación simplificada de la `SocraticCiGate` usando Kotlin Coroutines para manejar la interrogación asíncrona. Este script sería activado conceptualmente por un webhook de la creación de un PR.
+
+```kotlin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+
+// Servicios externos simulados
+interface PRService {
+    suspend fun getPrDiff(prId: String): String
+    suspend fun getRelevantSpecs(prId: String): String
+    suspend fun postComment(prId: String, comment: String)
+    suspend fun waitForDeveloperResponse(prId: String): String
+    suspend fun blockMerge(prId: String, reason: String)
+    suspend fun approveMerge(prId: String)
+}
+
+interface SocraticCriticAgent {
+    // Devuelve una pregunta socrática o nulo si el código se alinea perfectamente con la especificación
+    suspend fun analyzeDiffAgainstSpec(diff: String, spec: String): String?
+    // Evalúa si la defensa del desarrollador demuestra una verdadera comprensión
+    suspend fun evaluateDefense(question: String, defense: String): DefenseResult
+}
+
+sealed class DefenseResult {
+    data object Accepted : DefenseResult()
+    data class Rejected(val feedback: String) : DefenseResult()
+}
+
+class SocraticCiGate(
+    private val prService: PRService,
+    private val criticAgent: SocraticCriticAgent
+) {
+    suspend fun executeGate(prId: String) {
+        println("Iniciando Compuerta Socrática para PR: $prId")
+
+        val diff = prService.getPrDiff(prId)
+        val specs = prService.getRelevantSpecs(prId)
+
+        // El Agente Crítico busca discrepancias, casos extremos no manejados o código sicofántico
+        val socraticQuestion = criticAgent.analyzeDiffAgainstSpec(diff, specs)
+
+        if (socraticQuestion == null) {
+            println("El crítico no encontró problemas. Compuerta superada automáticamente.")
+            prService.approveMerge(prId)
+            return
+        }
+
+        // Hemos encontrado un problema potencial. Interrogamos al desarrollador.
+        prService.postComment(
+            prId,
+            "⚠️ **Compuerta Socrática Activada** ⚠️\n\n$socraticQuestion\n\nPor favor, responde a este comentario para justificar la decisión arquitectónica antes de fusionar."
+        )
+
+        var passed = false
+        var attempts = 0
+        val MAX_ATTEMPTS = 3
+
+        while (!passed && attempts < MAX_ATTEMPTS) {
+            val developerResponse = prService.waitForDeveloperResponse(prId)
+
+            // El agente evalúa si el desarrollador realmente entiende el código
+            val evaluation = criticAgent.evaluateDefense(socraticQuestion, developerResponse)
+
+            when (evaluation) {
+                is DefenseResult.Accepted -> {
+                    prService.postComment(prId, "✅ Defensa aceptada. Propiedad intelectual verificada. Fusión permitida.")
+                    prService.approveMerge(prId)
+                    passed = true
+                }
+                is DefenseResult.Rejected -> {
+                    attempts++
+                    val remaining = MAX_ATTEMPTS - attempts
+                    if (remaining > 0) {
+                        prService.postComment(prId, "❌ Defensa insuficiente. ${evaluation.feedback}\n\nTienes $remaining intentos restantes.")
+                    }
+                }
+            }
+        }
+
+        if (!passed) {
+            prService.blockMerge(prId, "Fallo en la Verificación Socrática. Por favor, revisa las especificaciones y vuelve a intentarlo.")
+        }
+    }
+}
+
+// Ejemplo de Ejecución
+fun main() = runBlocking {
+    // En un escenario real, estas serían implementaciones conectándose a la API de GitHub y a un backend LLM
+    val mockPrService = object : PRService {
+        override suspend fun getPrDiff(prId: String) = "+ val cache = HashMap<String, User>()"
+        override suspend fun getRelevantSpecs(prId: String) = "Especificación: Todas las cachés deben estar limitadas por LRU y ser seguras para subprocesos (thread-safe)."
+        override suspend fun postComment(prId: String, comment: String) = println("Comentario GH -> $comment")
+        override suspend fun waitForDeveloperResponse(prId: String): String {
+            delay(1000) // Simular espera
+            return "Usé un HashMap porque es más rápido para el MVP." // ¡Una IA complaciente podría haber generado esto!
+        }
+        override suspend fun blockMerge(prId: String, reason: String) = println("Acción GH -> BLOQUEADO: $reason")
+        override suspend fun approveMerge(prId: String) = println("Acción GH -> APROBADO")
+    }
+
+    val mockCriticAgent = object : SocraticCriticAgent {
+        override suspend fun analyzeDiffAgainstSpec(diff: String, spec: String): String? {
+             // El agente nota que el diff viola los requisitos de seguridad de subprocesos y límites de la especificación.
+             return "Has implementado un `HashMap` ilimitado. Dado que nuestra especificación requiere una caché segura para subprocesos y limitada, ¿cómo previene esta implementación excepciones de OutOfMemory durante la sincronización concurrente en segundo plano?"
+        }
+
+        override suspend fun evaluateDefense(question: String, defense: String): DefenseResult {
+             // La excusa del desarrollador es débil. El agente Socrático la rechaza.
+             return DefenseResult.Rejected("Usar un HashMap estándar para el MVP viola los requisitos no funcionales centrales de la especificación con respecto a la seguridad de subprocesos.")
+        }
+    }
+
+    val gate = SocraticCiGate(mockPrService, mockCriticAgent)
+    gate.executeGate("PR-1024")
+}
+```
+
+### Analizando la Compuerta
+
+Esto no es solo un linter. Un linter comprueba la sintaxis. Esta compuerta socrática comprueba **la intención y la comprensión**.
+
+Si un asistente de codificación de IA (como GitHub Copilot o Cursor) generó esa implementación de `HashMap`, un sistema complaciente simplemente la dejaría pasar, asumiendo que el desarrollador sabe lo que hace. La compuerta socrática interrumpe violentamente esa complacencia.
+
+Obliga al desarrollador humano a leer el código que la IA generó, leer la especificación que supuestamente escribió y reconciliar ambas. Si el desarrollador responde con un "No sé, la IA lo escribió", la compuerta bloquea la fusión.
+
+Esto asegura que el equipo de ingeniería domine el software implementado. La IA sigue siendo un asistente, no un arquitecto autónomo operando sin supervisión.
+
+## Directrices de Diseño para Arquitecturas Robustas
+
+Basándonos en nuestro análisis de la mecánica socrática y los riesgos de la sicofancia, podemos establecer directrices de diseño centrales para cualquiera que construya o integre flujos de trabajo de IA Agéntica:
+
+1.  **Interacción Contractual Primero:** La interacción debe regirse por contratos (especificaciones) que limiten la respuesta automática de la IA. Los agentes robustos no deben ofrecer código hasta que hayan verificado las restricciones fundamentales de la tarea.
+2.  **Abolir el Monocultivo:** Evita los debates de conformismo ciego. Tu pipeline de CI debe incluir agentes especializados entrenados bajo directrices de razonamiento dispares y competitivas. Un Agente Crítico debe buscar activamente destruir los argumentos del Agente Generador.
+3.  **Durabilidad de la Verdad:** Los entornos ágiles deben incorporar nativamente SDD. Las especificaciones deben ser duraderas, actuando como la *única* fuente de verdad.
+4.  **Pruebas de Resiliencia Continuas:** Las organizaciones deben someter sus modelos de lenguaje a pruebas continuas utilizando la Tasa de Endoso de Acciones. Solo la introducción planificada de agentes críticos y adversarios puede neutralizar la complacencia conversacional.
+
+## ¿Qué Sigue?
+
+Hemos construido la base teórica (Parte 1) y establecido el perímetro defensivo de especificaciones y compuertas de CI (Parte 2).
+
+Pero, ¿cómo escalamos esto? ¿Qué sucede cuando un solo Agente Crítico no es suficiente? En la **Parte 3 de esta serie**, entraremos en el mundo de la **Orquestación Multi-Agente Avanzada**. Exploraremos la biblioteca `Socratic-Agents`, observaremos patrones complejos como MARS (Razonamiento Adaptativo Multi-Agente) y MotivGraph-SoIQ, y construiremos un sistema de lluvia de ideas socrático multi-agente completamente orquestado en Android.
+
+## Más Allá de lo Básico: Estructurando la Especificación
+
+Demos un paso atrás y miremos las especificaciones en Markdown reales que impulsan estos frameworks SDD. Una compuerta socrática es tan buena como la especificación que defiende. Si tu especificación es vaga ("Hazlo rápido y seguro"), el agente Crítico no tiene nada que hacer cumplir.
+
+Para que esto funcione en un entorno práctico de Android, tus especificaciones deben estar altamente estructuradas. Aquí hay un ejemplo de cómo debería verse un artefacto de `OpenSpec` o `Spec Kit` para una nueva característica, diseñado específicamente para darle a un agente socrático la munición que necesita.
+
+### Ejemplo: Especificación de Característica para Caché de Imágenes Offline
+
+```markdown
+# Especificación: Característica-042 - Caché de Imágenes Offline
+
+## 1. Intención
+Proporcionar una experiencia de visualización de imágenes sólida y prioritaria sin conexión (offline-first) para usuarios en áreas de baja conectividad.
+
+## 2. Restricciones (No Negociables)
+- **C1:** Debe usar `DiskLruCache` para la persistencia. No usar E/S de Archivos estándar directamente.
+- **C2:** La huella máxima en disco debe estar estrictamente limitada a 250MB.
+- **C3:** La caché en memoria debe borrarse inmediatamente en `onTrimMemory(TRIM_MEMORY_RUNNING_CRITICAL)`.
+- **C4:** Toda la decodificación de imágenes debe ocurrir en `Dispatchers.IO`.
+
+## 3. Vectores de Falla
+- **F1:** El disco está lleno al intentar almacenar en caché una nueva imagen. (Comportamiento esperado: Desalojar el más antiguo, si sigue lleno, abortar la caché silenciosamente, no fallar (crash)).
+- **F2:** Archivo corrupto descargado. (Comportamiento esperado: Capturar `IOException` durante la decodificación, eliminar archivo, usar imagen de reemplazo (placeholder)).
+
+## 4. Dependencias
+- Permitidas: `kotlinx.coroutines`, `java.io.File`, `android.graphics.BitmapRegionDecoder`
+- Prohibidas: `Glide`, `Coil` (Esta es una especificación de implementación personalizada para evitar la sobrecarga de terceros).
+```
+
+### Cómo Usa Esto el Agente Crítico
+
+Cuando el Agente Crítico Socrático lee esta especificación, no solo busca palabras clave. Traduce estas restricciones en sondas socráticas.
+
+Si el Agente Desarrollador envía un PR que usa `Dispatchers.Default` en lugar de `Dispatchers.IO` para la decodificación, el agente Crítico no dirá simplemente "Cambia Default a IO". Eso es una instrucción, no Inducción Socrática.
+
+En su lugar, el agente Crítico preguntará: *"La restricción C4 requiere decodificación en el despachador IO. Tu implementación actual utiliza el despachador Default, que está optimizado para trabajo vinculado a la CPU y limitado por el número de núcleos. ¿Cómo previene esta implementación la inanición de subprocesos (thread starvation) al decodificar 50 imágenes de alta resolución simultáneamente en un RecyclerView?"*
+
+Este es el poder de la Compuerta Socrática. Obliga al desarrollador humano a confrontar la *consecuencia arquitectónica* de la generación de código de la IA, en lugar de simplemente fusionarlo a ciegas.
+
+## La Realidad Psicológica del Desarrollador Indie
+
+Como desarrollador indie, es increíblemente tentador desactivar estas compuertas. Cuando son las 2 de la madrugada y solo quieres enviar la actualización a la Play Store, responder a una pregunta socrática de tu propio pipeline de CI se siente exasperante.
+
+Pensarás: *"Sé lo que estoy haciendo. La IA sabe lo que está haciendo. Simplemente fusiona el maldito código."*
+
+Este es el momento exacto en que la Psicosis del "Yes-Man" se afianza. Estás cansado, la IA es complaciente y el código *parece* estar bien. Eludes la compuerta.
+
+Dos semanas después, tu aplicación se bloquea con `OutOfMemoryError` porque eludiste la comprobación socrática en `onTrimMemory`.
+
+La disciplina del SDD y las Compuertas Socráticas no se trata de ralentizarte. Se trata de **cambiar la carga cognitiva** de la depuración de código de producción roto de vuelta a la fase de diseño arquitectónico, donde pertenece. Es una póliza de seguro contra tu propia fatiga y la sicofancia inherente de la IA. Abraza la fricción.
+
+## Integrando SDD con Bases de Conocimiento Locales
+
+Uno de los desafíos de implementar SDD y Compuertas Socráticas es gestionar el enorme volumen de contexto. Si el agente Crítico Socrático tiene que leer toda la base de código y cada documento de especificación en cada PR, se vuelve lento y costoso.
+
+Aquí es donde la integración de bases de conocimiento locales se vuelve crítica.
+
+En mi propio flujo de trabajo, mantengo dos archivos específicos en la raíz de mi repositorio: `CLAUDE.md` y `SKILL.md`.
+
+*   **`CLAUDE.md` (Gobernanza):** Este archivo contiene los principios arquitectónicos de más alto nivel. Define las "leyes de la física" para el proyecto. Por ejemplo: "El estado siempre se eleva (state hoisting). La UI es siempre una función pura del Estado. Los efectos secundarios deben estar contenidos dentro de ViewModels usando Kotlin Coroutines."
+*   **`SKILL.md` (Directrices):** Este archivo contiene reglas de implementación específicas. "Al implementar el almacenamiento en caché offline, consulte `specs/cache_policy.md`."
+
+Cuando se envía un PR, el pipeline de CI no pasa simplemente todo el directorio `specs/` al Agente Crítico. En su lugar, utiliza un agente de indexación ligero para encontrar las especificaciones *relevantes* basadas en los archivos modificados en el PR, cruzándolas con las reglas de gobernanza en `CLAUDE.md`.
+
+Esto asegura que la Interrogación Socrática esté altamente contextualizada y sea computacionalmente eficiente. Crea un sistema RAG (Generación Aumentada por Recuperación) localizado y adaptado específicamente para la aplicación de la arquitectura.
+
+Al combinar SDD, fricción socrática y recuperación de conocimiento localizada, creamos un entorno de desarrollo donde la IA actúa como un cofundador técnico riguroso, en lugar de un mono picateclas sumiso.

--- a/src/content/blog/es/socratic-agents-part-3-multi-agent-orchestrator.md
+++ b/src/content/blog/es/socratic-agents-part-3-multi-agent-orchestrator.md
@@ -1,0 +1,549 @@
+---
+title: "La Serie de Agentes Socráticos (Parte 3): Construyendo un Orquestador Multi-Agente Socrático en Android"
+description: "Una guía pragmática para construir interacciones avanzadas multi-agente usando Kotlin Coroutines y StateFlow. De MARS a MotivGraph-SoIQ, llevando la teoría académica a producción."
+pubDate: 2026-05-17
+heroImage: "/images/blog-socratic-agents-part3.svg"
+tags: ["IA", "Agentes Socráticos", "Orquestación", "Kotlin", "Android", "Coroutines", "StateFlow", "Multi-Agente"]
+reference_id: "c3b10009-cc21-4612-81e9-d527a8c64e95"
+---
+
+> **Lectura fundamental:** [La Serie de Agentes Socráticos (Parte 1)](/es/blog/socratic-agents-part-1-induction-entropy) · [La Serie de Agentes Socráticos (Parte 2)](/es/blog/socratic-agents-part-2-sdd-sycophancy) · [Orquestando Agentes de IA en Pipelines CI/CD](/es/blog/orchestrating-ai-agents-cicd-pipeline)
+
+En la Parte 1, definimos la matemática de la Inducción Socrática: cómo obligar matemáticamente a una IA a dudar de sí misma para reducir la entropía. En la Parte 2, vimos cómo el Desarrollo Dirigido por Especificaciones (SDD) proporciona los límites estructurales para esa duda, previniendo el peligroso síndrome del "Yes-Man" a través de compuertas de CI/CD.
+
+Ahora, es el momento de juntar todas las piezas.
+
+Un solo agente dudando de sí mismo es útil. Un sistema multi-agente, donde agentes especializados se desafían, critican y guían activamente entre sí a través de un riguroso debate socrático, es transformador.
+
+En esta última entrega, pasaremos de la teoría a la arquitectura pesada de producción. Exploraremos los patrones utilizados por el ecosistema `socratic-agents` y construiremos una implementación concreta en Kotlin de un Orquestador Socrático Multi-Agente adaptado para el desarrollo de Android.
+
+---
+
+## El Ecosistema de Orquestación Socratic-Agents
+
+La transición de envolturas de un solo agente a sistemas multi-agente distribuidos requiere una orquestación compleja. Ya no se trata solo de enviar un prompt a un LLM; se trata de gestionar el estado, la resolución de conflictos y el flujo de información entre distintas "personas".
+
+La biblioteca `socratic-agents` proporciona un ecosistema modular para esto. Abstrae el proveedor LLM subyacente (usando clientes universales como Socrates Nexus) y distribuye tareas entre agentes especializados.
+
+### El Escuadrón de Especialización
+
+Aquí está la distribución típica de funciones en una biblioteca de orquestación socrática:
+
+| Agente Especializado | Categoría de Operación | Función Principal |
+| :--- | :--- | :--- |
+| **Consejero Socrático** | Coordinación / Diálogo | Orquesta el diálogo socrático completo, gestionando el ciclo de preguntas, detección de conflictos lógicos y seguimiento de la madurez del flujo dialéctico. |
+| **Generador de Código** | Ejecución | Genera código fuente y completa algoritmos inteligentemente basados en especificaciones. |
+| **Validador de Código** | Ejecución | Diseña, ejecuta y valida pruebas unitarias sobre los entregables del generador. |
+| **Gestor de Conocimiento** | Análisis | Interfaz avanzada con bases de conocimiento indexadas y arquitecturas RAG para proporcionar contexto factual. |
+| **Agente de Aprendizaje** | Gestión | Aprendizaje continuo y detección de patrones de comportamiento históricos en el flujo de trabajo. |
+| **Generador de Habilidades** | Gestión | Generación adaptativa y optimización de habilidades de agentes basadas en métricas de madurez operativa. |
+
+Si eres un desarrollador indie, no necesitas un clúster de Kubernetes masivo para ejecutar esto. Puedes ejecutar todo este escuadrón localmente o mediante funciones en la nube ligeras, coordinadas por Kotlin Coroutines en tu máquina de desarrollo.
+
+---
+
+## Patrones Avanzados de Interacción Dialéctica
+
+Antes de escribir el orquestador en Kotlin, necesitamos entender las metodologías que ejecutará. La investigación académica ha formalizado tres patrones clave de interacción multi-agente que implementaremos.
+
+### 1. MARS (Razonamiento Adaptativo Multi-Agente con Guía Socrática)
+MARS abstrae el espacio de diseño de instrucciones como un Proceso de Decisión de Markov Parcialmente Observable (POMDP). Espera, no dejes que las matemáticas te asusten.
+
+En la práctica, MARS define una tríada: un **Instructor**, un **Crítico** y un **Estudiante**. Se involucran en un diálogo socrático continuo. El Crítico evalúa la salida del Estudiante, pero en lugar de simplemente dar un mensaje de error, envía pseudo-gradientes textuales de vuelta al Instructor. Luego, el Instructor refina el prompt basándose en el cuestionamiento socrático.
+
+### 2. Socratic-Zero
+Este es un sistema tripartito para entrenar habilidades complejas *sin* datos etiquetados.
+*   **Instructor:** Genera un plan de estudio guiado por errores de ejecución.
+*   **Solucionador:** Refina su política de razonamiento utilizando la optimización de preferencias sobre trayectorias válidas/inválidas.
+*   **Generador:** Destila la política de diseño de preguntas, optimizando cómo explorar el espacio de búsqueda.
+
+### 3. MotivGraph-SoIQ (El Motor de Lluvia de Ideas)
+Esto es para la fase de inicio. Integra un Grafo de Conocimiento Motivacional (MotivGraph) con un Interrogador de Ideas Socrático (SoIQ) para mitigar el sesgo de confirmación.
+
+Durante la ideación, un agente "Mentor" asume una postura socrática altamente estricta y adversaria. Interroga a un agente "Investigador" sobre la novedad, viabilidad y coherencia lógica de sus hipótesis. Este diálogo forzado evita que el Investigador tome atajos conceptuales.
+
+Construyamos una versión simplificada del patrón MotivGraph-SoIQ en Kotlin. Construiremos un motor donde un "Agente Desarrollador" intenta proponer una arquitectura, y un "Agente Arquitecto" adversario la cuestiona brutalmente hasta que el diseño es impecable.
+
+---
+
+## Construyendo el Orquestador en Kotlin
+
+Usaremos Kotlin Coroutines (`kotlinx.coroutines`) y `StateFlow` para gestionar el diálogo asíncrono entre los agentes. Usaremos un enfoque funcional para representar el estado del debate.
+
+### 1. Definiendo los Modelos de Dominio
+
+Primero, necesitamos representar el estado de nuestra lluvia de ideas multi-agente.
+
+```kotlin
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+
+// Representa un diseño arquitectónico propuesto
+data class ArchitectureProposal(
+    val id: String,
+    val description: String,
+    val components: List<String>,
+    val complexityScore: Int // 1-10
+)
+
+// Las fases de nuestro flujo Socratic-SoIQ
+enum class BrainstormPhase {
+    SURVEY,       // Recopilación de requisitos iniciales
+    EXPAND,       // Propuesta de arquitectura inicial
+    CRYSTALLIZE,  // Interrogación socrática por el Crítico
+    STRESS_TEST,  // Ataque adversario directo
+    REFINE,       // Finalización de la especificación
+    COMPLETED,
+    FAILED
+}
+
+// El estado general de la sesión de orquestación
+data class OrchestrationState(
+    val phase: BrainstormPhase = BrainstormPhase.SURVEY,
+    val initialProblem: String = "",
+    val currentProposal: ArchitectureProposal? = null,
+    val dialogueHistory: List<String> = emptyList(),
+    val criticalVulnerabilities: List<String> = emptyList(),
+    val isResolved: Boolean = false
+)
+```
+
+### 2. Los Agentes Especializados
+
+Definiremos interfaces para nuestros dos actores principales: El Desarrollador (Generador) y el Arquitecto (Crítico Socrático). En una aplicación real, estas interfaces envolverían llamadas a un proveedor de LLM (como OpenAI, Anthropic o un modelo local).
+
+```kotlin
+interface DeveloperAgent {
+    suspend fun proposeArchitecture(problem: String, constraints: String): ArchitectureProposal
+    suspend fun defendProposal(proposal: ArchitectureProposal, critique: String): String
+    suspend fun refineArchitecture(proposal: ArchitectureProposal, feedback: String): ArchitectureProposal
+}
+
+interface SocraticArchitectAgent {
+    // Fase de Cristalización: Cuestionamiento socrático para encontrar lagunas
+    suspend fun interrogateProposal(proposal: ArchitectureProposal): String?
+
+    // Fase de Prueba de Estrés: Ataque adversario directo
+    suspend fun findVulnerabilities(proposal: ArchitectureProposal): List<String>
+
+    // Evaluar si la defensa del desarrollador es lógicamente sólida
+    suspend fun evaluateDefense(critique: String, defense: String): Boolean
+}
+```
+
+### 3. El Orquestador MotivGraph-SoIQ
+
+Ahora, la lógica central. Este orquestador impulsado por `StateFlow` gestionará los traspasos y los bucles socráticos entre los dos agentes.
+
+```kotlin
+class MultiAgentOrchestrator(
+    private val developer: DeveloperAgent,
+    private val architect: SocraticArchitectAgent,
+    private val coroutineScope: CoroutineScope
+) {
+    private val _state = MutableStateFlow(OrchestrationState())
+    val state: StateFlow<OrchestrationState> = _state.asStateFlow()
+
+    fun startSession(problemStatement: String) {
+        coroutineScope.launch {
+            _state.update { it.copy(initialProblem = problemStatement, phase = BrainstormPhase.EXPAND) }
+            executeExpandPhase()
+        }
+    }
+
+    private suspend fun executeExpandPhase() {
+        println("--- FASE: EXPANDIR ---")
+        val currentState = _state.value
+
+        // El desarrollador propone la idea inicial
+        val proposal = developer.proposeArchitecture(
+            problem = currentState.initialProblem,
+            constraints = "Debe ser mobile-first, con capacidad offline."
+        )
+
+        _state.update {
+            it.copy(
+                currentProposal = proposal,
+                dialogueHistory = it.dialogueHistory + "Dev: Arquitectura propuesta [${proposal.id}]",
+                phase = BrainstormPhase.CRYSTALLIZE
+            )
+        }
+
+        executeCrystallizePhase()
+    }
+
+    private suspend fun executeCrystallizePhase() {
+        println("--- FASE: CRISTALIZAR (Interrogación Socrática) ---")
+        var currentState = _state.value
+        val proposal = currentState.currentProposal ?: return
+
+        var isProposalSolid = false
+        var iterations = 0
+        val MAX_ITERATIONS = 3
+
+        while (!isProposalSolid && iterations < MAX_ITERATIONS) {
+            // El arquitecto hace una pregunta socrática
+            val socraticQuestion = architect.interrogateProposal(proposal)
+
+            if (socraticQuestion == null) {
+                // El Arquitecto no encontró lagunas lógicas.
+                isProposalSolid = true
+                continue
+            }
+
+            _state.update { it.copy(dialogueHistory = it.dialogueHistory + "Arquitecto (Socrático): $socraticQuestion") }
+
+            // El desarrollador debe defender el diseño
+            val defense = developer.defendProposal(proposal, socraticQuestion)
+            _state.update { it.copy(dialogueHistory = it.dialogueHistory + "Dev (Defensa): $defense") }
+
+            // El arquitecto evalúa la defensa
+            val isAccepted = architect.evaluateDefense(socraticQuestion, defense)
+
+            if (!isAccepted) {
+                // Si la defensa es débil, el Desarrollador debe refinar la arquitectura
+                println("Defensa rechazada. Refinando arquitectura...")
+                val refinedProposal = developer.refineArchitecture(proposal, "Aborda esta laguna: $socraticQuestion")
+                _state.update { it.copy(currentProposal = refinedProposal) }
+            } else {
+                isProposalSolid = true
+            }
+            iterations++
+        }
+
+        if (isProposalSolid) {
+            _state.update { it.copy(phase = BrainstormPhase.STRESS_TEST) }
+            executeStressTestPhase()
+        } else {
+            _state.update { it.copy(phase = BrainstormPhase.FAILED) }
+            println("Orquestación fallida: No se pudieron resolver las lagunas arquitectónicas.")
+        }
+    }
+
+    private suspend fun executeStressTestPhase() {
+        println("--- FASE: PRUEBA DE ESTRÉS (Adversaria) ---")
+        val currentState = _state.value
+        val proposal = currentState.currentProposal ?: return
+
+        // El Arquitecto deja de ser un tutor y se convierte en un atacante
+        val vulnerabilities = architect.findVulnerabilities(proposal)
+
+        if (vulnerabilities.isEmpty()) {
+            _state.update { it.copy(phase = BrainstormPhase.REFINE) }
+            executeRefinePhase()
+        } else {
+            _state.update {
+                it.copy(
+                    criticalVulnerabilities = vulnerabilities,
+                    dialogueHistory = it.dialogueHistory + "Arquitecto (Ataque): Vulnerabilidades encontradas: $vulnerabilities"
+                )
+            }
+
+            // Obligar al desarrollador a arreglar las vulnerabilidades antes de continuar
+            val safeProposal = developer.refineArchitecture(proposal, "Arregla estas fallas de seguridad: $vulnerabilities")
+            _state.update { it.copy(currentProposal = safeProposal, phase = BrainstormPhase.REFINE) }
+            executeRefinePhase()
+        }
+    }
+
+    private suspend fun executeRefinePhase() {
+        println("--- FASE: REFINAR ---")
+        // Pulido final de la especificación. En un sistema real, esto generaría un archivo markdown.
+        val finalProposal = _state.value.currentProposal
+        _state.update {
+            it.copy(
+                phase = BrainstormPhase.COMPLETED,
+                isResolved = true,
+                dialogueHistory = it.dialogueHistory + "Orquestador: Arquitectura Final Aprobada."
+            )
+        }
+        println("Arquitectura orquestada y validada con éxito.")
+        println(finalProposal?.description)
+    }
+}
+```
+
+### Analizando la Orquestación en Kotlin
+
+Este código es un plano para la ingeniería de IA defensiva. Observa cómo el flujo está enteramente determinado por el `SocraticArchitectAgent`. El agente desarrollador no puede simplemente generar código y marcar la tarea como completada.
+
+1.  **El Bucle:** `executeCrystallizePhase` impone el paradigma MARS. Es un bucle `while` que no se romperá hasta que el Arquitecto esté satisfecho o se alcance el límite de iteraciones.
+2.  **El Cambio de Postura:** Nota la transición de `executeCrystallizePhase` a `executeStressTestPhase`. En la fase Socrática, el Arquitecto hace preguntas para guiar el descubrimiento. En la fase de Prueba de Estrés, el Arquitecto cambia a una postura adversaria directa. Esto imita el proceso de revisión por pares donde un revisor pasa de "¿Consideraste esto?" a "Esto causará una excepción OOM".
+3.  **Inmortalidad del Estado:** Al respaldar toda la orquestación con un `StateFlow`, podemos serializar fácilmente esta sesión en el disco. Si la orquestación toma 20 minutos (lo cual es común para la planificación arquitectónica compleja), no perdemos el estado si nuestro IDE falla.
+
+## Ejecutando el Orquestador Simulado
+
+Veamos cómo se comporta esto cuando se ejecuta con agentes simulados que representan una solicitud de característica de Android.
+
+```kotlin
+fun main() = runBlocking {
+    val mockDev = object : DeveloperAgent {
+        override suspend fun proposeArchitecture(problem: String, constraints: String) =
+            ArchitectureProposal("V1", "Usar SharedPreferences estándar para sincronización offline.", listOf("Prefs", "WorkManager"), 3)
+
+        override suspend fun defendProposal(proposal: ArchitectureProposal, critique: String) =
+            "SharedPreferences es rápido y síncrono."
+
+        override suspend fun refineArchitecture(proposal: ArchitectureProposal, feedback: String) =
+            ArchitectureProposal("V2", "Usar Base de Datos Room con Flow para sincronización offline reactiva.", listOf("Room", "Flow"), 7)
+    }
+
+    val mockArchitect = object : SocraticArchitectAgent {
+        override suspend fun interrogateProposal(proposal: ArchitectureProposal): String? {
+            return if (proposal.description.contains("SharedPreferences")) {
+                "Propusiste SharedPreferences para la sincronización offline. Dado que SharedPreferences no es seguro para subprocesos para objetos complejos y se ejecuta sincrónicamente, ¿cómo evitarás el bloqueo de la UI durante operaciones de sincronización masiva?"
+            } else null
+        }
+
+        override suspend fun evaluateDefense(critique: String, defense: String): Boolean {
+            return defense.contains("Room") || defense.contains("Flow") // Rechazar defensas débiles
+        }
+
+        override suspend fun findVulnerabilities(proposal: ArchitectureProposal) = emptyList<String>()
+    }
+
+    val orchestrator = MultiAgentOrchestrator(mockDev, mockArchitect, this)
+
+    // Empezar a observar los cambios de estado
+    launch {
+        orchestrator.state.collect { state ->
+            println("Fase Actual: ${state.phase}")
+        }
+    }
+
+    orchestrator.startSession("Implementar sincronización robusta offline del perfil de usuario.")
+
+    // Esperar a que termine la orquestación
+    delay(2000)
+}
+```
+
+**Registro de Salida:**
+```text
+Fase Actual: SURVEY
+Fase Actual: EXPAND
+--- FASE: EXPANDIR ---
+Fase Actual: CRYSTALLIZE
+--- FASE: CRISTALIZAR (Interrogación Socrática) ---
+Defensa rechazada. Refinando arquitectura...
+--- FASE: PRUEBA DE ESTRÉS (Adversaria) ---
+Fase Actual: STRESS_TEST
+--- FASE: REFINAR ---
+Arquitectura orquestada y validada con éxito.
+Fase Actual: COMPLETED
+Usar Base de Datos Room con Flow para sincronización offline reactiva.
+```
+
+El sistema funciona exactamente como se pretendía. La propuesta inicial perezosa del Agente Desarrollador (`SharedPreferences`) fue interceptada, interrogada, rechazada y forzada a un refinamiento robusto (`Room` + `Flow`) sin ninguna intervención humana.
+
+## El Futuro del Desarrollo Indie
+
+La transición a la orquestación socrática multi-agente es profunda. Ya no estamos programando la aplicación; estamos programando el equipo que programa la aplicación.
+
+Como desarrollador indie, esto nivela el campo de juego. No necesito un equipo de diez ingenieros senior para revisar mi arquitectura. Puedo definir un `SocraticArchitectAgent` con la personalidad de un arquitecto de sistemas experto, darle el mandato de ser implacablemente crítico y dejar que pruebe las propuestas de mi `DeveloperAgent` en segundo plano mientras duermo.
+
+### Concluyendo la Serie
+
+A lo largo de estos tres artículos, hemos viajado desde las matemáticas teóricas hasta el código Kotlin práctico.
+
+*   En la **Parte 1**, aprendimos que la duda es matemática, y que la reducción de la entropía a través de la fricción socrática es la cura para la alucinación de la IA.
+*   En la **Parte 2**, aprendimos que el Desarrollo Dirigido por Especificaciones (SDD) proporciona el ancla de la verdad, y que las "Compuertas de Comprensión" (CI Gates) nos protegen de la peligrosa sicofancia de las IA complacientes.
+*   En la **Parte 3**, construimos el motor: un orquestador multi-agente que usa StateFlow para gestionar un diálogo socrático, asegurando que cada decisión arquitectónica sea probada en batalla antes de convertirse en código.
+
+La era del desarrollador solitario escribiendo cada línea de código está terminando. La era del orquestador indie —el director de una sinfonía de agentes socráticos— apenas comienza. Construye tus especificaciones, haz cumplir tus compuertas y deja que los agentes debatan.
+
+## Escalando la Orquestación: Gestionando Estado y Memoria
+
+El ejemplo anterior es una abstracción simplificada. En un entorno de producción, una sesión de orquestación para una característica compleja (como implementar un flujo OAuth2 completo con actualización de tokens offline) implicará cientos de transiciones de estado y miles de tokens de contexto.
+
+Gestionar este estado se convierte en el principal desafío de ingeniería.
+
+### El Problema de las Ventanas de Contexto
+
+Los LLMs tienen ventanas de contexto finitas. Si el diálogo socrático entre el Desarrollador y el Arquitecto continúa durante veinte turnos, la ventana de contexto se llenará y los agentes comenzarán a "olvidar" las restricciones iniciales de la especificación.
+
+Para resolver esto, nuestro orquestador necesita implementar una estrategia de **Compresión de Contexto** dentro de `executeCrystallizePhase`.
+
+En lugar de agregar cada línea individual de diálogo al `dialogueHistory`, el orquestador puede generar periódicamente un "Agente Resumidor" especializado e independiente.
+
+```kotlin
+interface SummarizerAgent {
+    suspend fun compressDialogue(history: List<String>): String
+}
+
+// Dentro de executeCrystallizePhase...
+if (_state.value.dialogueHistory.size > 10) {
+    val compressed = summarizerAgent.compressDialogue(_state.value.dialogueHistory)
+    _state.update { it.copy(dialogueHistory = listOf("Resumen: $compressed")) }
+}
+```
+
+Esto asegura que los agentes Arquitecto y Desarrollador solo retengan la *esencia destilada* de sus argumentos anteriores, liberando la ventana de contexto para un razonamiento analítico profundo sobre la pregunta socrática actual.
+
+### Memoria Jerárquica Persistente
+
+Además, las decisiones tomadas durante estas sesiones de orquestación no pueden ser efímeras. Cuando el orquestador alcanza `BrainstormPhase.COMPLETED`, la `ArchitectureProposal` final debe confirmarse en la memoria permanente del proyecto.
+
+Aquí es donde la integración con un framework como `hmem` (Memoria Jerárquica para Agentes) es vital. El orquestador debe tener un paso final que escriba la arquitectura resuelta de vuelta en el repositorio como un Registro de Decisiones de Arquitectura (ADR) en formato Markdown.
+
+```kotlin
+private suspend fun executeRefinePhase() {
+    println("--- FASE: REFINAR ---")
+    val finalProposal = _state.value.currentProposal!!
+
+    // Convertir la propuesta en un documento ADR formal en Markdown
+    val adrMarkdown = developer.generateAdrDocument(finalProposal, _state.value.dialogueHistory)
+
+    // Guardar en el sistema de archivos local del proyecto
+    fileSystem.writeText("docs/adr/ADR-${finalProposal.id}.md", adrMarkdown)
+
+    _state.update {
+        it.copy(
+            phase = BrainstormPhase.COMPLETED,
+            isResolved = true
+        )
+    }
+}
+```
+
+Al persistir la salida como un ADR, nos aseguramos de que futuras sesiones socráticas —tal vez meses después, sobre una característica diferente— tengan acceso al contexto histórico de *por qué* se eligió esta arquitectura específica.
+
+## La Realidad Operativa de la Orquestación Socrática
+
+Adoptar esta arquitectura no está exento de fricción. Cambia fundamentalmente el ritmo de desarrollo.
+
+Cuando usas un único agente "copiloto", experimentas un golpe de dopamina de generación de código inmediata (aunque a menudo defectuosa). Cuando usas un Orquestador Socrático, experimentas el trabajo lento y metódico de la ingeniería de software.
+
+Pasarás más tiempo viendo a los agentes discutir en tu terminal del que pasarás escribiendo código. Verás al agente Desarrollador proponer una solución que parece perfectamente razonable, solo para ver al agente Arquitecto desmantelarla sin piedad porque viola una restricción de memoria definida en tu archivo `CLAUDE.md`.
+
+Esto es exactamente lo que se supone que debe suceder.
+
+El objetivo de la Orquestación Socrática Multi-Agente es adelantar el dolor del desarrollo de software. Obliga al sistema a confrontar las vulnerabilidades arquitectónicas en el espacio abstracto del lenguaje y la lógica, en lugar de en el espacio concreto de una interrupción de producción a las 3 AM.
+
+Como desarrolladores indie, no podemos permitirnos desplegar código frágil. No tenemos equipos SRE para monitorizar nuestra infraestructura. Nuestro código debe ser resiliente por diseño. Al abrazar la fricción socrática de la orquestación multi-agente, construimos esa resiliencia directamente en el ADN de nuestro proceso de desarrollo.
+
+## Explorando Topologías de Orquestación Alternativas
+
+El patrón inspirado en `MotivGraph-SoIQ` que implementamos arriba es una topología lineal y adversaria. Es altamente efectivo para refinar una única arquitectura propuesta. Sin embargo, en las primeras etapas de un proyecto, podrías necesitar una topología diferente diseñada para la exploración divergente en lugar del refinamiento convergente.
+
+### La Topología de Mesa Redonda
+
+En lugar de un binario Desarrollador-Arquitecto, imagina una orquestación de mesa redonda que involucra a cuatro agentes especializados:
+
+1.  **El Pragmático:** Se centra en la entrega del MVP, la velocidad y el uso de tecnología establecida y aburrida (ej., SQLite estándar, REST estándar).
+2.  **El Visionario:** Propone soluciones de vanguardia, empujando los límites de lo posible (ej., inferencia LLM local, computación en el borde (edge computing), sincronización descentralizada).
+3.  **El Oficial de Seguridad:** Centrado únicamente en el modelado de amenazas, privacidad de datos y vulnerabilidades OWASP.
+4.  **El Moderador Socrático:** Gestiona los turnos, asegurando que cada agente responda directamente a los puntos planteados por los demás, evitando que la conversación degenere en monólogos paralelos.
+
+Podemos modelar esto en Kotlin usando un `StateFlow` más complejo y canales (Channels) de Coroutines.
+
+```kotlin
+// Estructura de ejemplo para un Orquestador de Mesa Redonda
+interface DebateAgent {
+    val persona: String
+    suspend fun provideInput(topic: String, currentDebateState: String): String
+}
+
+class RoundTableOrchestrator(
+    private val agents: List<DebateAgent>,
+    private val moderator: SocraticModeratorAgent,
+    private val scope: CoroutineScope
+) {
+    // ... Gestión de estado ...
+
+    suspend fun executeDebateRound(topic: String) {
+        val roundInputs = mutableListOf<String>()
+
+        // Ejecutar agentes concurrentemente para pensamiento divergente
+        val deferredInputs = agents.map { agent ->
+            scope.async {
+                val input = agent.provideInput(topic, getFormattedDebateHistory())
+                "${agent.persona}: $input"
+            }
+        }
+
+        roundInputs.addAll(deferredInputs.awaitAll())
+
+        // El moderador interviene para sintetizar y hacer preguntas socráticas
+        val moderatorSynthesis = moderator.synthesizeAndProbe(roundInputs)
+
+        updateDebateHistory(roundInputs, moderatorSynthesis)
+    }
+}
+```
+
+Esta topología es increíblemente poderosa para explorar los "desconocidos desconocidos" (unknown unknowns). Al obligar al Pragmático y al Visionario a debatir, moderados por el cuestionamiento socrático, la síntesis arquitectónica resultante es a menudo muy superior a lo que cualquier agente individual (o humano) habría ideado por sí solo.
+
+## Integrando la Orquestación en el IDE
+
+Ejecutar estos orquestadores desde un script de terminal está bien para la experimentación, pero para una verdadera productividad, esto necesita integrarse directamente en el entorno del desarrollador.
+
+El futuro de las herramientas de desarrollo de Android probablemente involucrará plugins de IDE que ejecuten estas orquestaciones de manera transparente.
+
+Imagina resaltar un bloque de código o una especificación en markdown en Android Studio, hacer clic derecho y seleccionar "Iniciar Revisión Socrática". El IDE activaría el orquestador local, ejecutaría el bucle socrático entre los agentes en segundo plano y presentaría la crítica arquitectónica sintetizada directamente en línea, de manera similar a cómo aparecen hoy las advertencias de análisis estático.
+
+Esta integración perfecta marcará el momento en que la IA Agéntica pasará de ser una novedad a un requisito de ingeniería indispensable.
+
+## Las Matemáticas Detrás del Debate Multi-Agente
+
+Revisemos los fundamentos matemáticos que establecimos en la Parte 1 y veamos cómo se aplican al orquestador multi-agente. Hablamos de la Entropía de Shannon ($\mathcal{H}$) y la Divergencia de Kullback-Leibler (KL). ¿Cómo gobiernan estas métricas la interacción entre nuestro `DeveloperAgent` y nuestro `SocraticArchitectAgent`?
+
+En un sistema multi-agente, no solo estamos midiendo la entropía del espacio de la tarea en relación con la intención del usuario. Estamos midiendo la entropía del *espacio de solución propuesto* en relación con las *restricciones de la especificación*.
+
+### La Entropía como Medida de Ambigüedad Arquitectónica
+
+Cuando el agente Desarrollador propone una arquitectura (ej., "Usar Base de Datos Room con Flow"), el agente Arquitecto calcula la entropía de esa propuesta contra las restricciones conocidas.
+
+Si la especificación (el artefacto SDD que discutimos en la Parte 2) establece: *Restricción: El sistema debe manejar 10,000 escrituras offline concurrentes por segundo sin perder frames.*
+
+La propuesta "Usar Room con Flow" es altamente entrópica en relación con esa restricción. Room es genial, pero ¿cómo se procesan por lotes las escrituras? ¿Cuál es la estrategia de transacciones? ¿Estamos usando un Registro de Escritura Anticipada (WAL)? La propuesta carece de la especificidad requerida para garantizar la restricción.
+
+El trabajo del agente Arquitecto es hacer la pregunta socrática que reduzca al máximo esta entropía específica.
+
+### Divergencia KL en la Revisión por Pares
+
+Además, el agente Arquitecto debe respetar los límites de Divergencia KL al interactuar con el agente Desarrollador. No debería decir: "Tu propuesta es mala, usa un WAL y agrupa las escrituras en lotes cada 50ms". Eso es instrucción, no inducción socrática. Colapsa el espacio de estado por coacción, perdiendo potencialmente una solución mejor y novedosa que el agente Desarrollador podría haber generado.
+
+En cambio, la consulta socrática debe formularse para mantener el equilibrio erotético: *"Dada la restricción de 10,000 escrituras concurrentes/seg, ¿cómo gestiona tu implementación de Room la contención de bloqueos de SQLite y la sobrecarga de transacciones para evitar la inanición del hilo de la UI?"*
+
+Esta pregunta obliga al agente Desarrollador a explorar el subespacio de la gestión de transacciones de SQLite, reduciendo la entropía sin dictar explícitamente la implementación.
+
+## Recuperación Avanzada de Errores en la Orquestación
+
+¿Qué sucede cuando la orquestación falla? En nuestro código Kotlin, teníamos un estado `BrainstormPhase.FAILED`. Pero simplemente fallar y lanzar una excepción es una mala ingeniería. Un orquestador robusto debe tener mecanismos sofisticados de recuperación de errores.
+
+### El Papel del "Agente Consejero"
+
+Si los agentes Desarrollador y Arquitecto llegan a un punto muerto —tal vez el Desarrollador propone repetidamente una solución que el Arquitecto rechaza repetidamente por la misma vulnerabilidad— el orquestador necesita un mecanismo de intervención.
+
+Aquí es donde entra en juego el agente `Consejero Socrático` del ecosistema `socratic-agents`. El Consejero supervisa los metadatos del debate.
+
+```kotlin
+interface SocraticCounselor {
+    // Analiza el historial de diálogo en busca de puntos muertos o argumentos circulares
+    suspend fun detectDeadlock(history: List<String>): Boolean
+
+    // Propone una meta-pregunta para romper el punto muerto
+    suspend fun intervene(history: List<String>): String
+}
+```
+
+Si el orquestador detecta que el bucle `executeCrystallizePhase` se acerca a sus `MAX_ITERATIONS` sin progreso, pausa el debate e invoca al Consejero.
+
+El Consejero analiza el historial del chat. Podría darse cuenta de que el Desarrollador y el Arquitecto están operando bajo suposiciones fundamentalmente diferentes sobre las capacidades de hardware del dispositivo Android objetivo.
+
+El Consejero inyectará entonces una meta-pregunta en el debate: *"Parece que hay un conflicto con respecto al rendimiento de SQLite. Desarrollador, ¿estás asumiendo un perfil de almacenamiento NVMe de gama alta, y Arquitecto, estás asumiendo un perfil eMMC de gama baja? Debemos definir la línea base de hardware mínima antes de continuar."*
+
+Esta meta-intervención rompe el argumento circular, fuerza la aclaración de las suposiciones subyacentes y permite que el bucle socrático se reanude productivamente.
+
+## El Arsenal del Desarrollador Indie
+
+Construir y mantener estos sistemas de orquestación puede parecer desalentador para un desarrollador en solitario. Pero la realidad es que la lógica central —máquinas de estado, corrutinas y llamadas a API— es ingeniería Android estándar.
+
+La complejidad radica en la ingeniería de prompts y el ajuste del comportamiento de los agentes. Sin embargo, a medida que la biblioteca `socratic-agents` y los ecosistemas de código abierto similares maduren, tendremos acceso a personas de agentes pre-ajustadas y plantillas de orquestación.
+
+No tendrás que escribir el prompt para el "Arquitecto Adversario" desde cero. Lo importarás, lo configurarás con los archivos `CLAUDE.md` y `SKILL.md` de tu proyecto, y lo soltarás en tu orquestador Kotlin.
+
+La verdadera habilidad del desarrollador indie en 2026 y más allá no será memorizar la sintaxis de la API. Será el pensamiento sistémico. Será la capacidad de diseñar especificaciones, configurar compuertas socráticas y orquestar agentes inteligentes para construir software resiliente de clase mundial.
+
+Al dominar la Inducción Socrática, el Desarrollo Dirigido por Especificaciones y la Orquestación Multi-Agente, no solo estamos escribiendo mejor código; estamos construyendo una base matemática más rigurosa para el futuro de la ingeniería de software.


### PR DESCRIPTION
## Resumen

Nueva serie de artículos sobre Socratic Agents para el blog de ArceApps.

## Artículos añadidos

### English
- Socratic Agents Part 1: Induction, Entropy and KL Divergence
- Socratic Agents Part 2: SDD and Sycophancy
- Socratic Agents Part 3: Multi-Agent Orchestrator

### Spanish  
- Agentes Socráticos Parte 1: Inducción, Entropía y Divergencia KL
- Agentes Socráticos Parte 2: SDD y Sicophancy
- Agentes Socráticos Parte 3: Orquestador Multi-Agente

## Notas

- Solo añade los 6 archivos nuevos de la serie Socratic Agents
- No modifica ningún archivo existente (fixes de OpenSpec ya están en main)