### PR TITLE
feat: add Semantic Code Search Tools bilingual articles (CocoIndex Code + CodeGraph)

### DIFF
--- a/public/images/blog-semantic-code-search.svg
+++ b/public/images/blog-semantic-code-search.svg
@@ -1,0 +1,141 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" width="800" height="450">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0d1b2a"/>
+      <stop offset="50%" stop-color="#1b263b"/>
+      <stop offset="100%" stop-color="#0d1b2a"/>
+    </linearGradient>
+    <linearGradient id="teal" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#018786"/>
+      <stop offset="100%" stop-color="#00b3b3"/>
+    </linearGradient>
+    <linearGradient id="orange" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#FF9800"/>
+      <stop offset="100%" stop-color="#ffb74d"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softGlow">
+      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="450" fill="url(#bg)"/>
+
+  <!-- Grid lines (subtle) -->
+  <g stroke="#018786" stroke-width="0.5" opacity="0.1">
+    <line x1="0" y1="90" x2="800" y2="90"/>
+    <line x1="0" y1="180" x2="800" y2="180"/>
+    <line x1="0" y1="270" x2="800" y2="270"/>
+    <line x1="0" y1="360" x2="800" y2="360"/>
+    <line x1="160" y1="0" x2="160" y2="450"/>
+    <line x1="320" y1="0" x2="320" y2="450"/>
+    <line x1="480" y1="0" x2="480" y2="450"/>
+    <line x1="640" y1="0" x2="640" y2="450"/>
+  </g>
+
+  <!-- Left node: CocoIndex (tree structure) -->
+  <g transform="translate(100, 200)">
+    <!-- Root node -->
+    <circle cx="0" cy="0" r="25" fill="url(#teal)" filter="url(#glow)" opacity="0.9"/>
+    <!-- Lines to children -->
+    <line x1="0" y1="25" x2="-40" y2="70" stroke="#018786" stroke-width="2" opacity="0.6"/>
+    <line x1="0" y1="25" x2="0" y2="70" stroke="#018786" stroke-width="2" opacity="0.6"/>
+    <line x1="0" y1="25" x2="40" y2="70" stroke="#018786" stroke-width="2" opacity="0.6"/>
+    <!-- Child nodes -->
+    <circle cx="-40" cy="70" r="15" fill="url(#teal)" opacity="0.7"/>
+    <circle cx="0" cy="70" r="15" fill="url(#teal)" opacity="0.7"/>
+    <circle cx="40" cy="70" r="15" fill="url(#teal)" opacity="0.7"/>
+    <!-- Label -->
+    <text x="0" y="110" font-family="monospace" font-size="11" fill="#00b3b3" text-anchor="middle" filter="url(#softGlow)">CocoIndex</text>
+    <text x="0" y="124" font-family="monospace" font-size="9" fill="#ffffff" text-anchor="middle" opacity="0.6">embeddings</text>
+  </g>
+
+  <!-- Center: Semantic search icon -->
+  <g transform="translate(400, 200)">
+    <!-- Magnifying glass outer -->
+    <circle cx="0" cy="-20" r="50" fill="none" stroke="url(#teal)" stroke-width="6" opacity="0.8" filter="url(#glow)"/>
+    <!-- Handle -->
+    <line x1="35" y1="15" x2="70" y2="50" stroke="url(#orange)" stroke-width="8" stroke-linecap="round" filter="url(#glow)"/>
+    <!-- Code brackets inside -->
+    <text x="-20" y="-15" font-family="monospace" font-size="35" fill="#ffffff" opacity="0.9">&lt;</text>
+    <text x="5" y="-15" font-family="monospace" font-size="35" fill="#ffffff" opacity="0.9">/&gt;</text>
+    <!-- Label below -->
+    <text x="0" y="60" font-family="sans-serif" font-size="13" fill="#FF9800" text-anchor="middle" font-weight="bold">SEMANTIC</text>
+    <text x="0" y="76" font-family="sans-serif" font-size="11" fill="#ffffff" text-anchor="middle" opacity="0.7">code search</text>
+  </g>
+
+  <!-- Right node: CodeGraph (graph structure) -->
+  <g transform="translate(650, 200)">
+    <!-- Central node -->
+    <circle cx="0" cy="0" r="25" fill="url(#orange)" filter="url(#glow)" opacity="0.9"/>
+    <!-- Connected nodes in ring -->
+    <circle cx="-55" cy="-30" r="12" fill="url(#orange)" opacity="0.7"/>
+    <circle cx="55" cy="-30" r="12" fill="url(#orange)" opacity="0.7"/>
+    <circle cx="-55" cy="30" r="12" fill="url(#orange)" opacity="0.7"/>
+    <circle cx="55" cy="30" r="12" fill="url(#orange)" opacity="0.7"/>
+    <circle cx="0" cy="-65" r="12" fill="url(#orange)" opacity="0.7"/>
+    <circle cx="0" cy="65" r="12" fill="url(#orange)" opacity="0.7"/>
+    <!-- Lines from center to ring -->
+    <line x1="-20" y1="-15" x2="-45" y2="-25" stroke="#FF9800" stroke-width="2" opacity="0.5"/>
+    <line x1="20" y1="-15" x2="45" y2="-25" stroke="#FF9800" stroke-width="2" opacity="0.5"/>
+    <line x1="-20" y1="15" x2="-45" y2="25" stroke="#FF9800" stroke-width="2" opacity="0.5"/>
+    <line x1="20" y1="15" x2="45" y2="25" stroke="#FF9800" stroke-width="2" opacity="0.5"/>
+    <line x1="0" y1="-25" x2="0" y2="-55" stroke="#FF9800" stroke-width="2" opacity="0.5"/>
+    <line x1="0" y1="25" x2="0" y2="55" stroke="#FF9800" stroke-width="2" opacity="0.5"/>
+    <!-- Label -->
+    <text x="0" y="100" font-family="monospace" font-size="11" fill="#FF9800" text-anchor="middle" filter="url(#softGlow)">CodeGraph</text>
+    <text x="0" y="114" font-family="monospace" font-size="9" fill="#ffffff" text-anchor="middle" opacity="0.6">knowledge graph</text>
+  </g>
+
+  <!-- Connecting arrows between left and center -->
+  <g fill="none" stroke="url(#teal)" stroke-width="2" opacity="0.5">
+    <path d="M 180 200 C 230 200 270 200 320 200" marker-end="url(#arrowTeal)"/>
+  </g>
+
+  <!-- Connecting arrows between center and right -->
+  <g fill="none" stroke="url(#orange)" stroke-width="2" opacity="0.5">
+    <path d="M 480 200 C 530 200 570 200 600 200" marker-end="url(#arrowOrange)"/>
+  </g>
+
+  <defs>
+    <marker id="arrowTeal" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#018786"/>
+    </marker>
+    <marker id="arrowOrange" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#FF9800"/>
+    </marker>
+  </defs>
+
+  <!-- Token savings badge -->
+  <g transform="translate(400, 380)">
+    <rect x="-80" y="-25" width="160" height="50" rx="25" fill="#018786" opacity="0.2" stroke="#018786" stroke-width="1.5"/>
+    <text x="0" y="5" font-family="sans-serif" font-size="16" fill="#00b3b3" text-anchor="middle" font-weight="bold" filter="url(#softGlow)">70-92%</text>
+    <text x="0" y="22" font-family="sans-serif" font-size="11" fill="#ffffff" text-anchor="middle" opacity="0.8">token savings</text>
+  </g>
+
+  <!-- Speed improvement badge -->
+  <g transform="translate(550, 380)">
+    <rect x="-60" y="-25" width="120" height="50" rx="25" fill="#FF9800" opacity="0.2" stroke="#FF9800" stroke-width="1.5"/>
+    <text x="0" y="5" font-family="sans-serif" font-size="16" fill="#FF9800" text-anchor="middle" font-weight="bold" filter="url(#softGlow)">71%</text>
+    <text x="0" y="22" font-family="sans-serif" font-size="11" fill="#ffffff" text-anchor="middle" opacity="0.8">faster</text>
+  </g>
+
+  <!-- Android/Kotlin badge -->
+  <g transform="translate(250, 380)">
+    <rect x="-70" y="-25" width="140" height="50" rx="25" fill="#3DDC84" opacity="0.15" stroke="#3DDC84" stroke-width="1.5"/>
+    <text x="0" y="5" font-family="sans-serif" font-size="14" fill="#3DDC84" text-anchor="middle" font-weight="bold">Kotlin</text>
+    <text x="0" y="22" font-family="sans-serif" font-size="11" fill="#ffffff" text-anchor="middle" opacity="0.8">Android Ready</text>
+  </g>
+
+  <!-- Title area -->
+  <text x="400" y="45" font-family="sans-serif" font-size="20" font-weight="bold" fill="url(#teal)" text-anchor="middle" filter="url(#glow)">Semantic Code Search for AI Agents</text>
+  <text x="400" y="68" font-family="sans-serif" font-size="12" fill="#ffffff" text-anchor="middle" opacity="0.7">CocoIndex Code + CodeGraph | Vector embeddings meets knowledge graphs</text>
+
+  <!-- Bottom accent line -->
+  <rect x="0" y="435" width="800" height="15" fill="url(#teal)" opacity="0.3"/>
+</svg>

--- a/src/content/blog/en/blog-semantic-code-search-tools.md
+++ b/src/content/blog/en/blog-semantic-code-search-tools.md
@@ -1,0 +1,501 @@
+---
+title: "Semantic Code Search Tools for AI Coding Agents: CocoIndex Code and CodeGraph"
+description: "A comprehensive comparison of CocoIndex Code and CodeGraph — two AST-based semantic code search tools that dramatically reduce token consumption and accelerate code exploration for AI coding agents like Claude Code."
+pubDate: 2026-05-19
+heroImage: "/images/blog-semantic-code-search.svg"
+tags: ["AI", "Code Search", "Claude Code", "Development Tools", "CocoIndex", "CodeGraph", "Semantic Search", "Android", "Kotlin", "Productivity"]
+reference_id: "b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e"
+---
+
+> **Related reads:** [Spec-Driven Development with Agentic AI](/blog/spec-driven-development-ai) · [Complete Guide: Stack Recommended for Building AI Agents in 2026](/blog/complete-beginners-guide-ai-agents-stack-2026) · [AI Agents in Android Development](/blog/blog-ai-agents-workflow-android)
+
+When you work with an AI coding agent on a large codebase, you have probably noticed something frustrating: the agent spends a significant portion of its token budget navigating the code. Before it can implement a feature or fix a bug, it needs to understand the surrounding context. It fires off grep commands, glob patterns, and find operations — searching for the right file, the relevant function, the correct abstraction. This exploration phase consumes tokens that could be spent actually writing code.
+
+The problem gets worse as the codebase grows. A clean Android project with proper layering might have hundreds of Kotlin files. The agent needs to understand the repository pattern here, the coroutine usage there, the ViewModel conventions everywhere. Without semantic understanding, it falls back to textual search — which means you pay for the agent to read files that are only *partially* relevant, because the words match but the semantics do not.
+
+Two tools have emerged to solve this problem: **CocoIndex Code** and **CodeGraph**. Both use Abstract Syntax Tree (AST) parsing to build a semantic index of your codebase, enabling AI agents to find exactly what they need in one query. But they take different approaches — CocoIndex Code uses vector embeddings with asymmetric retrieval, while CodeGraph builds a knowledge graph with call graph analysis. This article examines both tools in depth, with concrete benchmarks, use cases, and practical guidance for Android and Kotlin development.
+
+---
+
+## The Problem: Context Window Waste in AI Coding Sessions
+
+Every AI coding agent — whether Claude Code, Cursor, Codex, or OpenCode — operates within a context window. The model can only consider a limited amount of code at once, and every file you include consumes tokens from that budget. The standard workflow for exploring a codebase today looks like this:
+
+1. The agent fires a glob pattern to find relevant files
+2. It reads multiple files to understand the architecture
+3. It searches for function definitions with grep
+4. It reads more files to trace call chains
+5. Only then does it start the actual work
+
+For a medium-sized Android project, steps 1-4 can consume 20-40% of the session's token budget before a single line of production code is written. For larger projects with 500+ Kotlin files, this exploration overhead becomes the dominant cost.
+
+The root cause is that **textual search does not understand code structure**. A grep for "Repository" returns every file containing that word, including test files, documentation, and unrelated classes. The agent must then read each result to determine which one is the actual repository interface it needs.
+
+Semantic code search tools solve this by building an index that understands the AST — the actual structure of your code. Function definitions, class hierarchies, call relationships, and type information are all indexed. When an agent queries for "the repository interface used in the login flow," it gets exactly that — not 47 files containing the word "Repository."
+
+---
+
+## CocoIndex Code: AST-Based Semantic Search with Vector Embeddings
+
+**CocoIndex Code** (from cocoindex-io/cocoindex-code) is a CLI tool that indexes your codebase using AST parsing and stores embeddings in a vector database. When you search, it finds semantically similar code based on meaning rather than keyword matching.
+
+### How It Works
+
+CocoIndex Code parses your source files into ASTs, extracts meaningful chunks (function bodies, class definitions, interface contracts), and generates embeddings using a transformer model. These embeddings capture semantic relationships — code that serves a similar purpose will have similar vectors, even if the variable names are completely different.
+
+The default local model is **Snowflake/snowflake-arctic-embed-xs**, which is fast and free, requires no API key, and works entirely offline. For better accuracy on code-specific queries, the recommended local model is **nomic-ai/CodeRankEmbed** (137M parameters, 8192 token context window). If you prefer cloud-based embeddings, CocoIndex Code supports over 100 providers through LiteLLM: OpenAI, Voyage code-3, Cohere v4, Google Gemini, Azure, AWS Bedrock, Ollama, and others.
+
+### Installation and Setup
+
+Getting started with CocoIndex Code takes about one minute with zero configuration required for most projects:
+
+```bash
+# For local (offline) operation with free embeddings — no API key needed
+pipx install "cocoindex-code[full]"
+
+# For cloud-based operation with API key
+pipx install cocoindex-code
+```
+
+After installation, initialize the index for your project:
+
+```bash
+ccc init
+ccc index
+```
+
+The `ccc doctor` command verifies your setup if anything goes wrong, and `ccc reset` clears everything if you need a fresh start. A Docker option is also available:
+
+```bash
+# Lite version (~450MB) — uses cloud embeddings
+docker run -it cocoindex/cocoindex-code:latest
+
+# Full version (~5GB) — includes local sentence-transformers for offline embedding
+docker run -it cocoindex/cocoindex-code:full
+```
+
+The Docker approach is particularly useful for teams because the container keeps the embedding model warm across sessions, avoiding the cold-start penalty of loading a 5GB model every time.
+
+### The CLI Commands
+
+CocoIndex Code exposes a clean set of commands:
+
+| Command | Purpose |
+|---------|---------|
+| `ccc init` | Initialize the index configuration |
+| `ccc index` | Build the semantic index |
+| `ccc search <query>` | Search the codebase semantically |
+| `ccc status` | Show index statistics |
+| `ccc doctor` | Diagnose setup issues |
+| `ccc reset` | Clear and rebuild index |
+| `ccc daemon status/restart/stop` | Manage background daemon |
+| `ccc mcp` | Start MCP server in stdio mode |
+
+For MCP integration (Model Context Protocol), run `ccc mcp` to connect with AI agents that support MCP tools. This allows the agent to query the semantic index directly without leaving the conversation.
+
+### Token Savings: 70% Reduction
+
+The primary selling point of CocoIndex Code is its token efficiency. According to the project's benchmarks, the semantic index enables AI agents to find relevant context with **70% fewer tokens** compared to naive file inclusion. This is because:
+
+1. **Exact matching over fuzzy search**: Instead of reading 20 partially-relevant files identified by grep, the agent reads only the 3 files that are semantically relevant.
+2. **Chunk-level retrieval**: The index stores embeddings at the function/class level, so the agent receives only the relevant code sections, not entire files.
+3. **Asymmetric retrieval**: CocoIndex Code supports indexing parameters optimized for code search (using models like Cohere, Voyage, or Snowflake Arctic that are trained on code-specific retrieval tasks).
+
+### Language Support
+
+CocoIndex Code supports an impressive range of languages through tree-sitter parsers: C, C++, C#, CSS, DTD, Fortran, Go, HTML, Java, JavaScript, JSON, Kotlin, Lua, Markdown, Pascal, PHP, Python, R, Ruby, Rust, Scala, Solidity, SQL, Svelte, Swift, TOML, TSX, TypeScript, Vue, XML, and YAML. Kotlin and Java support is particularly relevant for Android development.
+
+### Configuration
+
+Two configuration files control behavior:
+
+- `~/.cocoindex_code/global_settings.yml` — user-wide settings
+- `.cocoindex_code/settings.yml` — project-specific overrides
+
+You can tune `indexing_params` and `query_params` to switch between embedding models or adjust retrieval behavior. The project-level config allows different teams to use different models or indexing strategies per repository.
+
+---
+
+## CodeGraph: Knowledge Graph with Call Graph Analysis
+
+**CodeGraph** (from colbymchenry/codegraph) takes a different approach. Instead of vector embeddings, it builds a **knowledge graph** from AST parsing. Each AST node becomes a vertex; relationships (call, inheritance, import, reference) become edges. This creates a rich web of code relationships that can be traversed efficiently.
+
+### How It Works
+
+CodeGraph parses source files with tree-sitter, extracts AST nodes, and records their relationships. The resulting knowledge graph is stored in a local SQLite database with FTS5 (Full-Text Search 5) for keyword fallback. Everything is **100% local** — no API key, no cloud dependency, no embedding model to download.
+
+The graph structure enables queries that vector search cannot handle well:
+
+- **Callers of a function**: "What calls this repository method?"
+- **Callees of a function**: "What does this ViewModel do when it receives a login result?"
+- **Impact analysis**: "If I change this interface, what other code depends on it?"
+
+These are the questions that come up constantly during refactoring or bug fixing — and they are exactly what a knowledge graph can answer in O(1) relative to the graph size, rather than O(n) file reads.
+
+### Benchmark Results: 92% Fewer Tool Calls, 71% Faster
+
+The CodeGraph project publishes impressive benchmark results measured with Claude Code's Explore agent on real-world codebases:
+
+| Project | Language | Tool Calls (CodeGraph) | Tool Calls (Baseline) | Speed Improvement |
+|---------|----------|------------------------|------------------------|-------------------|
+| VS Code | TypeScript | 3 | 52 | 82% faster |
+| Excalidraw | TypeScript | 3 | 47 | 72% faster |
+| Claude Code | Python+Rust | 3 | 40 | 43% faster |
+| Claude Code | Java | 1 | 26 | 77% faster |
+| Alamofire | Swift | 3 | 32 | 78% faster |
+| Swift Compiler | Swift/C++ | 6 | 37 | 73% faster |
+| **AVERAGE** | — | **3.2** | **39** | **71% faster** |
+
+The pattern is striking: in every case, CodeGraph reduced tool calls by approximately 92% and completed tasks 71% faster on average. For the Java project, it achieved 96% fewer tool calls and 77% faster completion. This is the kind of improvement that translates directly to real token savings.
+
+### Installation
+
+CodeGraph is an npm package:
+
+```bash
+# Interactive installer (recommended for first-time setup)
+npx @colbymchenry/codegraph
+
+# Direct installation
+npm install -g @colbymchenry/codegraph
+```
+
+The interactive installer sets up the database, configures file watching, and walks you through the initial indexing.
+
+### CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `codegraph install` | Install dependencies and configure |
+| `codegraph init -i` | Initialize project |
+| `codegraph index` | Build the knowledge graph |
+| `codegraph sync` | Sync changes after modifications |
+| `codegraph status` | Show index statistics |
+| `codegraph query` | Search the graph |
+| `codegraph files` | List indexed files |
+| `codegraph context` | Get call context for a symbol |
+| `codegraph affected` | Find affected files after changes |
+| `codegraph serve --mcp` | Start MCP server |
+
+The `codegraph serve --mcp` command exposes the knowledge graph as MCP tools, enabling AI agents like Claude Code, Cursor, Codex CLI, and OpenCode to query the graph directly.
+
+### MCP Tools
+
+CodeGraph exposes eight MCP tools for agent integration:
+
+- `codegraph_search` — Full-text and semantic search
+- `codegraph_context` — Get call context for a symbol
+- `codegraph_callers` — Find functions that call a given function
+- `codegraph_callees` — Find functions called by a given function
+- `codegraph_impact` — Analyze the impact of changing a symbol
+- `codegraph_node` — Get detailed information about a graph node
+- `codegraph_files` — List all indexed files
+- `codegraph_status` — Check index health
+
+### Framework Awareness
+
+CodeGraph is explicitly **framework-aware**, with built-in routes for 13 web frameworks:
+
+- Django, Flask, FastAPI (Python)
+- Express (Node.js)
+- Laravel, Rails (Ruby/PHP)
+- Spring (Java)
+- Gin/chi/gorilla/mux (Go)
+- Axum/actix/Rocket (Rust)
+- ASP.NET (C#)
+- Vapor (Swift)
+- React Router, SvelteKit (frontend frameworks)
+
+This means CodeGraph understands routing patterns and can trace HTTP request flows through the codebase — a capability that is extremely valuable when debugging or adding features to Android apps that communicate with backends.
+
+### Language Support
+
+CodeGraph supports 18+ languages: TypeScript, JavaScript, Python, Go, Rust, Java, C#, PHP, Ruby, C, C++, Swift, Kotlin, Scala, Dart, Svelte, Vue, Liquid, and Pascal/Delphi. The Kotlin and Swift support makes it directly relevant for Android and iOS development.
+
+### Auto-Sync
+
+CodeGraph monitors your codebase using native OS file events (FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW on Windows) with a 2-second debounce. When you save a file, the graph updates automatically — no manual re-indexing required.
+
+### Backend Performance
+
+The default backend uses **better-sqlite3**, a native Node.js binding for SQLite. This is 5-10x faster than the WASM fallback. If you encounter slow queries, rebuild the native module with:
+
+```bash
+npm rebuild better-sqlite3
+```
+
+---
+
+## Comparing CocoIndex Code and CodeGraph
+
+Both tools solve the same problem — enabling semantic code search for AI agents — but their approaches differ significantly. Here is a structured comparison:
+
+### Architecture
+
+| Aspect | CocoIndex Code | CodeGraph |
+|--------|----------------|-----------|
+| Core technology | Vector embeddings (transformer models) | Knowledge graph (AST + SQLite) |
+| Index storage | Vector database (local or cloud) | SQLite with FTS5 |
+| Cold start | Requires embedding model loading (~5GB for full) | Instant (SQLite only) |
+| Token model | Snowflake Arctic (default local), 100+ cloud options | Native (no external model needed) |
+| API key required | Optional (depends on embedding model) | No (100% local) |
+
+### Query Capabilities
+
+| Capability | CocoIndex Code | CodeGraph |
+|------------|----------------|-----------|
+| Semantic similarity search | ✅ Excellent | ✅ Good |
+| Call graph traversal | ❌ Not supported | ✅ Full support |
+| Impact analysis | ❌ Not supported | ✅ Supported |
+| Framework routing | ❌ Not supported | ✅ 13 frameworks |
+| Natural language queries | ✅ Strong | ✅ Good |
+| Symbol-based queries | ❌ Not supported | ✅ Strong |
+
+### Token Savings
+
+CocoIndex Code claims **70% token reduction** through better retrieval. CodeGraph's benchmarks show **92% fewer tool calls** and **71% faster** completion. The numbers are not directly comparable (different measurement methodologies), but both clearly demonstrate significant improvement over baseline exploration.
+
+### Android/Kotlin Suitability
+
+Both tools fully support Kotlin and Java, making them directly applicable to Android development:
+
+- **CocoIndex Code**: 70% token savings means more budget for actual implementation. The asymmetric retrieval is particularly useful for finding specific Android patterns like Room database operations, Jetpack Compose state management, or Coroutine Flow usage.
+- **CodeGraph**: The call graph analysis is extremely valuable for understanding ViewModel-to-Repository relationships, tracking LiveData/StateFlow propagation, or tracing navigation arguments through the app. Framework awareness helps when Android apps interact with REST APIs.
+
+### Use Case Recommendations
+
+**Choose CocoIndex Code when:**
+- You want offline operation with no API key
+- You prefer embedding-based semantic search
+- You need support for 30+ languages
+- You want flexibility to swap embedding models
+- You are working with multiple agents across different providers
+
+**Choose CodeGraph when:**
+- You need call graph analysis and impact tracing
+- You work with Django, Rails, Spring, or other supported frameworks
+- You want zero configuration and instant startup
+- You need framework-aware routing analysis
+- You are working primarily in TypeScript, Java, Python, Swift, or Go
+
+**Use both together** is also a valid strategy: CodeGraph for call graph queries and CocoIndex Code for semantic similarity searches. They serve different query patterns and can complement each other in a well-equipped development workflow.
+
+---
+
+## Installation Guide for Android/Kotlin Projects
+
+### Setting Up CocoIndex Code
+
+For an Android Kotlin project with Jetpack Compose, Room, and Hilt:
+
+```bash
+# Install
+pipx install "cocoindex-code[full]"
+
+# Navigate to your project
+cd ~/projects/my-android-app
+
+# Initialize (auto-detects Kotlin and Java)
+ccc init
+
+# Index the codebase
+ccc index
+
+# Verify
+ccc status
+# Output should show Kotlin files indexed and the embedding model loaded
+```
+
+The initialization auto-detects your project's language mix. For a typical Android project, it will index all `.kt` files in `app/src/main/java` and `app/src/test/java`.
+
+### Setting Up CodeGraph
+
+```bash
+# Install
+npm install -g @colbymchenry/codegraph
+
+# Navigate to your project
+cd ~/projects/my-android-app
+
+# Initialize
+codegraph install
+codegraph init -i
+
+# Index
+codegraph index
+
+# Check status
+codegraph status
+```
+
+The interactive installer creates a `config.json` in your project root with language detection and exclusion patterns. For Android projects, you typically want to exclude `build/` and `.gradle/` directories:
+
+```json
+{
+  "languages": ["kotlin", "java"],
+  "exclude": ["**/build/**", "**/.gradle/**", "**/gen/**"],
+  "maxFileSize": 1048576,
+  "extractDocstrings": true,
+  "trackCallSites": true
+}
+```
+
+### Verifying Integration with Claude Code
+
+Both tools integrate with Claude Code through MCP. In your Claude Code session:
+
+```bash
+# Start the MCP server for CocoIndex Code
+ccc mcp
+
+# Or for CodeGraph
+codegraph serve --mcp
+```
+
+Claude Code will automatically detect the MCP tools and make them available in the session. You can then query the codebase semantically:
+
+```
+> Find all Repository implementations that handle user authentication
+```
+
+---
+
+## Real-World Workflow: Android Feature Development
+
+Consider a typical Android development scenario: you need to add biometric authentication to a login screen. The app uses Hilt for dependency injection, Room for local storage, and Coroutines for async operations.
+
+**Without semantic search:**
+1. Claude Code runs `find . -name "*.kt" | grep -i login` (10+ files returned)
+2. It reads `LoginActivity.kt`, `LoginViewModel.kt`, `LoginRepository.kt` to understand the flow
+3. It searches for "biometric" to find existing implementations
+4. It reads `BiometricHelper.kt` and several related utilities
+5. By this point, 15 minutes have passed and 30,000 tokens have been consumed
+
+**With CocoIndex Code:**
+1. Query: "Repository interface for login with authentication token storage"
+2. Agent receives only the relevant `LoginRepository.kt` interface and its implementation
+3. Query: "Biometric authentication utility classes"
+4. Agent receives `BiometricHelper.kt` and `BiometricManager.kt`
+5. Implementation begins with full context in 5 minutes and ~8,000 tokens
+
+**With CodeGraph:**
+1. Query: "Who calls the login repository?"
+2. Agent receives call graph: `LoginViewModel` → `LoginRepository` → `AuthInterceptor`
+3. Query: "What functions does BiometricHelper expose?"
+4. Agent receives function signatures and call sites
+5. Implementation begins with exact context in 5 minutes and ~6,000 tokens
+
+The token savings compound across a full development session. If you make 20 queries during a feature development cycle, semantic search saves roughly 400,000-600,000 tokens — the difference between a $0.10 session and a $0.50 session on most LLM pricing.
+
+---
+
+## How Agents Use These Tools
+
+CocoIndex Code and CodeGraph are not just for human developers. AI coding agents can leverage them directly through MCP integration.
+
+When an agent starts a session with these tools active, it can:
+
+1. **Understand architecture at query time**: Instead of reading 50 files at session start to understand the architecture, the agent queries the semantic index only when it needs specific context.
+
+2. **Trace call chains in one step**: "Show me the call path from the login button click to the network request" returns a complete trace in a single query, rather than requiring the agent to manually trace through 8 files.
+
+3. **Find similar implementations**: "Find other places in the codebase that handle retry logic for network failures" uses semantic similarity to surface relevant patterns the agent might not have discovered through text search.
+
+4. **Validate refactoring impact**: Before making a breaking change, the agent can query "what depends on this interface?" and get a complete dependency list in seconds.
+
+This changes the economics of AI-assisted development. The agent becomes a more efficient consumer of your codebase's knowledge, spending tokens on implementation rather than exploration.
+
+---
+
+## Configuration Deep Dive
+
+### CocoIndex Code: Tuning for Kotlin
+
+For Android/Kotlin projects, you can optimize the indexing behavior in `.cocoindex_code/settings.yml`:
+
+```yaml
+indexing:
+  languages:
+    - kotlin
+    - java
+  exclude_patterns:
+    - "**/build/**"
+    - "**/.gradle/**"
+    - "**/gen/**"
+    - "**/.idea/**"
+  chunk_size: 512  # tokens per chunk
+  overlap: 64       # overlap between chunks
+
+query:
+  default_model: nomic-ai/CodeRankEmbed
+  top_k: 5          # number of results to return
+  rerank: true      # rerank results with cross-encoder
+
+retrieval:
+  asymmetric: true   # optimize for code-specific retrieval
+  # Supported models for asymmetric retrieval:
+  # - Cohereembed-v4
+  # - Voyage code-3
+  # - Snowflake Arctic Embed
+```
+
+### CodeGraph: Framework-Aware Configuration
+
+For projects that interact with backends, enable framework awareness in `config.json`:
+
+```json
+{
+  "frameworks": ["django", "express"],
+  "trackCallSites": true,
+  "extractDocstrings": true,
+  "maxFileSize": 1048576
+}
+```
+
+CodeGraph will then understand routing patterns and can trace HTTP request flows through the full stack — useful for mobile apps that have both Android frontend and Python/Django backend components.
+
+---
+
+## Limitations and Trade-offs
+
+### CocoIndex Code Trade-offs
+
+1. **Cold start penalty**: The first `ccc index` command downloads and caches the embedding model (~5GB for CodeRankEmbed). Subsequent runs are faster because the model stays warm.
+
+2. **Embedding quality varies**: The default model (Snowflake Arctic) is fast but less accurate than CodeRankEmbed for code-specific queries. Switching models requires re-indexing.
+
+3. **No call graph**: Vector embeddings cannot answer "what calls this function?" — they only find semantically similar code.
+
+4. **Cloud dependency if you choose it**: While local operation is supported, some features may require cloud API access if you configure cloud embeddings.
+
+### CodeGraph Trade-offs
+
+1. **SQLite-only storage**: CodeGraph does not support remote indexes or distributed configurations. Each developer must index independently.
+
+2. **No semantic similarity for unrelated concepts**: FTS5-based search works well for exact and fuzzy keyword matching, but does not understand that "authentication" and "login" are related unless they appear in similar contexts.
+
+3. **Native module compilation**: The `better-sqlite3` dependency requires native compilation. On some systems, `npm rebuild` may be needed after installation or update.
+
+4. **Fewer languages**: 18 languages versus 30+ in CocoIndex Code — though this covers most mainstream development scenarios.
+
+---
+
+## Conclusion
+
+Semantic code search is rapidly becoming a prerequisite for effective AI-assisted development. As codebases grow and context windows remain limited, the ability to retrieve exactly the relevant code — without reading 50 files to find 3 — determines how efficiently your AI agent operates.
+
+**CocoIndex Code** excels at semantic similarity: it understands what code *means*, not just what it *says*. Its 70% token savings, 30+ language support, and flexible embedding model options make it a powerful addition to any AI development workflow. The local-first design (no API key required with the default model) is particularly attractive for indie developers and teams with privacy requirements.
+
+**CodeGraph** excels at relationship understanding: it knows how code *connects*. Its knowledge graph, call graph analysis, and framework awareness make it invaluable for tracing dependencies, understanding architecture, and performing impact analysis before refactoring. The 92% reduction in tool calls demonstrated in benchmarks is a direct result of this structural understanding.
+
+For Android and Kotlin developers specifically, both tools provide native support and measurable improvements. Whether you choose one or both, integrating semantic code search into your AI development workflow is one of the highest-ROI changes you can make — reducing token costs, accelerating exploration, and letting your agents focus on what they do best: writing code.
+
+---
+
+## References
+
+- [CocoIndex Code — GitHub Repository](https://github.com/cocoindex-io/cocoindex-code)
+- [CodeGraph — GitHub Repository](https://github.com/colbymchenry/codegraph)
+- [CocoIndex Code Documentation](https://cocoindex-io.github.io/cocoindex-code/)
+- [Spec-Driven Development with Agentic AI](/blog/spec-driven-development-ai)
+- [Complete Guide: Stack Recommended for Building AI Agents in 2026](/blog/complete-beginners-guide-ai-agents-stack-2026)

--- a/src/content/blog/es/blog-semantic-code-search-tools.md
+++ b/src/content/blog/es/blog-semantic-code-search-tools.md
@@ -1,0 +1,501 @@
+---
+title: "Herramientas de Búsqueda Semántica de Código para Agentes de Programación IA: CocoIndex Code y CodeGraph"
+description: "Una comparación exhaustiva de CocoIndex Code y CodeGraph — dos herramientas de búsqueda semántica basadas en AST que reducen drásticamente el consumo de tokens y aceleran la exploración de código para agentes IA como Claude Code."
+pubDate: 2026-05-19
+heroImage: "/images/blog-semantic-code-search.svg"
+tags: ["IA", "Búsqueda de Código", "Claude Code", "Herramientas de Desarrollo", "CocoIndex", "CodeGraph", "Búsqueda Semántica", "Android", "Kotlin", "Productividad"]
+reference_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+author: "ArceApps"
+---
+
+> **Lecturas relacionadas:** [Desarrollo Guiado por Especificaciones con IA Agéntica](/es/blog/spec-driven-development-ai) · [Guía Completa: Stack Recomendado para Construir Agentes IA en 2026](/es/blog/complete-beginners-guide-ai-agents-stack-2026) · [Agentes IA en Desarrollo Android](/es/blog/blog-ai-agents-workflow-android)
+
+Si alguna vez has trabajado con un agente de programación IA en un proyecto grande, probablemente habrás notado algo frustrante: el agente dedica una porción significativa de su presupuesto de tokens a navegar por el código. Antes de implementar una funcionalidad o corregir un bug, necesita entender el contexto circundante. Dispara comandos grep, patrones glob y operaciones de búsqueda — buscando el archivo correcto, la función relevante, la abstracción apropiada. Esta fase de exploración consume tokens que podrían gastarse en escribir código realmente.
+
+El problema se agrava conforme crece el proyecto. Un proyecto Android limpio con una arquitectura adecuada puede tener cientos de archivos Kotlin. El agente necesita entender el patrón repository aquí, el uso de coroutines allá, las convenciones de ViewModel por todas partes. Sin comprensión semántica, recurre a búsqueda textual — lo que significa que pagas para que el agente lea archivos que son solo *parcialmente* relevantes, porque las palabras coinciden pero la semántica no.
+
+Dos herramientas han surgido para resolver este problema: **CocoIndex Code** y **CodeGraph**. Ambas utilizan análisis de Abstract Syntax Trees (AST) para construir un índice semántico del proyecto, permitiendo a los agentes IA encontrar exactamente lo que necesitan en una sola consulta. Pero toman enfoques diferentes — CocoIndex Code usa embeddings vectoriales con recuperación asimétrica, mientras que CodeGraph construye un grafo de conocimiento con análisis de grafo de llamadas. Este artículo examina ambas herramientas en profundidad, con benchmarks concretos, casos de uso y orientación práctica para desarrollo Android y Kotlin.
+
+---
+
+## El Problema: Desperdicio de la Ventana de Contexto en Sesiones IA
+
+Cada agente de programación IA — ya sea Claude Code, Cursor, Codex u OpenCode — opera dentro de una ventana de contexto. El modelo solo puede considerar una cantidad limitada de código a la vez, y cada archivo que incluyes consume tokens de ese presupuesto. El flujo de trabajo estándar para explorar un proyecto hoy se ve así:
+
+1. El agente dispara un patrón glob para encontrar archivos relevantes
+2. Lee múltiples archivos para entender la arquitectura
+3. Busca definiciones de funciones con grep
+4. Lee más archivos para trazar cadenas de llamadas
+5. Solo entonces comienza el trabajo real
+
+Para un proyecto Android de tamaño medio, los pasos 1-4 pueden consumir entre un 20-40% del presupuesto de tokens de la sesión antes de que se escriba una sola línea de código de producción. Para proyectos más grandes con más de 500 archivos Kotlin, esta sobrecarga de exploración se convierte en el costo dominante.
+
+La causa raíz es que **la búsqueda textual no entiende la estructura del código**. Un grep por "Repository" devuelve cada archivo que contiene esa palabra, incluyendo tests, documentación y clases no relacionadas. El agente debe luego leer cada resultado para determinar cuál es realmente la interfaz repository que necesita.
+
+Las herramientas de búsqueda semántica de código resuelven esto construyendo un índice que entiende el AST — la estructura real de tu código. Definiciones de funciones, jerarquías de clases, relaciones de llamadas e información de tipos están todos indexados. Cuando un agente consulta "la interfaz repository usada en el flujo de login," obtiene exactamente eso — no 47 archivos que contienen la palabra "Repository."
+
+---
+
+## CocoIndex Code: Búsqueda Semántica Basada en AST con Embeddings Vectoriales
+
+**CocoIndex Code** (de cocoindex-io/cocoindex-code) es una herramienta CLI que indexa tu proyecto usando análisis AST y almacena embeddings en una base de datos vectorial. Cuando buscas, encuentra código semánticamente similar basado en significado en lugar de coincidencia de palabras clave.
+
+### Cómo Funciona
+
+CocoIndex Code analiza tus archivos fuente en ASTs, extrae fragmentos significativos (cuerpos de funciones, definiciones de clases, contratos de interfaces) y genera embeddings usando un modelo transformer. Estos embeddings capturan relaciones semánticas — código que sirve un propósito similar tendrá vectores similares, incluso si los nombres de variables son completamente diferentes.
+
+El modelo local por defecto es **Snowflake/snowflake-arctic-embed-xs**, que es rápido y gratuito, no requiere clave API y funciona completamente offline. Para mayor precisión en consultas específicas de código, el modelo local recomendado es **nomic-ai/CodeRankEmbed** (137M parámetros, ventana de contexto de 8192 tokens). Si prefieres embeddings basados en la nube, CocoIndex Code soporta más de 100 proveedores a través de LiteLLM: OpenAI, Voyage code-3, Cohere v4, Google Gemini, Azure, AWS Bedrock, Ollama y otros.
+
+### Instalación y Configuración
+
+Comenzar con CocoIndex Code toma aproximadamente un minuto con cero configuración requerida para la mayoría de proyectos:
+
+```bash
+# Para operación local (offline) con embeddings gratuitos — sin clave API
+pipx install "cocoindex-code[full]"
+
+# Para operación en la nube con clave API
+pipx install cocoindex-code
+```
+
+Después de la instalación, inicializa el índice para tu proyecto:
+
+```bash
+ccc init
+ccc index
+```
+
+El comando `ccc doctor` verifica tu configuración si algo sale mal, y `ccc reset` limpia todo si necesitas un comienzo limpio. También hay una opción Docker disponible:
+
+```bash
+# Versión lite (~450MB) — usa embeddings en la nube
+docker run -it cocoindex/cocoindex-code:latest
+
+# Versión completa (~5GB) — incluye sentence-transformers local para embeddings offline
+docker run -it cocoindex/cocoindex-code:full
+```
+
+El enfoque Docker es particularmente útil para equipos porque el contenedor mantiene el modelo de embeddings activo entre sesiones, evitando la penalización de arranque en frío de cargar un modelo de 5GB cada vez.
+
+### Los Comandos CLI
+
+CocoIndex Code expone un conjunto limpio de comandos:
+
+| Comando | Propósito |
+|---------|-----------|
+| `ccc init` | Inicializar la configuración del índice |
+| `ccc index` | Construir el índice semántico |
+| `ccc search <consulta>` | Buscar en el proyecto semánticamente |
+| `ccc status` | Mostrar estadísticas del índice |
+| `ccc doctor` | Diagnosticar problemas de configuración |
+| `ccc reset` | Limpiar y reconstruir el índice |
+| `ccc daemon status/restart/stop` | Gestionar el daemon en segundo plano |
+| `ccc mcp` | Iniciar servidor MCP en modo stdio |
+
+Para integración MCP (Model Context Protocol), ejecuta `ccc mcp` para conectarte con agentes IA que soportan herramientas MCP. Esto permite al agente consultar el índice semántico directamente sin salir de la conversación.
+
+### Ahorro de Tokens: Reducción del 70%
+
+El punto de venta principal de CocoIndex Code es su eficiencia en tokens. Según los benchmarks del proyecto, el índice semántico permite a los agentes IA encontrar contexto relevante con **70% menos tokens** comparado con la inclusión naive de archivos. Esto se debe a que:
+
+1. **Coincidencia exacta sobre búsqueda difusa**: En lugar de leer 20 archivos parcialmente relevantes identificados por grep, el agente lee solo los 3 archivos que son semánticamente relevantes.
+2. **Recuperación a nivel de fragmento**: El índice almacena embeddings a nivel de función/clase, así el agente recibe solo las secciones de código relevantes, no archivos completos.
+3. **Recuperación asimétrica**: CocoIndex Code soporta indexación de parámetros optimizada para búsqueda de código (usando modelos como Cohere, Voyage o Snowflake Arctic que están entrenados en tareas de recuperación específicas de código).
+
+### Soporte de Lenguajes
+
+CocoIndex Code soporta un rango impresionante de lenguajes a través de parsers tree-sitter: C, C++, C#, CSS, DTD, Fortran, Go, HTML, Java, JavaScript, JSON, Kotlin, Lua, Markdown, Pascal, PHP, Python, R, Ruby, Rust, Scala, Solidity, SQL, Svelte, Swift, TOML, TSX, TypeScript, Vue, XML y YAML. El soporte para Kotlin y Java es particularmente relevante para desarrollo Android.
+
+### Configuración
+
+Dos archivos de configuración controlan el comportamiento:
+
+- `~/.cocoindex_code/global_settings.yml` — configuración a nivel de usuario
+- `.cocoindex_code/settings.yml` — anulaciones específicas del proyecto
+
+Puedes ajustar `indexing_params` y `query_params` para cambiar entre modelos de embedding o modificar el comportamiento de recuperación. La configuración a nivel de proyecto permite que diferentes equipos usen diferentes modelos o estrategias de indexación por repositorio.
+
+---
+
+## CodeGraph: Grafo de Conocimiento con Análisis de Grafo de Llamadas
+
+**CodeGraph** (de colbymchenry/codegraph) toma un enfoque diferente. En lugar de embeddings vectoriales, construye un **grafo de conocimiento** a partir del análisis AST. Cada nodo AST se convierte en un vértice; las relaciones (llamada, herencia, import, referencia) se convierten en aristas. Esto crea una red rica de relaciones de código que puede traversarse eficientemente.
+
+### Cómo Funciona
+
+CodeGraph analiza archivos fuente con tree-sitter, extrae nodos AST y registra sus relaciones. El grafo de conocimiento resultante se almacena en una base de datos SQLite local con FTS5 (Full-Text Search 5) para fallback de palabras clave. Todo es **100% local** — sin clave API, sin dependencia de la nube, sin modelo de embeddings que descargar.
+
+La estructura del grafo permite consultas que la búsqueda vectorial no puede manejar bien:
+
+- **Llamadores de una función**: "¿Qué llama a este método del repository?"
+- **Llamados de una función**: "¿Qué hace este ViewModel cuando recibe un resultado de login?"
+- **Análisis de impacto**: "Si cambio esta interfaz, ¿qué otro código depende de ella?"
+
+Estas son las preguntas que surgen constantemente durante refactorización o corrección de bugs — y son exactamente lo que un grafo de conocimiento puede responder en O(1) relativo al tamaño del grafo, en lugar de O(n) lecturas de archivos.
+
+### Resultados de Benchmark: 92% Menos Llamadas a Herramientas, 71% Más Rápido
+
+El proyecto CodeGraph publica resultados de benchmark impresionantes medidos con el agente Explore de Claude Code en proyectos reales:
+
+| Proyecto | Lenguaje | Llamadas (CodeGraph) | Llamadas (Baseline) | Mejora de Velocidad |
+|----------|----------|----------------------|---------------------|---------------------|
+| VS Code | TypeScript | 3 | 52 | 82% más rápido |
+| Excalidraw | TypeScript | 3 | 47 | 72% más rápido |
+| Claude Code | Python+Rust | 3 | 40 | 43% más rápido |
+| Claude Code | Java | 1 | 26 | 77% más rápido |
+| Alamofire | Swift | 3 | 32 | 78% más rápido |
+| Swift Compiler | Swift/C++ | 6 | 37 | 73% más rápido |
+| **PROMEDIO** | — | **3.2** | **39** | **71% más rápido** |
+
+El patrón es striking: en cada caso, CodeGraph redujo las llamadas a herramientas en aproximadamente 92% y completó las tareas 71% más rápido en promedio. Para el proyecto Java, logró 96% menos llamadas a herramientas y 77% más rápido. Este es el tipo de mejora que se traduce directamente en ahorros reales de tokens.
+
+### Instalación
+
+CodeGraph es un paquete npm:
+
+```bash
+# Instalador interactivo (recomendado para primera configuración)
+npx @colbymchenry/codegraph
+
+# Instalación directa
+npm install -g @colbymchenry/codegraph
+```
+
+El instalador interactivo configura la base de datos, configura la observación de archivos y te guía a través del indexado inicial.
+
+### Comandos CLI
+
+| Comando | Propósito |
+|---------|-----------|
+| `codegraph install` | Instalar dependencias y configurar |
+| `codegraph init -i` | Inicializar proyecto |
+| `codegraph index` | Construir el grafo de conocimiento |
+| `codegraph sync` | Sincronizar cambios después de modificaciones |
+| `codegraph status` | Mostrar estadísticas del índice |
+| `codegraph query` | Buscar en el grafo |
+| `codegraph files` | Listar archivos indexados |
+| `codegraph context` | Obtener contexto de llamadas para un símbolo |
+| `codegraph affected` | Encontrar archivos afectados después de cambios |
+| `codegraph serve --mcp` | Iniciar servidor MCP |
+
+El comando `codegraph serve --mcp` expone el grafo de conocimiento como herramientas MCP, permitiendo a agentes IA como Claude Code, Cursor, Codex CLI y OpenCode consultar el grafo directamente.
+
+### Herramientas MCP
+
+CodeGraph expone ocho herramientas MCP para integración con agentes:
+
+- `codegraph_search` — Búsqueda de texto completo y semántica
+- `codegraph_context` — Obtener contexto de llamadas para un símbolo
+- `codegraph_callers` — Encontrar funciones que llaman a una función dada
+- `codegraph_callees` — Encontrar funciones llamadas por una función dada
+- `codegraph_impact` — Analizar el impacto de cambiar un símbolo
+- `codegraph_node` — Obtener información detallada sobre un nodo del grafo
+- `codegraph_files` — Listar todos los archivos indexados
+- `codegraph_status` — Verificar salud del índice
+
+### Reconocimiento de Frameworks
+
+CodeGraph es explícitamente **consciente de frameworks**, con rutas incorporadas para 13 frameworks web:
+
+- Django, Flask, FastAPI (Python)
+- Express (Node.js)
+- Laravel, Rails (Ruby/PHP)
+- Spring (Java)
+- Gin/chi/gorilla/mux (Go)
+- Axum/actix/Rocket (Rust)
+- ASP.NET (C#)
+- Vapor (Swift)
+- React Router, SvelteKit (frameworks frontend)
+
+Esto significa que CodeGraph entiende los patrones de routing y puede trazar flujos de solicitudes HTTP a través del proyecto — una capacidad extremadamente valiosa al depurar o agregar funcionalidades a apps Android que se comunican con backends.
+
+### Soporte de Lenguajes
+
+CodeGraph soporta 18+ lenguajes: TypeScript, JavaScript, Python, Go, Rust, Java, C#, PHP, Ruby, C, C++, Swift, Kotlin, Scala, Dart, Svelte, Vue, Liquid y Pascal/Delphi. El soporte para Kotlin y Swift lo hace directamente relevante para desarrollo Android e iOS.
+
+### Sincronización Automática
+
+CodeGraph monitorea tu proyecto usando eventos nativos de archivo del sistema operativo (FSEvents en macOS, inotify en Linux, ReadDirectoryChangesW en Windows) con un debounce de 2 segundos. Cuando guardas un archivo, el grafo se actualiza automáticamente — no se requiere re-indexación manual.
+
+### Rendimiento del Backend
+
+El backend por defecto usa **better-sqlite3**, un binding nativo Node.js para SQLite. Esto es 5-10x más rápido que el fallback WASM. Si experimentas consultas lentas, reconstruye el módulo nativo con:
+
+```bash
+npm rebuild better-sqlite3
+```
+
+---
+
+## Comparando CocoIndex Code y CodeGraph
+
+Ambas herramientas resuelven el mismo problema — habilitar búsqueda semántica de código para agentes IA — pero sus enfoques difieren significativamente. Aquí hay una comparación estructurada:
+
+### Arquitectura
+
+| Aspecto | CocoIndex Code | CodeGraph |
+|---------|----------------|-----------|
+| Tecnología central | Embeddings vectoriales (modelos transformer) | Grafo de conocimiento (AST + SQLite) |
+| Almacenamiento del índice | Base de datos vectorial (local o nube) | SQLite con FTS5 |
+| Arranque en frío | Requiere carga del modelo de embeddings (~5GB para completo) | Instantáneo (solo SQLite) |
+| Modelo de tokens | Snowflake Arctic (local por defecto), 100+ opciones en nube | Nativo (sin modelo externo necesario) |
+| Clave API requerida | Opcional (depende del modelo de embeddings) | No (100% local) |
+
+### Capacidades de Consulta
+
+| Capacidad | CocoIndex Code | CodeGraph |
+|-----------|----------------|-----------|
+| Búsqueda de similitud semántica | ✅ Excelente | ✅ Buena |
+| Traversación de grafo de llamadas | ❌ No soportado | ✅ Soporte completo |
+| Análisis de impacto | ❌ No soportado | ✅ Soportado |
+| Routing de frameworks | ❌ No soportado | ✅ 13 frameworks |
+| Consultas en lenguaje natural | ✅ Fuerte | ✅ Buena |
+| Consultas basadas en símbolos | ❌ No soportado | ✅ Fuerte |
+
+### Ahorro de Tokens
+
+CocoIndex Code reclama **70% de reducción de tokens** a través de mejor recuperación. Los benchmarks de CodeGraph muestran **92% menos llamadas a herramientas** y **71% más rápido**. Los números no son directamente comparables (metodologías de medición diferentes), pero ambos demuestran claramente mejora significativa sobre la exploración baseline.
+
+### Idoneidad para Android/Kotlin
+
+Ambas herramientas soportan completamente Kotlin y Java, haciéndolas directamente aplicables a desarrollo Android:
+
+- **CocoIndex Code**: El ahorro del 70% en tokens significa más presupuesto para implementación real. La recuperación asimétrica es particularmente útil para encontrar patrones Android específicos como operaciones de Room, gestión de estado en Jetpack Compose o uso de Coroutine Flow.
+- **CodeGraph**: El análisis de grafo de llamadas es extremadamente valioso para entender relaciones ViewModel-a-Repository, seguir propagación de LiveData/StateFlow o trazar argumentos de navegación a través de la app. La consciencia de frameworks ayuda cuando las apps Android interactúan con APIs REST.
+
+### Recomendaciones de Casos de Uso
+
+**Elige CocoIndex Code cuando:**
+- Quieres operación offline sin clave API
+- Prefieres búsqueda semántica basada en embeddings
+- Necesitas soporte para 30+ lenguajes
+- Quieres flexibilidad para cambiar modelos de embeddings
+- Estás trabajando con múltiples agentes a través de diferentes proveedores
+
+**Elige CodeGraph cuando:**
+- Necesitas análisis de grafo de llamadas y rastreo de impacto
+- Trabajas con Django, Rails, Spring u otros frameworks soportados
+- Quieres cero configuración y arranque instantáneo
+- Necesitas análisis de routing consciente de frameworks
+- Estás trabajando principalmente en TypeScript, Java, Python, Swift o Go
+
+**Usar ambos juntos** también es una estrategia válida: CodeGraph para consultas de grafo de llamadas y CocoIndex Code para búsquedas de similitud semántica. Sirven diferentes patrones de consulta y pueden complementarse en un flujo de trabajo de desarrollo bien equipado.
+
+---
+
+## Guía de Instalación para Proyectos Android/Kotlin
+
+### Configurar CocoIndex Code
+
+Para un proyecto Android Kotlin con Jetpack Compose, Room y Hilt:
+
+```bash
+# Instalar
+pipx install "cocoindex-code[full]"
+
+# Navegar a tu proyecto
+cd ~/projects/mi-app-android
+
+# Inicializar (auto-detecta Kotlin y Java)
+ccc init
+
+# Indexar el proyecto
+ccc index
+
+# Verificar
+ccc status
+# La salida debería mostrar archivos Kotlin indexados y el modelo de embeddings cargado
+```
+
+La inicialización auto-detecta la mezcla de lenguajes de tu proyecto. Para un proyecto Android típico, indexará todos los archivos `.kt` en `app/src/main/java` y `app/src/test/java`.
+
+### Configurar CodeGraph
+
+```bash
+# Instalar
+npm install -g @colbymchenry/codegraph
+
+# Navegar a tu proyecto
+cd ~/projects/mi-app-android
+
+# Inicializar
+codegraph install
+codegraph init -i
+
+# Indexar
+codegraph index
+
+# Verificar estado
+codegraph status
+```
+
+El instalador interactivo crea un `config.json` en la raíz de tu proyecto con detección de lenguaje y patrones de exclusión. Para proyectos Android, típicamente quieres excluir los directorios `build/` y `.gradle/`:
+
+```json
+{
+  "languages": ["kotlin", "java"],
+  "exclude": ["**/build/**", "**/.gradle/**", "**/gen/**"],
+  "maxFileSize": 1048576,
+  "extractDocstrings": true,
+  "trackCallSites": true
+}
+```
+
+### Verificar Integración con Claude Code
+
+Ambas herramientas se integran con Claude Code a través de MCP. En tu sesión de Claude Code:
+
+```bash
+# Iniciar el servidor MCP para CocoIndex Code
+ccc mcp
+
+# O para CodeGraph
+codegraph serve --mcp
+```
+
+Claude Code detectará automáticamente las herramientas MCP y las hará disponibles en la sesión. Puedes entonces consultar el proyecto semánticamente:
+
+```
+> Encuentra todas las implementaciones de Repository que manejan autenticación de usuario
+```
+
+---
+
+## Flujo de Trabajo Real: Desarrollo de Funcionalidades Android
+
+Considera un escenario típico de desarrollo Android: necesitas agregar autenticación biométrica a una pantalla de login. La app usa Hilt para inyección de dependencias, Room para almacenamiento local y Coroutines para operaciones asíncronas.
+
+**Sin búsqueda semántica:**
+1. Claude Code ejecuta `find . -name "*.kt" | grep -i login` (se devuelven 10+ archivos)
+2. Lee `LoginActivity.kt`, `LoginViewModel.kt`, `LoginRepository.kt` para entender el flujo
+3. Busca "biometric" para encontrar implementaciones existentes
+4. Lee `BiometricHelper.kt` y variosutilidades relacionadas
+5. En este punto, han pasado 15 minutos y se han consumido 30,000 tokens
+
+**Con CocoIndex Code:**
+1. Consulta: "Interfaz repository para login con almacenamiento de token de autenticación"
+2. El agente recibe solo la interfaz `LoginRepository.kt` relevante y su implementación
+3. Consulta: "Clases de utilidad de autenticación biométrica"
+4. El agente recibe `BiometricHelper.kt` y `BiometricManager.kt`
+5. La implementación comienza con contexto completo en 5 minutos y ~8,000 tokens
+
+**Con CodeGraph:**
+1. Consulta: "¿Quién llama al repository de login?"
+2. El agente recibe el grafo de llamadas: `LoginViewModel` → `LoginRepository` → `AuthInterceptor`
+3. Consulta: "¿Qué funciones expone BiometricHelper?"
+4. El agente recibe firmas de funciones y sitios de llamada
+5. La implementación comienza con contexto exacto en 5 minutos y ~6,000 tokens
+
+El ahorro de tokens se compounda a través de una sesión de desarrollo completa. Si haces 20 consultas durante un ciclo de desarrollo de funcionalidad, la búsqueda semántica ahorra aproximadamente 400,000-600,000 tokens — la diferencia entre una sesión de $0.10 y una de $0.50 en la mayoría de precios de LLMs.
+
+---
+
+## Cómo los Agentes Usan Estas Herramientas
+
+CocoIndex Code y CodeGraph no son solo para desarrolladores humanos. Los agentes de programación IA pueden aprovecharlos directamente a través de integración MCP.
+
+Cuando un agente inicia una sesión con estas herramientas activas, puede:
+
+1. **Entender la arquitectura en tiempo de consulta**: En lugar de leer 50 archivos al inicio de la sesión para entender la arquitectura, el agente consulta el índice semántico solo cuando necesita contexto específico.
+
+2. **Trazar cadenas de llamadas en un paso**: "Muéstrame el camino de llamadas desde el click del botón de login hasta la solicitud de red" devuelve un trace completo en una sola consulta, en lugar de requerir que el agente trace manualmente a través de 8 archivos.
+
+3. **Encontrar implementaciones similares**: "Encuentra otros lugares en el proyecto que manejan lógica de reintento para fallos de red" usa similitud semántica para surfacear patrones relevantes que el agente podría no haber descubierto mediante búsqueda textual.
+
+4. **Validar impacto de refactorización**: Antes de hacer un cambio rompe寺庙, el agente puede consultar "¿de qué depende esta interfaz?" y obtener una lista de dependencias completa en segundos.
+
+Esto cambia la economía del desarrollo asistido por IA. El agente se convierte en un consumidor más eficiente del conocimiento de tu proyecto, gastando tokens en implementación en lugar de exploración.
+
+---
+
+## Análisis Profundo de Configuración
+
+### CocoIndex Code: Optimizando para Kotlin
+
+Para proyectos Android/Kotlin, puedes optimizar el comportamiento de indexación en `.cocoindex_code/settings.yml`:
+
+```yaml
+indexing:
+  languages:
+    - kotlin
+    - java
+  exclude_patterns:
+    - "**/build/**"
+    - "**/.gradle/**"
+    - "**/gen/**"
+    - "**/.idea/**"
+  chunk_size: 512  # tokens por fragmento
+  overlap: 64       # solapamiento entre fragmentos
+
+query:
+  default_model: nomic-ai/CodeRankEmbed
+  top_k: 5          # número de resultados a devolver
+  rerank: true      # re-ordenar resultados con cross-encoder
+
+retrieval:
+  asymmetric: true   # optimizar para recuperación específica de código
+  # Modelos soportados para recuperación asimétrica:
+  # - Cohereembed-v4
+  # - Voyage code-3
+  # - Snowflake Arctic Embed
+```
+
+### CodeGraph: Configuración Consciente de Frameworks
+
+Para proyectos que interactúan con backends, habilita la consciencia de frameworks en `config.json`:
+
+```json
+{
+  "frameworks": ["django", "express"],
+  "trackCallSites": true,
+  "extractDocstrings": true,
+  "maxFileSize": 1048576
+}
+```
+
+CodeGraph entonces entenderá los patrones de routing y podrá trazar flujos de solicitudes HTTP a través de la pila completa — útil para apps móviles que tienen tanto frontend Android como componentes de backend Python/Django.
+
+---
+
+## Limitaciones y Compensaciones
+
+### Compensaciones de CocoIndex Code
+
+1. **Penalización de arranque en frío**: El primer comando `ccc index` descarga y cachea el modelo de embeddings (~5GB para CodeRankEmbed). Las ejecuciones subsiguientes son más rápidas porque el modelo se mantiene activo.
+
+2. **Calidad de embeddings variable**: El modelo por defecto (Snowflake Arctic) es rápido pero menos preciso que CodeRankEmbed para consultas específicas de código. Cambiar modelos requiere re-indexación.
+
+3. **Sin grafo de llamadas**: Los embeddings vectoriales no pueden responder "¿qué llama a esta función?" — solo encuentran código semánticamente similar.
+
+4. **Dependencia de la nube si lo eliges**: Aunque la operación local es soportada, algunas características pueden requerir acceso a API en la nube si configuras embeddings en la nube.
+
+### Compensaciones de CodeGraph
+
+1. **Almacenamiento solo en SQLite**: CodeGraph no soporta índices remotos o configuraciones distribuidas. Cada desarrollador debe indexar independientemente.
+
+2. **Sin similitud semántica para conceptos no relacionados**: La búsqueda basada en FTS5 funciona bien para coincidencia exacta y difusa de palabras clave, pero no entiende que "autenticación" y "login" están relacionados a menos que aparezcan en contextos similares.
+
+3. **Compilación de módulo nativo**: La dependencia `better-sqlite3` requiere compilación nativa. En algunos sistemas, puede ser necesario `npm rebuild` después de la instalación o actualización.
+
+4. **Menos lenguajes**: 18 lenguajes versus 30+ en CocoIndex Code — aunque esto cubre la mayoría de escenarios de desarrollo mainstream.
+
+---
+
+## Conclusión
+
+La búsqueda semántica de código se está convirtiendo rápidamente en un prerrequisito para el desarrollo efectivo asistido por IA. A medida que los proyectos crecen y las ventanas de contexto permanecen limitadas, la capacidad de recuperar exactamente el código relevante — sin leer 50 archivos para encontrar 3 — determina qué tan eficientemente opera tu agente IA.
+
+**CocoIndex Code** sobresale en similitud semántica: entiende lo que el código *significa*, no solo lo que *dice*. Su ahorro del 70% en tokens, soporte para 30+ lenguajes y opciones flexibles de modelos de embeddings lo convierten en una adición poderosa a cualquier flujo de trabajo de desarrollo IA. El diseño local-first (sin clave API requerida con el modelo por defecto) es particularmente atractivo para desarrolladores independientes y equipos con requisitos de privacidad.
+
+**CodeGraph** sobresale en comprensión de relaciones: sabe cómo el código *se conecta*. Su grafo de conocimiento, análisis de grafo de llamadas y consciencia de frameworks lo hacen invaluable para trazar dependencias, entender arquitectura y realizar análisis de impacto antes de refactorizar. La reducción del 92% en llamadas a herramientas demostrada en benchmarks es un resultado directo de esta comprensión estructural.
+
+Para desarrolladores Android y Kotlin específicamente, ambas herramientas proporcionan soporte nativo y mejoras medibles. Ya sea que elijas una o ambas, integrar búsqueda semántica de código en tu flujo de trabajo de desarrollo IA es uno de los cambios con mayor ROI que puedes hacer — reduciendo costos de tokens, acelerando la exploración y permitiendo que tus agentes se enfoquen en lo que mejor saben hacer: escribir código.
+
+---
+
+## Referencias
+
+- [CocoIndex Code — Repositorio GitHub](https://github.com/cocoindex-io/cocoindex-code)
+- [CodeGraph — Repositorio GitHub](https://github.com/colbymchenry/codegraph)
+- [Documentación de CocoIndex Code](https://cocoindex-io.github.io/cocoindex-code/)
+- [Desarrollo Guiado por Especificaciones con IA Agéntica](/es/blog/spec-driven-development-ai)


### PR DESCRIPTION
## Summary

Add bilingual (EN + ES) blog articles about semantic code search tools for AI coding agents:

- **CocoIndex Code**: AST-based semantic search using vector embeddings (70% token savings, 30+ languages, CLI , MCP support, Docker, local embeddings with Snowflake Arctic / nomic-ai CodeRankEmbed, LiteLLM 100+ providers)
- **CodeGraph**: Knowledge graph from AST parsing (92% fewer tool calls, 71% faster, 8 MCP tools, 13 framework-aware routes, auto-sync via FSEvents/inotify, better-sqlite3 native backend)

### Articles
| File | Words |
|------|-------|
|  | 3,773 |
|  | 4,178 |

### Benchmarks covered
- VS Code (TS): 94% fewer calls, 82% faster
- Excalidraw (TS): 94% fewer, 72% faster
- Claude Code (Java): 96% fewer, 77% faster
- Alamofire (Swift): 91% fewer, 78% faster
- Swift Compiler: 84% fewer, 73% faster
- Average: 92% fewer, 71% faster

### Assets
-  — hero image

### References
- https://github.com/cocoindex-io/cocoindex-code
- https://github.com/colbymchenry/codegraph