### PR TITLE
fix(layout): add initial-scale=1.0 to viewport meta tag

### DIFF
--- a/src/content/devlog/en/responsive-visual-hierarchy-2024.md
+++ b/src/content/devlog/en/responsive-visual-hierarchy-2024.md
@@ -505,7 +505,7 @@ const socialImageURL = new URL(image, Astro.url);
 <html lang={lang} class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <link rel="apple-touch-icon" href="/logo.png" />
     <link rel="canonical" href={canonicalURL} />

--- a/src/content/devlog/es/responsive-visual-hierarchy-2024.md
+++ b/src/content/devlog/es/responsive-visual-hierarchy-2024.md
@@ -505,7 +505,7 @@ const socialImageURL = new URL(image, Astro.url);
 <html lang={lang} class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <link rel="apple-touch-icon" href="/logo.png" />
     <link rel="canonical" href={canonicalURL} />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -40,7 +40,7 @@ const socialImageURL = new URL(image, Astro.url);
 <html lang={lang} class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <link rel="apple-touch-icon" href="/logo.png" />
     <link rel="canonical" href={canonicalURL} />


### PR DESCRIPTION
Agregada la propiedad `initial-scale=1.0` a la etiqueta viewport en `Layout.astro` para forzar a los dispositivos móviles a usar el ancho de la pantalla y no una simulación de escritorio. Además se sincronizó esta corrección con la documentación del devlog.

---
*PR created automatically by Jules for task [18166973512474732016](https://jules.google.com/task/18166973512474732016) started by @ArceApps*