### PR TITLE
Sync visual hierarchy CSS comment in devlogs

### DIFF
--- a/src/content/devlog/en/2026-W18-Security-And-Visual-Hierarchy.md
+++ b/src/content/devlog/en/2026-W18-Security-And-Visual-Hierarchy.md
@@ -32,7 +32,7 @@ We updated `src/styles/global.css` to enforce a strict, responsive bounding box 
   @apply rounded-2xl shadow-lg block;
   margin-block: 2.5rem;
   margin-inline: auto;
-  max-inline-size: min(100%, 500px); /* Fix: Responsive Visual Hierarchy */
+  max-inline-size: min(100%, 500px); /* Fix: Responsive Visual Hierarchy to avoid "exploding" media on tablets/desktop */
 }
 
 .prose :where(img, video) {

--- a/src/content/devlog/es/2026-W18-Seguridad-Y-Jerarquia-Visual.md
+++ b/src/content/devlog/es/2026-W18-Seguridad-Y-Jerarquia-Visual.md
@@ -32,7 +32,7 @@ Actualizamos `src/styles/global.css` para aplicar una caja delimitadora estricta
   @apply rounded-2xl shadow-lg block;
   margin-block: 2.5rem;
   margin-inline: auto;
-  max-inline-size: min(100%, 500px); /* Fix: Responsive Visual Hierarchy */
+  max-inline-size: min(100%, 500px); /* Fix: Responsive Visual Hierarchy to avoid "exploding" media on tablets/desktop */
 }
 
 .prose :where(img, video) {


### PR DESCRIPTION
This PR synchronizes a CSS code snippet in the W18 devlog (English and Spanish) to match the current comment in `src/styles/global.css`, making sure the rationale for preventing "exploding" media is correctly documented.

---
*PR created automatically by Jules for task [16826127697274287748](https://jules.google.com/task/16826127697274287748) started by @ArceApps*