### PR TITLE
feat: add deep dive articles on Agentic Frameworks (Superpowers vs OpenSpec)

### DIFF
--- a/src/content/blog/en/blog-superpowers-deep-dive.md
+++ b/src/content/blog/en/blog-superpowers-deep-dive.md
@@ -1,0 +1,236 @@
+---
+title: "Inside Superpowers: The Framework That Forces AI to Engineer"
+description: "A comprehensive technical deep dive into the Superpowers methodology, exploring its subagent orchestration, strict TDD enforcement, and how it transforms AI from a chaotic coder into a disciplined engineering partner."
+pubDate: 2026-04-19
+heroImage: "/images/blog-superpowers-deep-dive.svg"
+tags: ["Superpowers", "AI Agents", "TDD", "Subagents", "Methodology", "Engineering", "Workflow", "Deep Dive"]
+reference_id: "b7c3e5d1-9a2f-4c8e-b1d6-8a9f2e3d4c5b"
+---
+
+> **Related reads:** [Agentic Engineering Methodologies: Superpowers vs OpenSpec](/blog/blog-superpowers-vs-openspec) · [Subagents in OpenCode](/blog/blog-opencode-subagents) · [TDD and AI in Android Development](/blog/tdd-ai-android-development)
+
+If you've spent any significant time building software with AI agents, you know the cycle. You start with a brilliant idea, write a detailed prompt, and hit enter. The agent writes 500 lines of code. You run it. It crashes. You paste the error back. It writes another 200 lines, fixing the error but silently breaking an unrelated feature. Two hours later, you are drowning in a sea of context-polluted chat history, manually reverting files and questioning why you didn't just write the code yourself.
+
+This is the reality of unconstrained AI generation. Large Language Models are probabilistic text engines; without strict guardrails, they drift. They hallucinate APIs, forget edge cases, and abandon architectural patterns the moment a bug appears.
+
+Enter [Superpowers](https://github.com/obra/superpowers).
+
+Developed by Jesse Vincent, Superpowers is not just another wrapper or a set of clever prompts. It describes itself as a "complete software development methodology for your coding agents." After spending weeks dissecting its source code and running it through the paces on the ArceApps portfolio, I can confidently say it is the most opinionated, rigorous, and fascinating approach to AI coding currently available.
+
+In my previous article, I [compared Superpowers to OpenSpec](/blog/blog-superpowers-vs-openspec), highlighting the philosophical differences between process-oriented and artifact-oriented frameworks. Today, we are going all the way down the rabbit hole. We will look at exactly how Superpowers works, how its "skills" are structured, why its use of parallel subagents is a stroke of genius, and where the framework falls short.
+
+## The Foundation: Composable Skills
+
+To understand Superpowers, you have to understand how it interfaces with the AI. Superpowers is designed to run *inside* an existing agent harness, such as Claude Code, Codex CLI, or Cursor.
+
+Instead of a single monolithic system prompt, Superpowers is built as a library of "Skills." Each skill is defined in a markdown file containing a name, a description of when to use it, and a highly detailed set of instructions.
+
+When you install the plugin, these skills are loaded into the agent's context. The agent's native system prompt is instructed to evaluate the user's request and autonomously trigger the relevant skill.
+
+Here are some of the core skills in the Superpowers library:
+*   `test-driven-development`
+*   `systematic-debugging`
+*   `brainstorming`
+*   `writing-plans`
+*   `using-git-worktrees`
+*   `subagent-driven-development`
+
+### The Anatomy of a Skill
+
+Let's look at how a skill is actually written. It's not polite conversational text; it's a strict algorithm for the LLM to follow. Take the `test-driven-development` skill, for example. The documentation explicitly states:
+
+> **The Iron Law:** NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST. Write code before the test? Delete it. Start over. No exceptions.
+
+This is prompt engineering taken to its logical extreme. It leaves no room for the LLM to "helpfully" skip steps. If the agent triggers the TDD skill, it is bound by these instructions. This composable architecture means you can add new skills or modify existing ones without rewriting the entire framework logic.
+
+## The Superpowers Workflow: From Idea to Execution
+
+The true power of Superpowers becomes apparent when you watch these skills chain together. When you ask the agent to implement a feature, it doesn't just start writing code. It initiates a complex, multi-stage workflow.
+
+### Phase 1: Brainstorming (`brainstorming`)
+
+The moment the agent detects you want to build something new, it halts. It refuses to write code. Instead, it triggers the `brainstorming` skill.
+
+This phase is Socratic. The agent asks probing questions about edge cases, data structures, and architectural constraints. Once it has enough information, it generates a rough design document and presents it to you *in chunks*. It forces you to validate the design before it proceeds.
+
+As a solo developer, this is invaluable. I often approach a feature with a half-baked idea. Having an agent relentlessly question my assumptions ("How will this UI component handle RTL languages?", "What is the fallback if the API rate limits?") catches fundamental flaws before they are set in code.
+
+### Phase 2: Isolation (`using-git-worktrees`)
+
+Once the design is approved, Superpowers enforces a clean workspace. It triggers the `using-git-worktrees` skill.
+
+Instead of polluting your current branch with experimental, AI-generated code, it creates a dedicated `git worktree` in a temporary directory on a new branch. It then runs your project's setup scripts and verifies that the test suite passes cleanly in this isolated environment. If the tests fail before it even starts, the process halts.
+
+This guarantees that any subsequent failures are the fault of the new code, not environmental pollution.
+
+
+### Phase 3: The Plan (`writing-plans`)
+
+With a clean worktree ready, the agent triggers `writing-plans`. It takes the approved design and breaks it down into a highly granular, markdown-formatted implementation plan.
+
+Superpowers dictates that tasks should be "bite-sized" (2-5 minutes of work). Each task in the plan must include:
+1.  Exact file paths.
+2.  The complete code to be written (no "etc." or "implement logic here" placeholders).
+3.  Specific verification steps (the test that must be written).
+
+This plan acts as the blueprint for the rest of the execution. It is the crucial artifact that prevents the agent from losing its way.
+
+### Phase 4: Subagent Orchestration (`subagent-driven-development`)
+
+This is the crown jewel of the Superpowers methodology. If your harness supports it (like Claude Code), the main agent will now trigger `subagent-driven-development`.
+
+Instead of the main agent reading the plan and trying to execute all 15 steps in one massive, context-heavy session, it becomes an orchestrator. For Task 1, it spawns a *completely fresh subagent*.
+
+The orchestrator hands the subagent only what it needs:
+*   The overall context (so it knows where it fits).
+*   The specific instructions for Task 1.
+*   The strict order to follow the `test-driven-development` skill.
+
+The subagent wakes up, writes the failing test, writes the implementation, makes the test pass, and reports back. It is then terminated.
+
+The orchestrator then initiates a **two-stage review**:
+1.  **Spec Compliance:** Did the subagent build exactly what Task 1 demanded?
+2.  **Code Quality:** Does the code meet the project's standards?
+
+If the review fails, the orchestrator spawns a new "fixer" subagent with specific feedback. If it passes, it moves to Task 2 and spawns another fresh subagent.
+
+### Why Subagents Change Everything
+
+If you've ever watched an LLM try to implement a 10-step plan in a single chat, you've seen context collapse. By Step 6, the LLM has forgotten the architectural constraints established in Step 1. It starts repeating itself, confusing variable names from previous steps, and generally degrading in reasoning capability as the token count explodes.
+
+Subagents solve this elegantly. A fresh subagent has zero memory of the struggles of the previous step. Its context window is empty, its attention mechanism is laser-focused, and its token generation is cheap. It only knows about Task N.
+
+This isolation is how Superpowers can run autonomously for two hours, implementing complex features across dozens of files, without deviating from the original plan. It mimics how a tech lead (the orchestrator) delegates small, scoped tickets to junior developers (the subagents) and reviews their PRs before moving on.
+
+## The Iron Law of TDD in Practice
+
+Let's look closer at how Superpowers enforces TDD. For many developers, TDD is an aspiration, not a daily reality. Superpowers forces it to be a reality.
+
+When a subagent is tasked with implementing a feature, the `test-driven-development` skill explicitly forbids writing production code first.
+
+If you are building an Android app and ask it to implement a new `ViewModel`, it will not write the Kotlin code for the `ViewModel`. It will first write `MyViewModelTest.kt`, instantiating the view model and asserting that the initial state is correct. It will run the test. The test will fail (because the class doesn't exist). Only then will it write the skeleton `ViewModel` class.
+
+This process is slow. It feels agonizingly methodical when you are watching the terminal output. The agent runs `pnpm test`, reads the failure logs, writes three lines of code, runs `pnpm test` again, reads the success logs, and commits.
+
+But the result is undeniable. When the Superpowers run finishes, you don't just have a feature; you have a fully tested feature. You have absolute confidence that the code works exactly as specified in the plan. For an indie developer managing a complex codebase alone, this automated safety net is priceless.
+
+
+## Critical Analysis: The Good, The Bad, and The Brutal
+
+Superpowers is an incredible piece of engineering, but it is not a silver bullet. After extensive use, here are my unvarnished opinions on its strengths and weaknesses.
+
+### The Good: Unprecedented Quality and Focus
+
+**1. Context Preservation Through Isolation:** The subagent architecture is the killer feature. By wiping the slate clean for every discrete task, Superpowers completely eliminates the context drift that plagues long-running AI sessions. The quality of the code generated on Task 15 is just as sharp as the code generated on Task 1.
+
+**2. The End of "It Works on My Machine":** The insistence on git worktrees is brilliant. How many times have you let an AI loose in your repo, only to realize it modified a configuration file you were experimenting with, breaking your local environment? Worktrees guarantee the AI operates in a sterile lab, proving its code works against a clean baseline.
+
+**3. TDD as a Guardrail:** While human developers often argue about the ROI of strict TDD, for an AI agent, it is the ultimate guardrail. The test acts as an objective, machine-readable validation that the agent understood the prompt. If the agent hallucinates, the test fails. It forces the LLM to ground its reasoning in executable reality.
+
+### The Bad: Friction and Speed
+
+**1. It is Agonizingly Slow:** Superpowers trades speed for correctness. A task that might take you 10 minutes to hack together manually could take Superpowers 45 minutes to brainstorm, plan, worktree, test, implement, and review. If you are doing rapid prototyping or visual UI tweaks, the methodology feels like walking through molasses. It is designed for engineering, not hacking.
+
+**2. Token Gluttony:** The workflow is incredibly token-intensive. The constant context switching, the Socratic brainstorming, the writing and reading of extensive plan documents, and the back-and-forth of the TDD cycle consume massive amounts of API credits. If you are paying per token, Superpowers will burn a hole in your wallet rapidly.
+
+**3. The Boilerplate Burden:** Sometimes, you just want to add a single CSS class or update a typo in a markdown file. Triggering the Superpowers workflow for these micro-tasks is absurd. You have to actively fight the framework or step outside of it to do simple things.
+
+### The Ugly: Harness Dependency and Brittleness
+
+The biggest fundamental flaw of Superpowers is its architecture as a plugin residing *inside* an LLM prompt.
+
+Because it relies on the host LLM (like Claude 3.5 Sonnet within the Claude Code CLI) to read the skill instructions and flawlessly execute them, it is inherently brittle. LLMs are not deterministic state machines. Sometimes, despite the strict instructions in `subagent-driven-development`, the orchestrator will get lazy and try to execute a task itself instead of dispatching a subagent. Sometimes it will decide to write the implementation before the test, flagrantly violating "The Iron Law."
+
+When this happens, the entire methodology breaks down. You find yourself yelling at the terminal, "No, read the skill documentation again!"
+
+Furthermore, the framework is heavily dependent on the capabilities of the CLI harness. If you use a harness that lacks a robust subagent API, Superpowers falls back to a much less effective sequential execution mode (`executing-plans`), negating its biggest advantage. It feels like trying to run a high-performance operating system on a hardware abstraction layer that keeps changing the rules.
+
+## The Verdict: Who is Superpowers For?
+
+Superpowers is not for everyone. If your primary use case for AI is writing boilerplate, generating simple scripts, or assisting with CSS layouts, this framework will frustrate you immensely. You will feel bogged down by process and ceremony. For those tasks, an artifact-guided approach like OpenSpec is far superior.
+
+However, if you are a solo developer building complex backend systems, intricate algorithms, or mission-critical data pipelines—scenarios where a subtle bug can cause catastrophic failure—Superpowers is a revelation.
+
+It is the closest thing I have experienced to having a disciplined, senior pair programmer sitting next to me. It forces me to think through my designs, it demands that my tests are comprehensive, and it executes implementation plans with a relentless, untiring focus.
+
+For the ArceApps portfolio, I don't use Superpowers every day. But when I need to refactor the core search indexing logic, or when I'm building a complex state machine for a new game mechanic in PuzzleHub, Superpowers is the tool I reach for. I gladly trade the speed and token cost for the absolute peace of mind that comes from knowing the code is robust, isolated, and perfectly tested.
+
+As agentic AI continues to evolve, we will likely see these methodological concepts baked directly into the IDE or the harness itself. But right now, Superpowers stands as a pioneering example of how to force probabilistic text engines to do rigorous, deterministic engineering. It is a glimpse into the future of human-AI collaboration, where the human provides the architecture, and the agent, bound by methodology, provides the execution.
+
+## Dissecting the "Writing Plans" Skill
+
+To truly appreciate the depth of the Superpowers methodology, we must examine the specific mechanics of its planning phase. The `writing-plans` skill is not merely a suggestion to "make a list"; it is a rigid architectural contract.
+
+When an agent triggers this skill, it is instructed to generate a Markdown document that follows a highly specific schema. This isn't just for human readability; it's designed so that the subsequent subagents can parse the tasks without ambiguity.
+
+A typical task generated by `writing-plans` looks like this:
+
+```markdown
+### Task 1.2: Implement Authentication Token Validation
+
+**Context**: We need to validate the JWT token on incoming API requests before allowing access to the protected routes.
+
+**File to modify**: `src/middleware/auth.ts`
+
+**Action**: Create a new middleware function `validateToken`.
+
+**Code to write**:
+- Import `jsonwebtoken` library.
+- Extract the Bearer token from the `Authorization` header.
+- Use `jwt.verify` with the `JWT_SECRET` environment variable.
+- If valid, attach the decoded user payload to the `req` object and call `next()`.
+- If invalid or missing, return a `401 Unauthorized` response with a JSON error message.
+
+**Verification (TDD Requirement)**:
+- Create `src/middleware/auth.test.ts`.
+- Write tests for:
+  - Missing token (returns 401).
+  - Invalid signature (returns 401).
+  - Expired token (returns 401).
+  - Valid token (calls next() and attaches user to req).
+```
+
+### Why this Granularity Matters
+
+Notice the level of detail here. The orchestrator agent does not say, "Add auth middleware." It specifies the file path, the exact logic flow, and critically, the exact edge cases that must be tested.
+
+This granularity is the antidote to LLM hallucination. When the fresh subagent receives this task, it doesn't need to guess how the authentication should work. It doesn't need to invent a new abstraction. It simply executes the highly constrained technical spec.
+
+If the plan was vague, the subagent might decide to implement a custom session-based auth system instead of JWT, or it might forget to handle the expired token edge case. By forcing the planning agent to think through these details upfront during the `writing-plans` phase, Superpowers ensures that the execution phase is purely mechanical.
+
+## The Two-Stage Review Process
+
+Another fascinating aspect of the `subagent-driven-development` skill is the mandatory two-stage review process. In a typical AI coding workflow, the agent writes the code, says "I'm done," and you review the diff.
+
+Superpowers automates the initial layers of this review, mimicking a senior developer reviewing a junior's Pull Request.
+
+Once a subagent completes a task (meaning the tests pass and the code is written), the orchestrator agent does not immediately merge the work or move to the next task. Instead, it pauses and performs two distinct reviews:
+
+### 1. Spec Compliance Review
+The orchestrator looks at the original task description in the plan and compares it to the subagent's implementation. Did the subagent build exactly what was asked?
+
+If the task asked for a function that returns a boolean, and the subagent wrote a function that returns an object, the spec compliance review fails. The orchestrator will spawn a new "fixer" subagent, passing it the error: *"The implementation returns an object, but the spec requires a boolean. Fix the implementation and update the tests accordingly."*
+
+This prevents feature creep and ensures the architecture remains aligned with the original design.
+
+### 2. Code Quality Review
+Only after the code passes the spec compliance check does the orchestrator evaluate code quality. This review looks for standard engineering best practices:
+*   **DRY (Don't Repeat Yourself):** Did the subagent duplicate logic that already exists elsewhere in the codebase?
+*   **YAGNI (You Aren't Gonna Need It):** Did the subagent over-engineer the solution by adding unnecessary abstractions or generic interfaces?
+*   **Complexity:** Is the code overly complex or difficult to read? Are the variable names descriptive?
+
+If the code is messy or over-engineered, the orchestrator will instruct a fixer subagent to refactor it.
+
+This automated rigorous review loop is exhausting to watch in the terminal, but the output is pristine. It forces the AI to produce code that isn't just functional, but maintainable.
+
+## The Future of Agentic Workflows
+
+Working with Superpowers feels like peering into the future of software development. We are moving away from treating AI as a highly advanced autocomplete engine, and towards treating it as an active participant in an engineering organization.
+
+The current implementation of Superpowers has its flaws—mostly stemming from the limitations of the underlying LLMs and the brittleness of prompt-based plugin architectures. The token costs are high, and the process is slow.
+
+However, the core concepts—enforced isolation via subagents, mandatory test-driven development, explicit planning, and automated multi-stage reviews—are fundamentally sound engineering principles.
+
+As LLMs become faster, cheaper, and possess larger, more reliable context windows, the friction of this methodology will decrease. Eventually, IDEs will likely build these concepts natively into their interfaces. You won't need to install a Markdown-based skill plugin; your editor will simply spin up secure, isolated containers for subagents, enforce testing visually, and orchestrate the workflow seamlessly.
+
+Until then, for those building complex applications where correctness matters more than speed, Jesse Vincent's Superpowers framework offers the most rigorous, disciplined, and effective methodology available for taming the chaos of agentic AI. It requires patience and a willingness to embrace process, but the reward is a codebase you can actually trust.

--- a/src/content/blog/en/blog-superpowers-vs-openspec.md
+++ b/src/content/blog/en/blog-superpowers-vs-openspec.md
@@ -1,0 +1,222 @@
+---
+title: "Agentic Engineering Methodologies: Superpowers vs OpenSpec"
+description: "A deep dive comparison of two distinct approaches to AI software development: the skill-based methodology of Superpowers and the artifact-guided workflow of OpenSpec."
+pubDate: 2026-04-12
+heroImage: "/images/blog-superpowers-vs-openspec.svg"
+tags: ["SDD", "AI", "Superpowers", "OpenSpec", "Agentic AI", "Methodology", "Workflow", "Productivity"]
+reference_id: "e4d2a1c9-6f8b-4a3d-8e7c-2b1d9f4a5c6d"
+---
+
+> **Related reads:** [Spec-Driven Development with Agentic AI](/blog/spec-driven-development-ai) · [Alternative Paradigms in AI-Assisted Engineering](/blog/alternative-paradigms-ai-software-engineering) · [SDD Frameworks Deep Dive](/blog/sdd-frameworks-analysis-spec-kit-openspec-bmad)
+
+When I started bringing AI coding agents into my daily workflow for ArceApps, the honeymoon phase didn't last long. Initially, it felt like magic: drop a prompt into the chat, watch the code pour out, and hit commit. But as the applications grew in complexity, so did the friction. Agents would hallucinate architectural decisions, overwrite perfectly good abstractions with naive implementations, and worst of all, silently break existing behavior because they lacked the broader context of what I was trying to build.
+
+The core issue wasn't the LLM's reasoning capability; it was the lack of a structured **methodology**. We wouldn't let a junior developer loose on a production codebase without a technical spec, a clear plan, and a code review process. Yet, we routinely expect AI agents to magically intuit our architectural intent from a three-sentence prompt.
+
+This realization led to the rise of Spec-Driven Development (SDD) and agentic frameworks. In a previous article, I analyzed [GitHub Spec Kit, OpenSpec, and BMAD-METHOD](/blog/sdd-frameworks-analysis-spec-kit-openspec-bmad). Today, I want to pit two of the most fascinating approaches against each other: [Superpowers](https://github.com/obra/superpowers) and [OpenSpec](https://github.com/Fission-AI/OpenSpec).
+
+Both tools aim to solve the same problem—keeping AI agents aligned and preventing context collapse—but they approach it from completely different philosophical angles. Superpowers is a prescriptive, skill-based methodology that enforces strict engineering practices like Test-Driven Development (TDD). OpenSpec, on the other hand, is an artifact-guided workflow that focuses on creating living documentation before any code is written.
+
+In this deep dive, we'll explore how these frameworks work under the hood, compare their philosophies, and discuss which one might fit your indie dev workflow. As a solo developer building projects on nights and weekends, my tolerance for boilerplate and ceremony is incredibly low. I need tools that amplify my intent, not systems that turn me into a project manager for my own side projects. Let's see how these two stack up.
+
+## The Evolution of AI Coding: From Chat to Methodology
+
+Before we compare the specific frameworks, we need to understand the evolution of how we interact with AI agents.
+
+### Generation 1: The Copilot Era
+The first generation was inline code completion. You write a comment, the AI suggests the next few lines. It was useful for boilerplate, but it didn't fundamentally change how software was designed. The context was limited to the active file and perhaps a few open tabs.
+
+### Generation 2: The Chat Era
+The second generation brought the chat interface into the IDE. You could highlight a block of code and ask the AI to refactor it, or paste an error message and ask for a fix. This was a massive leap forward, but it still relied on the developer to hold the entire mental model of the application. The AI was a smart intern that you had to micromanage.
+
+### Generation 3: The Agentic Era
+We are now in the third generation, where tools like Claude Code, Cursor, and OpenCode can execute complex tasks across multiple files. They can run shell commands, read logs, and modify the codebase autonomously. But with this power comes a new class of problems. When an agent is given the freedom to roam a repository, it can easily lose sight of the original goal. It might refactor a core utility class while trying to fix a minor UI bug, leading to cascading failures.
+
+This is where methodologies become critical. Just as Agile and Scrum provided structure for human teams, we now need frameworks for human-AI collaboration. The goal is to constrain the agent's autonomy within defined boundaries, ensuring that its actions are aligned with our intent.
+
+This brings us to Superpowers and OpenSpec. Both are responses to the chaos of unconstrained agentic coding, but they represent two distinct philosophies: the **Process-Oriented** approach (Superpowers) versus the **Artifact-Oriented** approach (OpenSpec).
+
+
+
+## Superpowers: The Process-Oriented Methodology
+
+[Superpowers](https://github.com/obra/superpowers), developed by Jesse Vincent and the team at Prime Radiant, describes itself as "a complete software development methodology for your coding agents."
+
+If I had to summarize Superpowers in one sentence, it would be: **"Do it right, or don't do it at all."**
+
+### The Core Philosophy
+
+Superpowers is deeply opinionated. It doesn't just want to help you write code faster; it wants to force you to write code *better*. It acts almost like a strict senior mentor looking over your agent's shoulder, enforcing rigorous engineering standards.
+
+The framework is built on a set of composable "skills" that trigger automatically based on the context of the conversation. These skills aren't just prompts; they are executable workflows that guide the agent through specific phases of development.
+
+The defining characteristic of Superpowers is its absolute, uncompromising insistence on **Test-Driven Development (TDD)**. It literally refers to this as "The Iron Law": *No production code without a failing test first*. If the agent tries to write implementation code before a test, the methodology instructs it to delete the code and start over. For a solo developer used to hacking things together late at night, this level of discipline can be jarring, but it is undeniably effective at preventing regressions.
+
+### The Workflow Phases
+
+When you start a task with a Superpowers-enabled agent, you don't just get code. You get a structured process:
+
+1.  **Brainstorming**: Before writing a single line, the agent stops and asks questions. It refines rough ideas, explores alternatives, and presents a design document in digestible chunks for your validation. This prevents the "rush to implementation" that often plagues AI interactions.
+2.  **Using Git Worktrees**: Once the design is approved, Superpowers enforces isolation. It creates a dedicated git worktree on a new branch, ensuring a clean test baseline. This means the agent isn't polluting your main workspace with experimental code.
+3.  **Writing Plans**: The agent breaks the validated design down into bite-sized tasks, typically taking 2-5 minutes each. Every task in the plan includes exact file paths, the code to be written, and the verification steps required to prove it works.
+4.  **Subagent-Driven Development (SDD)**: This is where Superpowers truly shines. Instead of executing the entire plan in a single massive context window, it dispatches *fresh subagents* for each individual task. This is a brilliant solution to context collapse. Each subagent only knows about its specific task, preventing it from getting confused by previous steps or unrelated code.
+5.  **Test-Driven Development**: As mentioned, this runs concurrently with implementation. The agent must write a failing test, watch it fail, write minimal code to make it pass, and then commit.
+6.  **Code Review**: Between tasks, a separate review agent acts as a quality gate, checking the implementation against the plan and reporting issues by severity. Critical issues block progress until resolved.
+7.  **Finishing**: Once all tasks are complete, the agent verifies the entire test suite, presents options for merging or creating a PR, and cleans up the worktree.
+
+### The Good, The Bad, and The Strict
+
+**What I love about Superpowers:**
+The isolation provided by subagents and git worktrees is phenomenal. It treats AI agents the way we treat modular code: small, focused, and independently verifiable. The strict adherence to TDD, while sometimes frustrating when you just want to prototype, results in remarkably stable code. It genuinely feels like working with a disciplined engineering team rather than a chaotic autocomplete engine.
+
+**The friction points:**
+Superpowers is heavy. It's an entire methodology imposed upon your workflow. If you just want a quick script or a CSS tweak, the brainstorming and planning phases feel like massive overkill. Furthermore, it relies heavily on the capabilities of the underlying agent harness (like Claude Code or Codex CLI). If the harness doesn't support subagents robustly, the entire methodology falls back to a much less effective sequential execution mode, which can quickly consume context windows.
+
+## OpenSpec: The Artifact-Guided Workflow
+
+While Superpowers focuses on strict process and execution guardrails, [OpenSpec](https://github.com/Fission-AI/OpenSpec) takes a fundamentally different route. Developed by Fission AI, OpenSpec is an **artifact-guided workflow**.
+
+If Superpowers is a strict senior engineer enforcing TDD, OpenSpec is a pragmatic technical product manager helping you write a clear Spec before you hand it off to the dev team.
+
+### The Core Philosophy
+
+OpenSpec is built around four principles:
+1.  **Fluid not rigid:** There are no hard phase gates. You can work on what makes sense at any given moment.
+2.  **Iterative not waterfall:** You learn as you build and refine the spec as you go.
+3.  **Easy not complex:** It boasts lightweight setup and minimal ceremony.
+4.  **Brownfield-first:** It is explicitly designed to work with existing codebases, focusing on specifying *changes* rather than describing entire systems from scratch.
+
+Unlike the heavy methodology of Superpowers, OpenSpec operates via slash commands (e.g., `/opsx:propose`, `/opsx:apply`) within your coding assistant's chat interface. It acts as a lightweight layer over your existing workflow rather than completely replacing it.
+
+### The Artifact Lifecycle
+
+OpenSpec organizes your work into distinct, version-controlled artifacts, stored in a dedicated `openspec/` directory in your project root. The workflow revolves around creating and refining these documents:
+
+1.  **The Source of Truth (`specs/`)**: This directory contains the living documentation of how your system *currently* works.
+2.  **The Proposal (`changes/<change-name>/`)**: When you want to build a new feature, you run `/opsx:propose <feature-name>`. OpenSpec doesn't write code; it generates a structured folder for the change containing:
+    *   `proposal.md`: Why we are doing this and what is changing.
+    *   `specs/`: "Delta specs" defining the specific requirements and scenarios for this feature.
+    *   `design.md`: The technical approach and architecture.
+    *   `tasks.md`: The implementation checklist.
+
+This step is crucial. You and the AI align on these markdown documents. You review them, edit them manually if necessary, and ensure the agent perfectly understands the intent before moving forward.
+
+3.  **Implementation (`/opsx:apply`)**: Once the artifacts are approved, you command the agent to implement the tasks defined in `tasks.md`. The agent uses the delta specs and design documents as its context, reducing hallucinations.
+4.  **Synchronization and Archiving (`/opsx:sync`, `/opsx:archive`)**: After the code is written and verified, OpenSpec merges the delta specs back into the main source of truth (`specs/`) and archives the change proposal, keeping your documentation perfectly up-to-date with your codebase.
+
+### The Good, The Bad, and The Fluid
+
+**What I love about OpenSpec:**
+OpenSpec is incredibly respectful of the developer's time and existing workflow. The "brownfield-first" approach is a breath of fresh air; most of my time is spent modifying ArceApps, not starting from `astro new`. By forcing the AI to generate a `design.md` and `tasks.md` first, I get a clear, readable contract of what it intends to do. If the design is wrong, I fix the markdown file, not the code. It drastically reduces the "AI churn" of generating code, realizing it's wrong, and trying to prompt it back on track.
+
+**The friction points:**
+OpenSpec provides the artifacts, but it doesn't strictly enforce *how* the implementation happens. Unlike Superpowers, it won't force the agent to write tests first, nor will it inherently dispatch parallel subagents (though you could theoretically combine OpenSpec artifacts with a subagent-capable harness). If your agent goes rogue during the `/opsx:apply` phase and ignores the `tasks.md`, OpenSpec doesn't have the deep process hooks to stop it, relying entirely on the underlying agent's adherence to instructions.
+
+
+## Head-to-Head Comparison
+
+To truly understand which framework fits your style, let's compare how they handle the critical stages of software development.
+
+### 1. Planning and Context Management
+
+**Superpowers** manages context through conversation and rigorous planning skills. It relies heavily on the agent's ability to interview you, extract the requirements, and formulate a plan dynamically. The plan is an ephemeral state within the agent's active memory or temporary files.
+
+**OpenSpec** externalizes context into durable markdown files. The plan is a concrete set of artifacts (`proposal.md`, `design.md`, `tasks.md`). This means the context is version-controlled, easily readable by humans, and can be paused and resumed days later without losing state.
+
+*Winner here depends on preference. If you want the AI to manage the process internally, Superpowers is smoother. If you want explicit, reviewable documents that act as contracts, OpenSpec is superior.*
+
+### 2. Execution and Implementation
+
+**OpenSpec** tells the agent *what* to do (via `tasks.md`) but largely leaves the *how* up to the agent's default behavior. It's a handoff: "Here is the spec, go build it."
+
+**Superpowers** dictates exactly *how* the code is written. It enforces the Red-Green-Refactor TDD cycle, demands git worktree isolation, and utilizes a complex subagent architecture to execute tasks independently. It is highly structured execution.
+
+*Superpowers wins the execution phase hands down. Its use of subagents to prevent context pollution during implementation is a game-changer for complex features.*
+
+### 3. Flexibility vs. Rigidity
+
+**OpenSpec** embraces fluidity. If you are halfway through implementation and realize the design needs a tweak, you just edit the `design.md` and continue. It doesn't force you into rigid phase gates.
+
+**Superpowers** is rigid by design. "Violating the letter of the rules is violating the spirit of the rules," its documentation states. If you try to skip writing a test, it will fight you. If you try to shortcut the planning phase, it will resist.
+
+*For indie hackers and rapid prototyping, OpenSpec's flexibility is much more accommodating. For mission-critical infrastructure where stability is paramount, Superpowers' rigidity is a feature, not a bug.*
+
+## The Indie Developer Verdict
+
+So, which one am I adopting for ArceApps?
+
+The reality of being an indie developer is that you have limited hours. You need tools that maximize your leverage without bogging you down in enterprise-level ceremony.
+
+If I am building a highly complex, isolated backend service—say, a new authentication flow or a critical data migration script—I want **Superpowers**. The guarantee of TDD and the safety of subagent isolation are worth the upfront investment in conversation and planning. It acts as the rigorous pair programmer I don't have.
+
+However, for 80% of my daily work—adding new UI components to the Astro portfolio, writing blog posts, tweaking Tailwind styles, or implementing standard CRUD features—**OpenSpec** is the clear winner. Its "brownfield-first" approach maps perfectly to how I actually work. I love being able to run `/opsx:propose add-dark-mode`, review a cleanly generated markdown file detailing exactly what CSS variables will be touched, and then approve the implementation. It provides just enough structure to prevent hallucinations without feeling like a straitjacket.
+
+### The Ultimate Stack?
+
+The holy grail of agentic engineering might not be choosing between them, but combining their strengths. Imagine a workflow where you use OpenSpec to generate the durable, version-controlled artifacts (`design.md`, `tasks.md`), and then hand those exact tasks off to a Superpowers-style subagent orchestrator that enforces TDD during the execution of each specific task.
+
+We are still in the early days of Spec-Driven Development. Both Superpowers and OpenSpec are brilliant attempts to tame the chaos of LLM coding. They prove that the future of AI engineering isn't just about better models; it's about better methodologies.
+
+As we move toward 2026, the developers who thrive won't be the ones who can write the fastest prompts. They will be the ones who know how to architect clear specifications and orchestrate agents effectively within structured frameworks. Whether you lean toward the strict discipline of Superpowers or the fluid documentation of OpenSpec, adopting a structured methodology is the only way to scale your solo development efforts without losing your mind.
+
+## A Deeper Technical Dive: Integrating with Existing Tooling
+
+To fully appreciate the divergence between these two frameworks, we must look at how they integrate with the developer's existing ecosystem. This isn't just about abstract philosophy; it's about what happens in your terminal and your IDE.
+
+### Superpowers: The Harness Dependency
+
+Superpowers is fundamentally a set of advanced prompt engineering techniques and workflow scripts that must be injected into an existing agent "harness." It explicitly supports tools like Claude Code, Codex CLI, Cursor, and GitHub Copilot CLI.
+
+The integration relies on the concept of "Skills." When you install Superpowers into Claude Code, for example, you are essentially loading a library of pre-defined behaviors (`test-driven-development`, `subagent-driven-development`, `writing-plans`). The framework relies on the underlying LLM to recognize the context of your request and autonomously trigger the appropriate skill.
+
+This creates a highly magical experience when it works perfectly. You say, "I need to fix the authentication bug," and the agent autonomously decides to trigger the `systematic-debugging` skill, asks you probing questions, formulates a hypothesis, creates a git worktree, writes a failing test, and fixes the bug.
+
+However, this deep integration has a significant downside: **Brittle Harness Dependency**. If Claude Code updates its internal system prompt, or if the LLM's behavior drifts, the trigger mechanisms for Superpowers' skills can break. The framework is constantly fighting against the native tendencies of the underlying agent. Furthermore, the most powerful feature—subagent dispatching—is entirely dependent on whether the host harness supports spawning parallel, isolated agent instances. If you are using a harness that only supports sequential chat history, Superpowers loses its biggest advantage and becomes a very token-heavy conversational partner.
+
+### OpenSpec: The CLI Agnostic Approach
+
+OpenSpec, conversely, takes a more decoupled approach. It is primarily a Node.js CLI tool (`npm install -g @fission-ai/openspec`) that manages the file system.
+
+The "integration" with your coding agent is much looser and more resilient. OpenSpec generates the `/openspec` directory and the markdown artifacts. It then relies on the coding agent (whether it's Cursor, Windsurf, or a simple terminal integration) to read those files as standard context.
+
+When you type `/opsx:propose` in your AI chat interface, you aren't triggering a complex internal LLM state machine like in Superpowers. You are simply running a command that tells the OpenSpec CLI to scaffold some folders and generate a markdown template based on your prompt.
+
+This decoupled architecture makes OpenSpec incredibly resilient. It doesn't care if you switch from Claude 3.5 Sonnet to GPT-4o, or if you move from Cursor to a custom CLI tool. As long as the agent can read markdown files in your repository, OpenSpec works. The artifacts—`proposal.md`, `design.md`, `tasks.md`—are universally understood formats.
+
+This resilience makes OpenSpec much easier to adopt for a solo developer who might be experimenting with different AI coding tools. You aren't locking yourself into a specific harness's plugin ecosystem.
+
+## Real-World Scenarios: Where They Shine
+
+Let's ground this comparison in practical, everyday scenarios I encounter while maintaining the ArceApps portfolio.
+
+### Scenario A: The UI Component Refactor
+
+**The Task:** I need to refactor the blog card component (`BlogCard.astro`) to use the new logical CSS properties defined in Tailwind v4, ensuring RTL compatibility without changing the visual design.
+
+**Using Superpowers:**
+The agent would likely trigger the `brainstorming` skill, asking me clarifying questions about RTL edge cases. It would then create a new worktree, write a test suite verifying the visual layout (which is notoriously difficult for UI components without visual regression testing), and then implement the CSS changes. The overhead of TDD for purely stylistic CSS refactoring is immense and often counterproductive. I would spend more time arguing with the agent about testing CSS classes than actually writing the CSS.
+
+**Using OpenSpec:**
+I would run `/opsx:propose refactor-blog-card-css`. It generates a `design.md` noting the shift to logical properties (e.g., changing `ml-4` to `ms-4`). I approve the markdown. I run `/opsx:apply`. The agent reads the design, modifies `BlogCard.astro`, and finishes. Quick, clean, and perfectly aligned with the task's complexity.
+
+### Scenario B: Implementing a Complex Search Algorithm
+
+**The Task:** I need to replace the basic client-side search with a custom TF-IDF indexing script that runs during the Astro build process and outputs a highly optimized JSON index for the client to consume.
+
+**Using OpenSpec:**
+I propose the change, and OpenSpec generates a solid design document detailing the TF-IDF math and the Astro integration points. I apply the change. The agent attempts to write the build script and the client-side consumer in one go. Because the task spans multiple architectural boundaries (Node.js build step vs. browser-side hydration) and requires precise mathematical logic, the agent gets confused halfway through `tasks.md`. It hallucinates a missing dependency, breaks the Astro build, and I have to step in, revert the changes, and manually guide it step-by-step.
+
+**Using Superpowers:**
+The agent recognizes the complexity and triggers `writing-plans`. It breaks the TF-IDF algorithm into small, mathematically verifiable functions. It triggers `subagent-driven-development`. Subagent A writes a test for the term frequency calculation, watches it fail, and implements the math perfectly. Subagent B handles the inverse document frequency. Subagent C writes the Astro integration test. Because each subagent operates in an isolated context, they don't confuse the build script logic with the client-side UI logic. The rigorous TDD ensures the math is correct before it ever touches the Astro build process. The feature lands perfectly, fully tested.
+
+## Conclusion: Engineering is Contextual
+
+The comparison between Superpowers and OpenSpec is not about finding the "best" tool in a vacuum; it is about finding the right tool for the specific context of your engineering challenge.
+
+Superpowers is the heavy cavalry. It brings rigorous engineering discipline, enforced testing, and advanced isolation techniques to AI coding. It is ideal for complex, algorithmic, or mission-critical backend work where correctness is non-negotiable.
+
+OpenSpec is the agile infantry. It provides lightweight, artifact-driven structure that respects your existing workflow and scales seamlessly with brownfield projects. It is perfect for the day-to-day feature development, UI tweaks, and rapid iterations that define the indie developer experience.
+
+For the ArceApps portfolio, I find myself reaching for OpenSpec the vast majority of the time. Its fluid nature and markdown-based contracts fit perfectly with a project built on Astro and static content. However, knowing that tools like Superpowers exist—and understanding the philosophy behind subagent isolation and strict TDD enforcement—has profoundly changed how I write prompts and structure my own workflows, even when I'm not explicitly using the framework.
+
+Ultimately, the shift towards Spec-Driven Development is the most important takeaway. Whether you choose the strict process of Superpowers or the fluid artifacts of OpenSpec, moving away from unstructured chat and toward defined methodologies is the key to unlocking the true potential of AI agents in software engineering.

--- a/src/content/blog/es/blog-superpowers-deep-dive.md
+++ b/src/content/blog/es/blog-superpowers-deep-dive.md
@@ -1,0 +1,236 @@
+---
+title: "Dentro de Superpowers: El Framework que Obliga a la IA a Hacer Ingeniería"
+description: "Un análisis técnico exhaustivo de la metodología Superpowers, explorando su orquestación de subagentes, la aplicación estricta de TDD y cómo transforma a la IA de un programador caótico a un socio de ingeniería disciplinado."
+pubDate: 2026-04-19
+heroImage: "/images/blog-superpowers-deep-dive.svg"
+tags: ["Superpowers", "Agentes IA", "TDD", "Subagentes", "Metodología", "Ingeniería", "Workflow", "Análisis Profundo"]
+reference_id: "b7c3e5d1-9a2f-4c8e-b1d6-8a9f2e3d4c5b"
+---
+
+> **Lectura previa recomendada:** [Metodologías de Ingeniería Agéntica: Superpowers vs OpenSpec](/blog/blog-superpowers-vs-openspec) · [Subagentes en OpenCode](/blog/blog-opencode-subagents) · [TDD e IA en el Desarrollo Android](/blog/blog-ia-tdd-android)
+
+Si has pasado una cantidad significativa de tiempo construyendo software con agentes de IA, conoces el ciclo. Empiezas con una idea brillante, escribes un prompt detallado y presionas Enter. El agente escribe 500 líneas de código. Lo ejecutas. Falla. Pegas el error de vuelta. Escribe otras 200 líneas, arreglando el error pero rompiendo silenciosamente una funcionalidad no relacionada. Dos horas después, te estás ahogando en un mar de historial de chat contaminado por el contexto, revirtiendo archivos manualmente y preguntándote por qué no escribiste el código tú mismo desde el principio.
+
+Esta es la realidad de la generación con IA sin restricciones. Los Grandes Modelos de Lenguaje (LLMs) son motores probabilísticos de texto; sin barandillas estrictas, se desvían. Alucinan APIs, olvidan casos límite y abandonan patrones arquitectónicos en el instante en que aparece un error.
+
+Entra [Superpowers](https://github.com/obra/superpowers).
+
+Desarrollado por Jesse Vincent, Superpowers no es solo un *wrapper* o un conjunto de prompts ingeniosos. Se describe a sí mismo como una "metodología de desarrollo de software completa para tus agentes de programación". Después de pasar semanas diseccionando su código fuente y poniéndolo a prueba en el portafolio de ArceApps, puedo decir con confianza que es el enfoque más obstinado, riguroso y fascinante para la programación con IA disponible actualmente.
+
+En mi artículo anterior, [comparé Superpowers con OpenSpec](/blog/blog-superpowers-vs-openspec), destacando las diferencias filosóficas entre los frameworks orientados a procesos y los orientados a artefactos. Hoy, vamos a llegar hasta el fondo de la madriguera del conejo. Veremos exactamente cómo funciona Superpowers, cómo están estructuradas sus "habilidades" (*skills*), por qué su uso de subagentes paralelos es una genialidad y en qué puntos flaquea el framework.
+
+## Los Cimientos: Habilidades Componibles
+
+Para entender Superpowers, tienes que entender cómo interactúa con la IA. Superpowers está diseñado para ejecutarse *dentro* de un entorno o *harness* de agente existente, como Claude Code, Codex CLI o Cursor.
+
+En lugar de un único y monolítico prompt del sistema, Superpowers se construye como una biblioteca de "Habilidades" (*Skills*). Cada habilidad se define en un archivo markdown que contiene un nombre, una descripción de cuándo usarla y un conjunto de instrucciones altamente detalladas.
+
+Cuando instalas el plugin, estas habilidades se cargan en el contexto del agente. Se instruye al prompt del sistema nativo del agente para que evalúe la solicitud del usuario y active de forma autónoma la habilidad pertinente.
+
+Aquí están algunas de las habilidades centrales en la biblioteca de Superpowers:
+*   `test-driven-development` (Desarrollo Guiado por Pruebas)
+*   `systematic-debugging` (Depuración Sistemática)
+*   `brainstorming` (Lluvia de ideas)
+*   `writing-plans` (Redacción de planes)
+*   `using-git-worktrees` (Uso de Git Worktrees)
+*   `subagent-driven-development` (Desarrollo Guiado por Subagentes)
+
+### La Anatomía de una Habilidad
+
+Veamos cómo se escribe realmente una habilidad. No es texto conversacional educado; es un algoritmo estricto que el LLM debe seguir. Tomemos como ejemplo la habilidad `test-driven-development`. La documentación declara explícitamente:
+
+> **La Ley de Hierro:** NINGÚN CÓDIGO DE PRODUCCIÓN SIN UNA PRUEBA QUE FALLE PRIMERO. ¿Escribiste código antes que la prueba? Bórralo. Empieza de nuevo. Sin excepciones.
+
+Esto es ingeniería de prompts llevada a su extremo lógico. No deja margen para que el LLM se salte pasos "para ayudar". Si el agente activa la habilidad TDD, está obligado por estas instrucciones. Esta arquitectura componible significa que puedes añadir nuevas habilidades o modificar las existentes sin tener que reescribir toda la lógica del framework.
+
+## El Flujo de Trabajo de Superpowers: De la Idea a la Ejecución
+
+El verdadero poder de Superpowers se hace evidente cuando ves encadenarse estas habilidades. Cuando pides al agente que implemente una nueva funcionalidad, no empieza a escribir código sin más. Inicia un flujo de trabajo complejo de múltiples etapas.
+
+### Fase 1: Lluvia de Ideas (`brainstorming`)
+
+En el momento en que el agente detecta que quieres construir algo nuevo, se detiene. Se niega a escribir código. En su lugar, activa la habilidad de `brainstorming`.
+
+Esta fase es socrática. El agente hace preguntas incisivas sobre casos límite, estructuras de datos y restricciones arquitectónicas. Una vez que tiene suficiente información, genera un documento de diseño preliminar y te lo presenta *en fragmentos*. Te obliga a validar el diseño antes de continuar.
+
+Como desarrollador independiente, esto tiene un valor incalculable. A menudo abordo una funcionalidad con una idea a medio cocinar. Tener a un agente cuestionando implacablemente mis suposiciones ("¿Cómo manejará este componente de UI los idiomas RTL?", "¿Cuál es el plan de contingencia si la API supera el límite de peticiones?") detecta fallos fundamentales antes de que queden fijados en el código.
+
+### Fase 2: Aislamiento (`using-git-worktrees`)
+
+Una vez aprobado el diseño, Superpowers impone un espacio de trabajo limpio. Activa la habilidad `using-git-worktrees`.
+
+En lugar de contaminar tu rama actual con código experimental generado por IA, crea un `git worktree` dedicado en un directorio temporal en una nueva rama. Luego ejecuta los scripts de configuración de tu proyecto y verifica que la suite de pruebas pase limpiamente en este entorno aislado. Si las pruebas fallan antes de siquiera empezar, el proceso se detiene.
+
+Esto garantiza que cualquier fallo posterior sea culpa del nuevo código, no de la contaminación del entorno.
+
+
+### Fase 3: El Plan (`writing-plans`)
+
+Con un worktree limpio y listo, el agente activa `writing-plans`. Toma el diseño aprobado y lo desglosa en un plan de implementación en formato markdown altamente granular.
+
+Superpowers dicta que las tareas deben ser "pequeñas" (bocados de 2 a 5 minutos de trabajo). Cada tarea en el plan debe incluir:
+1.  Rutas de archivo exactas.
+2.  El código completo que se debe escribir (nada de placeholders como "etc." o "implementa la lógica aquí").
+3.  Pasos de verificación específicos (la prueba que debe escribirse).
+
+Este plan actúa como el plano para el resto de la ejecución. Es el artefacto crucial que evita que el agente pierda el rumbo.
+
+### Fase 4: Orquestación de Subagentes (`subagent-driven-development`)
+
+Esta es la joya de la corona de la metodología Superpowers. Si tu entorno base lo soporta (como Claude Code), el agente principal activará ahora el `subagent-driven-development` (Desarrollo Guiado por Subagentes).
+
+En lugar de que el agente principal lea el plan e intente ejecutar los 15 pasos en una sesión masiva y cargada de contexto, se convierte en un orquestador. Para la Tarea 1, genera un *subagente completamente nuevo*.
+
+El orquestador le entrega al subagente solo lo que necesita:
+*   El contexto general (para que sepa dónde encaja).
+*   Las instrucciones específicas para la Tarea 1.
+*   La orden estricta de seguir la habilidad `test-driven-development`.
+
+El subagente se despierta, escribe la prueba que falla, escribe la implementación, hace que la prueba pase y reporta su estado. Luego, es terminado.
+
+El orquestador inicia entonces una **revisión en dos etapas**:
+1.  **Revisión de Cumplimiento de Especificaciones:** ¿Construyó el subagente exactamente lo que la Tarea 1 exigía?
+2.  **Revisión de Calidad del Código:** ¿Cumple el código con los estándares del proyecto?
+
+Si la revisión falla, el orquestador genera un nuevo subagente "reparador" con comentarios específicos. Si pasa, pasa a la Tarea 2 y genera otro subagente completamente fresco.
+
+### Por Qué los Subagentes lo Cambian Todo
+
+Si alguna vez has visto a un LLM intentar implementar un plan de 10 pasos en un solo chat, has visto el colapso del contexto. Para el Paso 6, el LLM ha olvidado las restricciones arquitectónicas establecidas en el Paso 1. Empieza a repetirse, confunde nombres de variables de pasos anteriores y, en general, se degrada en su capacidad de razonamiento a medida que el conteo de tokens explota.
+
+Los subagentes resuelven esto de forma elegante. Un subagente nuevo tiene cero recuerdos de las dificultades del paso anterior. Su ventana de contexto está vacía, su mecanismo de atención está enfocado como un láser y su generación de tokens es barata. Solo sabe sobre la Tarea N.
+
+Este aislamiento es cómo Superpowers puede funcionar autónomamente durante dos horas, implementando funcionalidades complejas en docenas de archivos, sin desviarse del plan original. Imita cómo un líder técnico (el orquestador) delega pequeños tickets a desarrolladores junior (los subagentes) y revisa sus Pull Requests antes de seguir adelante.
+
+## La Ley de Hierro de TDD en la Práctica
+
+Veamos más de cerca cómo Superpowers impone el TDD. Para muchos desarrolladores humanos, TDD es una aspiración, no una realidad diaria. Superpowers obliga a que sea una realidad.
+
+Cuando se asigna a un subagente la tarea de implementar una funcionalidad, la habilidad `test-driven-development` prohíbe explícitamente escribir código de producción primero.
+
+Si estás construyendo una aplicación de Android y le pides que implemente un nuevo `ViewModel`, no escribirá el código Kotlin para el `ViewModel`. Primero escribirá `MyViewModelTest.kt`, instanciando el view model y afirmando que el estado inicial es correcto. Ejecutará la prueba. La prueba fallará (porque la clase no existe). Solo entonces escribirá el esqueleto de la clase `ViewModel`.
+
+Este proceso es lento. Se siente agónicamente metódico cuando estás viendo la salida del terminal. El agente ejecuta `pnpm test`, lee los logs de fallos, escribe tres líneas de código, ejecuta `pnpm test` de nuevo, lee los logs de éxito y hace un commit.
+
+Pero el resultado es innegable. Cuando termina la ejecución de Superpowers, no tienes solo una funcionalidad; tienes una funcionalidad completamente probada. Tienes absoluta confianza en que el código funciona exactamente como se especificó en el plan. Para un desarrollador indie que gestiona solo una base de código compleja, esta red de seguridad automatizada no tiene precio.
+
+
+## Análisis Crítico: Lo Bueno, Lo Malo y Lo Brutal
+
+Superpowers es una pieza increíble de ingeniería, pero no es una bala de plata. Tras un uso extensivo, aquí están mis opiniones sin barniz sobre sus fortalezas y debilidades.
+
+### Lo Bueno: Calidad y Enfoque Sin Precedentes
+
+**1. Preservación del Contexto a través del Aislamiento:** La arquitectura de subagentes es la característica estrella. Al hacer borrón y cuenta nueva para cada tarea discreta, Superpowers elimina por completo la deriva del contexto que plaga las sesiones largas de IA. La calidad del código generado en la Tarea 15 es tan nítida como el código generado en la Tarea 1.
+
+**2. El Fin de "En mi máquina funciona":** La insistencia en los git worktrees es brillante. ¿Cuántas veces has dejado a una IA suelta en tu repositorio, solo para darte cuenta de que modificó un archivo de configuración con el que estabas experimentando, rompiendo tu entorno local? Los worktrees garantizan que la IA opera en un laboratorio estéril, probando que su código funciona contra una línea base limpia.
+
+**3. TDD como Barandilla de Seguridad:** Mientras que los desarrolladores humanos a menudo discuten sobre el retorno de inversión del TDD estricto, para un agente de IA, es la barandilla de seguridad definitiva. La prueba actúa como una validación objetiva y legible por máquina de que el agente entendió el prompt. Si el agente alucina, la prueba falla. Obliga al LLM a fundamentar su razonamiento en una realidad ejecutable.
+
+### Lo Malo: Fricción y Velocidad
+
+**1. Es Agónicamente Lento:** Superpowers sacrifica la velocidad por la exactitud. Una tarea que podrías hackear manualmente en 10 minutos podría tomarle a Superpowers 45 minutos entre hacer la lluvia de ideas, planificar, crear el worktree, probar, implementar y revisar. Si estás haciendo prototipado rápido o ajustes visuales de UI, la metodología se siente como caminar sobre melaza. Está diseñado para hacer ingeniería, no para hackear.
+
+**2. Gula de Tokens:** El flujo de trabajo es increíblemente intensivo en tokens. El constante cambio de contexto, la lluvia de ideas socrática, la redacción y lectura de extensos documentos de planes y el ir y venir del ciclo TDD consumen cantidades masivas de créditos de API. Si estás pagando por token, Superpowers quemará un agujero en tu cartera rápidamente.
+
+**3. La Carga del Boilerplate:** A veces, solo quieres añadir una sola clase CSS o corregir un error tipográfico en un archivo markdown. Activar el flujo de trabajo de Superpowers para estas microtareas es absurdo. Tienes que luchar activamente contra el framework o salir de él para hacer cosas sencillas.
+
+### Lo Feo: Dependencia del Entorno y Fragilidad
+
+El mayor defecto fundamental de Superpowers es su arquitectura como un plugin que reside *dentro* del prompt de un LLM.
+
+Debido a que depende del LLM anfitrión (como Claude 3.5 Sonnet dentro de la CLI de Claude Code) para leer las instrucciones de la habilidad y ejecutarlas sin problemas, es inherentemente frágil. Los LLMs no son máquinas de estado deterministas. A veces, a pesar de las instrucciones estrictas en `subagent-driven-development`, el orquestador se vuelve perezoso e intenta ejecutar una tarea él mismo en lugar de despachar a un subagente. A veces decide escribir la implementación antes que la prueba, violando flagrantemente "La Ley de Hierro".
+
+Cuando esto sucede, toda la metodología se viene abajo. Te encuentras gritándole a la terminal: "¡No, lee la documentación de la habilidad de nuevo!"
+
+Además, el framework depende en gran medida de las capacidades del entorno CLI. Si usas un entorno que carece de una API robusta para subagentes, Superpowers recurre a un modo de ejecución secuencial mucho menos efectivo (`executing-plans`), anulando su mayor ventaja. Se siente como intentar ejecutar un sistema operativo de alto rendimiento en una capa de abstracción de hardware que cambia las reglas constantemente.
+
+## El Veredicto: ¿Para Quién es Superpowers?
+
+Superpowers no es para todos. Si tu principal caso de uso para la IA es escribir código repetitivo, generar scripts simples o ayudar con los diseños CSS, este framework te frustrará inmensamente. Te sentirás empantanado por el proceso y la ceremonia. Para esas tareas, un enfoque guiado por artefactos como OpenSpec es muy superior.
+
+Sin embargo, si eres un desarrollador en solitario que construye sistemas de backend complejos, algoritmos intrincados o tuberías de datos de misión crítica —escenarios donde un error sutil puede causar un fallo catastrófico— Superpowers es una revelación.
+
+Es lo más cercano que he experimentado a tener a un riguroso programador senior trabajando a mi lado. Me obliga a pensar bien mis diseños, exige que mis pruebas sean exhaustivas y ejecuta los planes de implementación con un enfoque implacable e incansable.
+
+Para el portafolio de ArceApps, no uso Superpowers todos los días. Pero cuando necesito refactorizar la lógica central de indexación de búsqueda, o cuando estoy construyendo una compleja máquina de estados para una nueva mecánica de juego en PuzzleHub, Superpowers es la herramienta a la que recurro. Con gusto intercambio la velocidad y el costo de los tokens por la absoluta tranquilidad de saber que el código es robusto, está aislado y perfectamente probado.
+
+A medida que la IA agéntica continúe evolucionando, es probable que veamos estos conceptos metodológicos integrados directamente en el IDE o en el propio entorno. Pero ahora mismo, Superpowers se erige como un ejemplo pionero de cómo obligar a los motores probabilísticos de texto a hacer ingeniería rigurosa y determinista. Es un vistazo al futuro de la colaboración humano-IA, donde el humano proporciona la arquitectura, y el agente, atado por la metodología, proporciona la ejecución.
+
+## Diseccionando la Habilidad de "Redacción de Planes"
+
+Para apreciar verdaderamente la profundidad de la metodología Superpowers, debemos examinar la mecánica específica de su fase de planificación. La habilidad `writing-plans` no es meramente una sugerencia para "hacer una lista"; es un contrato arquitectónico rígido.
+
+Cuando un agente activa esta habilidad, se le instruye para generar un documento Markdown que sigue un esquema altamente específico. Esto no es solo para la legibilidad humana; está diseñado para que los subagentes posteriores puedan analizar las tareas sin ambigüedades.
+
+Una tarea típica generada por `writing-plans` se ve así:
+
+```markdown
+### Tarea 1.2: Implementar la Validación del Token de Autenticación
+
+**Contexto**: Necesitamos validar el token JWT en las solicitudes de API entrantes antes de permitir el acceso a las rutas protegidas.
+
+**Archivo a modificar**: `src/middleware/auth.ts`
+
+**Acción**: Crear una nueva función middleware `validateToken`.
+
+**Código a escribir**:
+- Importar la biblioteca `jsonwebtoken`.
+- Extraer el token Bearer de la cabecera `Authorization`.
+- Usar `jwt.verify` con la variable de entorno `JWT_SECRET`.
+- Si es válido, adjuntar el payload del usuario decodificado al objeto `req` y llamar a `next()`.
+- Si es inválido o falta, devolver una respuesta `401 Unauthorized` con un mensaje de error en JSON.
+
+**Verificación (Requisito TDD)**:
+- Crear `src/middleware/auth.test.ts`.
+- Escribir pruebas para:
+  - Token faltante (devuelve 401).
+  - Firma inválida (devuelve 401).
+  - Token expirado (devuelve 401).
+  - Token válido (llama a next() y adjunta el usuario a req).
+```
+
+### Por Qué Importa esta Granularidad
+
+Observa el nivel de detalle aquí. El agente orquestador no dice "Añade un middleware de autenticación". Especifica la ruta del archivo, el flujo lógico exacto y, críticamente, los casos límite exactos que deben ser probados.
+
+Esta granularidad es el antídoto contra la alucinación de los LLM. Cuando el subagente fresco recibe esta tarea, no tiene que adivinar cómo debería funcionar la autenticación. No tiene que inventar una nueva abstracción. Simplemente ejecuta la especificación técnica altamente restringida.
+
+Si el plan fuera vago, el subagente podría decidir implementar un sistema de autenticación basado en sesiones personalizado en lugar de JWT, o podría olvidar manejar el caso límite del token caducado. Al obligar al agente planificador a pensar en estos detalles por adelantado durante la fase de `writing-plans`, Superpowers asegura que la fase de ejecución sea puramente mecánica.
+
+## El Proceso de Revisión en Dos Etapas
+
+Otro aspecto fascinante de la habilidad `subagent-driven-development` es el proceso obligatorio de revisión en dos etapas. En un flujo de trabajo típico de codificación con IA, el agente escribe el código, dice "He terminado" y tú revisas el *diff*.
+
+Superpowers automatiza las capas iniciales de esta revisión, imitando a un desarrollador senior revisando el *Pull Request* de un junior.
+
+Una vez que un subagente completa una tarea (lo que significa que las pruebas pasan y el código está escrito), el agente orquestador no fusiona inmediatamente el trabajo ni pasa a la siguiente tarea. En cambio, se detiene y realiza dos revisiones distintas:
+
+### 1. Revisión de Cumplimiento de Especificaciones
+El orquestador mira la descripción original de la tarea en el plan y la compara con la implementación del subagente. ¿Construyó el subagente exactamente lo que se pidió?
+
+Si la tarea pedía una función que devolviera un booleano, y el subagente escribió una función que devuelve un objeto, la revisión de cumplimiento falla. El orquestador generará un nuevo subagente "reparador", pasándole el error: *"La implementación devuelve un objeto, pero la especificación requiere un booleano. Corrige la implementación y actualiza las pruebas en consecuencia."*
+
+Esto previene la corrupción de características (*feature creep*) y asegura que la arquitectura se mantenga alineada con el diseño original.
+
+### 2. Revisión de Calidad del Código
+Solo después de que el código pasa la comprobación de cumplimiento de especificaciones, el orquestador evalúa la calidad del código. Esta revisión busca las mejores prácticas estándar de ingeniería:
+*   **DRY (Don't Repeat Yourself):** ¿Duplicó el subagente lógica que ya existe en otro lugar de la base de código?
+*   **YAGNI (You Aren't Gonna Need It):** ¿Sobre-ingenierizó el subagente la solución añadiendo abstracciones innecesarias o interfaces genéricas?
+*   **Complejidad:** ¿Es el código excesivamente complejo o difícil de leer? ¿Son descriptivos los nombres de las variables?
+
+Si el código es un desastre o está sobre-ingenierizado, el orquestador instruirá a un subagente reparador para que lo refactorice.
+
+Este riguroso ciclo de revisión automatizado es agotador de ver en la terminal, pero el resultado es impecable. Obliga a la IA a producir código que no solo es funcional, sino mantenible.
+
+## El Futuro de los Flujos de Trabajo Agénticos
+
+Trabajar con Superpowers se siente como asomarse al futuro del desarrollo de software. Nos estamos alejando de tratar a la IA como un motor de autocompletado altamente avanzado, y avanzando hacia tratarla como un participante activo en una organización de ingeniería.
+
+La implementación actual de Superpowers tiene sus fallos —que en su mayoría provienen de las limitaciones de los LLMs subyacentes y la fragilidad de las arquitecturas de plugins basadas en prompts—. Los costos de los tokens son altos y el proceso es lento.
+
+Sin embargo, los conceptos centrales —aislamiento forzado a través de subagentes, desarrollo guiado por pruebas obligatorio, planificación explícita y revisiones automatizadas en múltiples etapas— son principios de ingeniería fundamentalmente sólidos.
+
+A medida que los LLMs se vuelvan más rápidos, más baratos y posean ventanas de contexto más grandes y confiables, la fricción de esta metodología disminuirá. Con el tiempo, es probable que los IDEs integren estos conceptos de forma nativa en sus interfaces. No necesitarás instalar un plugin de habilidades basado en Markdown; tu editor simplemente creará contenedores seguros y aislados para subagentes, impondrá visualmente las pruebas y orquestará el flujo de trabajo sin problemas.
+
+Hasta entonces, para aquellos que construyen aplicaciones complejas donde la exactitud importa más que la velocidad, el framework Superpowers de Jesse Vincent ofrece la metodología más rigurosa, disciplinada y efectiva disponible para domar el caos de la IA agéntica. Requiere paciencia y la voluntad de adoptar el proceso, pero la recompensa es una base de código en la que realmente puedes confiar.

--- a/src/content/blog/es/blog-superpowers-vs-openspec.md
+++ b/src/content/blog/es/blog-superpowers-vs-openspec.md
@@ -1,0 +1,220 @@
+---
+title: "Metodologías de Ingeniería Agéntica: Superpowers vs OpenSpec"
+description: "Una comparación profunda de dos enfoques distintos para el desarrollo de software con IA: la metodología basada en habilidades de Superpowers y el flujo de trabajo guiado por artefactos de OpenSpec."
+pubDate: 2026-04-12
+heroImage: "/images/blog-superpowers-vs-openspec.svg"
+tags: ["SDD", "IA", "Superpowers", "OpenSpec", "IA Agéntica", "Metodología", "Workflow", "Productividad"]
+reference_id: "e4d2a1c9-6f8b-4a3d-8e7c-2b1d9f4a5c6d"
+---
+
+> **Lectura previa recomendada:** [Desarrollo Guiado por Especificaciones con IA Agéntica](/blog/blog-specs-driven-development) · [Paradigmas Alternativos en Ingeniería de Software con IA](/blog/blog-paradigmas-alternativos-ingenieria-software-ia) · [Análisis Profundo de Frameworks SDD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad)
+
+Cuando comencé a incorporar agentes de programación con IA en mi flujo de trabajo diario para ArceApps, la fase de luna de miel no duró mucho. Al principio, parecía magia: dejabas un prompt en el chat, veías cómo el código brotaba de la nada y le dabas a commit. Pero a medida que las aplicaciones crecían en complejidad, también lo hacía la fricción. Los agentes alucinaban decisiones arquitectónicas, sobrescribían abstracciones perfectamente válidas con implementaciones ingenuas y, lo peor de todo, rompían comportamientos existentes en silencio porque carecían del contexto general de lo que estaba intentando construir.
+
+El problema central no era la capacidad de razonamiento del LLM; era la falta de una **metodología** estructurada. No dejaríamos suelto a un desarrollador junior en una base de código de producción sin una especificación técnica, un plan claro y un proceso de revisión de código. Sin embargo, habitualmente esperamos que los agentes de IA intuyan mágicamente nuestra intención arquitectónica a partir de un prompt de tres frases.
+
+Esta realización condujo al auge del Desarrollo Guiado por Especificaciones (SDD) y los frameworks agénticos. En un artículo anterior, analicé [GitHub Spec Kit, OpenSpec y BMAD-METHOD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad). Hoy quiero enfrentar a dos de los enfoques más fascinantes: [Superpowers](https://github.com/obra/superpowers) y [OpenSpec](https://github.com/Fission-AI/OpenSpec).
+
+Ambas herramientas pretenden resolver el mismo problema —mantener a los agentes de IA alineados y evitar el colapso de contexto—, pero lo abordan desde ángulos filosóficos completamente diferentes. Superpowers es una metodología prescriptiva basada en habilidades que impone prácticas de ingeniería estrictas como el Desarrollo Guiado por Pruebas (TDD). OpenSpec, por otro lado, es un flujo de trabajo guiado por artefactos que se centra en crear documentación viva antes de escribir cualquier código.
+
+En este análisis profundo, exploraremos cómo funcionan estos frameworks bajo el capó, compararemos sus filosofías y discutiremos cuál podría encajar mejor en tu flujo de trabajo como desarrollador independiente. Como *solo dev* que construye proyectos en noches y fines de semana, mi tolerancia por el código repetitivo (*boilerplate*) y la ceremonia burocrática es increíblemente baja. Necesito herramientas que amplifiquen mi intención, no sistemas que me conviertan en un gestor de proyectos para mis propios proyectos paralelos. Veamos cómo se comparan estos dos.
+
+## La Evolución de la Programación con IA: Del Chat a la Metodología
+
+Antes de comparar los frameworks específicos, necesitamos entender la evolución de cómo interactuamos con los agentes de IA.
+
+### Generación 1: La Era del Copiloto
+La primera generación fue el autocompletado de código en línea. Escribías un comentario y la IA sugería las siguientes líneas. Era útil para el *boilerplate*, pero no cambiaba fundamentalmente la forma en que se diseñaba el software. El contexto se limitaba al archivo activo y quizás a algunas pestañas abiertas.
+
+### Generación 2: La Era del Chat
+La segunda generación llevó la interfaz de chat al IDE. Podías resaltar un bloque de código y pedir a la IA que lo refactorizara, o pegar un mensaje de error y pedir una solución. Esto fue un gran salto adelante, pero todavía dependía del desarrollador para mantener todo el modelo mental de la aplicación en su cabeza. La IA era un becario inteligente al que tenías que microgestionar.
+
+### Generación 3: La Era Agéntica
+Ahora estamos en la tercera generación, donde herramientas como Claude Code, Cursor y OpenCode pueden ejecutar tareas complejas en múltiples archivos. Pueden ejecutar comandos de terminal, leer logs y modificar la base de código de forma autónoma. Pero con este poder viene una nueva clase de problemas. Cuando a un agente se le da libertad para vagar por un repositorio, fácilmente puede perder de vista el objetivo original. Podría refactorizar una clase de utilidad central mientras intenta arreglar un error menor de UI, provocando fallos en cascada.
+
+Aquí es donde las metodologías se vuelven críticas. Al igual que Agile y Scrum proporcionaron estructura a los equipos humanos, ahora necesitamos frameworks para la colaboración humano-IA. El objetivo es restringir la autonomía del agente dentro de límites definidos, asegurando que sus acciones estén alineadas con nuestra intención.
+
+Esto nos lleva a Superpowers y OpenSpec. Ambos son respuestas al caos de la programación agéntica sin restricciones, pero representan dos filosofías distintas: el enfoque **Orientado a Procesos** (Superpowers) frente al enfoque **Orientado a Artefactos** (OpenSpec).
+
+
+## Superpowers: La Metodología Orientada a Procesos
+
+[Superpowers](https://github.com/obra/superpowers), desarrollado por Jesse Vincent y el equipo de Prime Radiant, se describe a sí mismo como "una metodología de desarrollo de software completa para tus agentes de programación".
+
+Si tuviera que resumir Superpowers en una sola frase, sería: **"Hazlo bien, o no lo hagas en absoluto."**
+
+### La Filosofía Central
+
+Superpowers es profundamente obstinado. No solo quiere ayudarte a escribir código más rápido; quiere obligarte a escribir código *mejor*. Actúa casi como un mentor senior estricto que mira por encima del hombro de tu agente, imponiendo rigurosos estándares de ingeniería.
+
+El framework está construido sobre un conjunto de "habilidades" (*skills*) componibles que se activan automáticamente según el contexto de la conversación. Estas habilidades no son solo prompts; son flujos de trabajo ejecutables que guían al agente a través de fases específicas del desarrollo.
+
+La característica definitoria de Superpowers es su insistencia absoluta e intransigente en el **Desarrollo Guiado por Pruebas (TDD)**. Se refiere literalmente a esto como "La Ley de Hierro": *No hay código de producción sin una prueba que falle primero*. Si el agente intenta escribir código de implementación antes que una prueba, la metodología le indica que borre el código y empiece de nuevo. Para un desarrollador independiente acostumbrado a montar cosas rápidamente a altas horas de la noche, este nivel de disciplina puede resultar chocante, pero es innegablemente efectivo para prevenir regresiones.
+
+### Las Fases del Flujo de Trabajo
+
+Cuando inicias una tarea con un agente habilitado para Superpowers, no solo obtienes código. Obtienes un proceso estructurado:
+
+1.  **Lluvia de ideas (*Brainstorming*)**: Antes de escribir una sola línea, el agente se detiene y hace preguntas. Refina ideas en bruto, explora alternativas y presenta un documento de diseño en trozos digeribles para tu validación. Esto previene la "prisa por implementar" que a menudo plaga las interacciones con la IA.
+2.  **Uso de Git Worktrees**: Una vez aprobado el diseño, Superpowers impone aislamiento. Crea un *git worktree* dedicado en una rama nueva, asegurando una línea base de pruebas limpia. Esto significa que el agente no está contaminando tu espacio de trabajo principal con código experimental.
+3.  **Redacción de Planes**: El agente desglosa el diseño validado en tareas pequeñas, que normalmente tardan de 2 a 5 minutos cada una. Cada tarea en el plan incluye rutas de archivo exactas, el código a escribir y los pasos de verificación necesarios para demostrar que funciona.
+4.  **Desarrollo Guiado por Subagentes (SDD)**: Aquí es donde Superpowers realmente brilla. En lugar de ejecutar todo el plan en una sola y masiva ventana de contexto, despacha *nuevos subagentes* para cada tarea individual. Esta es una solución brillante al colapso de contexto. Cada subagente solo sabe de su tarea específica, evitando que se confunda con pasos anteriores o código no relacionado.
+5.  **Desarrollo Guiado por Pruebas (TDD)**: Como se mencionó, esto se ejecuta concurrentemente con la implementación. El agente debe escribir una prueba que falle, ver cómo falla, escribir el código mínimo para hacer que pase y luego hacer el commit.
+6.  **Revisión de Código**: Entre tareas, un agente de revisión separado actúa como una puerta de calidad, comprobando la implementación contra el plan y reportando problemas por severidad. Los problemas críticos bloquean el progreso hasta que se resuelven.
+7.  **Finalización**: Una vez que todas las tareas están completas, el agente verifica toda la suite de pruebas, presenta opciones para fusionar o crear una PR, y limpia el *worktree*.
+
+### Lo Bueno, Lo Malo y Lo Estricto
+
+**Lo que me encanta de Superpowers:**
+El aislamiento proporcionado por los subagentes y los *git worktrees* es fenomenal. Trata a los agentes de IA como tratamos al código modular: pequeño, enfocado y verificable independientemente. La estricta adherencia a TDD, aunque a veces frustrante cuando solo quieres prototipar, resulta en un código notablemente estable. Realmente se siente como trabajar con un equipo de ingeniería disciplinado en lugar de un motor de autocompletado caótico.
+
+**Los puntos de fricción:**
+Superpowers es pesado. Es una metodología entera impuesta sobre tu flujo de trabajo. Si solo quieres un script rápido o un ajuste de CSS, las fases de lluvia de ideas y planificación se sienten como una exageración masiva. Además, depende en gran medida de las capacidades del entorno base del agente (como Claude Code o Codex CLI). Si el entorno no soporta subagentes de manera robusta, toda la metodología recae en un modo de ejecución secuencial mucho menos efectivo, que puede consumir rápidamente las ventanas de contexto.
+
+## OpenSpec: El Flujo de Trabajo Guiado por Artefactos
+
+Mientras que Superpowers se centra en un proceso estricto y en barandillas de ejecución, [OpenSpec](https://github.com/Fission-AI/OpenSpec) toma una ruta fundamentalmente diferente. Desarrollado por Fission AI, OpenSpec es un **flujo de trabajo guiado por artefactos**.
+
+Si Superpowers es un ingeniero senior estricto imponiendo TDD, OpenSpec es un pragmático *Technical Product Manager* ayudándote a escribir una especificación clara antes de pasársela al equipo de desarrollo.
+
+### La Filosofía Central
+
+OpenSpec se basa en cuatro principios:
+1.  **Fluido, no rígido:** No hay puertas de fase estrictas. Puedes trabajar en lo que tenga sentido en un momento dado.
+2.  **Iterativo, no en cascada:** Aprendes mientras construyes y refinas la especificación sobre la marcha.
+3.  **Fácil, no complejo:** Presume de una configuración ligera y una ceremonia mínima.
+4.  **Brownfield primero:** Está diseñado explícitamente para trabajar con bases de código existentes, centrándose en especificar *cambios* en lugar de describir sistemas enteros desde cero.
+
+A diferencia de la pesada metodología de Superpowers, OpenSpec opera mediante comandos de barra (ej., `/opsx:propose`, `/opsx:apply`) dentro de la interfaz de chat de tu asistente de programación. Actúa como una capa ligera sobre tu flujo de trabajo existente en lugar de reemplazarlo por completo.
+
+### El Ciclo de Vida del Artefacto
+
+OpenSpec organiza tu trabajo en artefactos distintos controlados por versiones, almacenados en un directorio dedicado `openspec/` en la raíz de tu proyecto. El flujo de trabajo gira en torno a la creación y refinamiento de estos documentos:
+
+1.  **La Fuente de la Verdad (`specs/`)**: Este directorio contiene la documentación viva de cómo funciona tu sistema *actualmente*.
+2.  **La Propuesta (`changes/<change-name>/`)**: Cuando quieres construir una nueva funcionalidad, ejecutas `/opsx:propose <feature-name>`. OpenSpec no escribe código; genera una carpeta estructurada para el cambio que contiene:
+    *   `proposal.md`: Por qué estamos haciendo esto y qué está cambiando.
+    *   `specs/`: "Especificaciones delta" que definen los requisitos y escenarios específicos para esta funcionalidad.
+    *   `design.md`: El enfoque técnico y la arquitectura.
+    *   `tasks.md`: La lista de verificación de implementación.
+
+Este paso es crucial. Tú y la IA os alineáis en estos documentos markdown. Los revisas, los editas manualmente si es necesario y te aseguras de que el agente entienda perfectamente la intención antes de avanzar.
+
+3.  **Implementación (`/opsx:apply`)**: Una vez aprobados los artefactos, ordenas al agente que implemente las tareas definidas en `tasks.md`. El agente utiliza las especificaciones delta y los documentos de diseño como su contexto, reduciendo las alucinaciones.
+4.  **Sincronización y Archivado (`/opsx:sync`, `/opsx:archive`)**: Después de que el código se escribe y verifica, OpenSpec fusiona las especificaciones delta de nuevo en la fuente principal de la verdad (`specs/`) y archiva la propuesta de cambio, manteniendo tu documentación perfectamente actualizada con tu base de código.
+
+### Lo Bueno, Lo Malo y Lo Fluido
+
+**Lo que me encanta de OpenSpec:**
+OpenSpec es increíblemente respetuoso con el tiempo del desarrollador y el flujo de trabajo existente. El enfoque "brownfield primero" es un soplo de aire fresco; la mayor parte de mi tiempo lo paso modificando ArceApps, no empezando desde `astro new`. Al obligar a la IA a generar un `design.md` y `tasks.md` primero, obtengo un contrato claro y legible de lo que tiene intención de hacer. Si el diseño es incorrecto, arreglo el archivo markdown, no el código. Reduce drásticamente la "rotación de IA" de generar código, darse cuenta de que está mal, e intentar hacer prompts para volver a encarrilarlo.
+
+**Los puntos de fricción:**
+OpenSpec proporciona los artefactos, pero no impone estrictamente *cómo* ocurre la implementación. A diferencia de Superpowers, no obligará al agente a escribir pruebas primero, ni despachará inherentemente subagentes paralelos (aunque teóricamente podrías combinar los artefactos de OpenSpec con un entorno capaz de manejar subagentes). Si tu agente se vuelve rebelde durante la fase `/opsx:apply` e ignora el `tasks.md`, OpenSpec no tiene los ganchos profundos de proceso para detenerlo, dependiendo enteramente de la adherencia del agente subyacente a las instrucciones.
+
+## Comparación Cara a Cara
+
+Para entender verdaderamente qué framework se adapta a tu estilo, comparemos cómo manejan las etapas críticas del desarrollo de software.
+
+### 1. Planificación y Gestión del Contexto
+
+**Superpowers** gestiona el contexto a través de la conversación y de rigurosas habilidades de planificación. Se basa en gran medida en la capacidad del agente para entrevistarte, extraer los requisitos y formular un plan dinámicamente. El plan es un estado efímero dentro de la memoria activa del agente o en archivos temporales.
+
+**OpenSpec** externaliza el contexto en archivos markdown duraderos. El plan es un conjunto concreto de artefactos (`proposal.md`, `design.md`, `tasks.md`). Esto significa que el contexto está controlado por versiones, es fácilmente legible por humanos y se puede pausar y reanudar días después sin perder el estado.
+
+*El ganador aquí depende de la preferencia. Si quieres que la IA gestione el proceso internamente, Superpowers es más fluido. Si quieres documentos explícitos y revisables que actúen como contratos, OpenSpec es superior.*
+
+### 2. Ejecución e Implementación
+
+**OpenSpec** le dice al agente *qué* hacer (a través de `tasks.md`) pero en gran medida deja el *cómo* al comportamiento predeterminado del agente. Es un traspaso: "Aquí está la especificación, ve a construirlo."
+
+**Superpowers** dicta exactamente *cómo* se escribe el código. Impone el ciclo TDD Rojo-Verde-Refactorizar, exige el aislamiento del git worktree y utiliza una compleja arquitectura de subagentes para ejecutar tareas de forma independiente. Es una ejecución altamente estructurada.
+
+*Superpowers gana la fase de ejecución sin lugar a dudas. Su uso de subagentes para prevenir la contaminación del contexto durante la implementación es un cambio de juego para funcionalidades complejas.*
+
+### 3. Flexibilidad vs. Rigidez
+
+**OpenSpec** abraza la fluidez. Si estás a mitad de la implementación y te das cuenta de que el diseño necesita un ajuste, simplemente editas el `design.md` y continúas. No te fuerza a pasar por estrictas puertas de fase.
+
+**Superpowers** es rígido por diseño. "Violar la letra de las reglas es violar el espíritu de las reglas", dice su documentación. Si intentas saltarte escribir una prueba, peleará contigo. Si intentas acortar la fase de planificación, se resistirá.
+
+*Para indie hackers y prototipado rápido, la flexibilidad de OpenSpec es mucho más complaciente. Para infraestructura de misión crítica donde la estabilidad es primordial, la rigidez de Superpowers es una característica, no un error.*
+
+## El Veredicto del Desarrollador Indie
+
+Entonces, ¿cuál estoy adoptando para ArceApps?
+
+La realidad de ser un desarrollador independiente es que tienes horas limitadas. Necesitas herramientas que maximicen tu apalancamiento sin empantanarte en ceremonias a nivel empresarial.
+
+Si estoy construyendo un servicio backend aislado y altamente complejo —digamos, un nuevo flujo de autenticación o un script crítico de migración de datos— quiero **Superpowers**. La garantía de TDD y la seguridad del aislamiento de los subagentes valen la inversión inicial en conversación y planificación. Actúa como el riguroso programador en pareja que no tengo.
+
+Sin embargo, para el 80% de mi trabajo diario —añadir nuevos componentes de UI al portafolio en Astro, escribir artículos para el blog, ajustar estilos de Tailwind o implementar funciones CRUD estándar— **OpenSpec** es el claro ganador. Su enfoque de "brownfield primero" se adapta perfectamente a cómo trabajo en realidad. Me encanta poder ejecutar `/opsx:propose add-dark-mode`, revisar un archivo markdown limpiamente generado que detalla exactamente qué variables CSS se tocarán, y luego aprobar la implementación. Proporciona justo la estructura suficiente para prevenir alucinaciones sin sentirse como una camisa de fuerza.
+
+### ¿El Stack Definitivo?
+
+El santo grial de la ingeniería agéntica podría no ser elegir entre ellos, sino combinar sus fortalezas. Imagina un flujo de trabajo donde uses OpenSpec para generar los artefactos duraderos y controlados por versiones (`design.md`, `tasks.md`), y luego entregues esas tareas exactas a un orquestador de subagentes estilo Superpowers que imponga TDD durante la ejecución de cada tarea específica.
+
+Aún estamos en los primeros días del Desarrollo Guiado por Especificaciones. Tanto Superpowers como OpenSpec son intentos brillantes de domar el caos de la programación con LLMs. Demuestran que el futuro de la ingeniería con IA no se trata solo de mejores modelos; se trata de mejores metodologías.
+
+A medida que avanzamos hacia 2026, los desarrolladores que prosperen no serán los que puedan escribir los prompts más rápidos. Serán aquellos que sepan cómo diseñar especificaciones claras y orquestar agentes de manera efectiva dentro de frameworks estructurados. Ya sea que te inclines por la estricta disciplina de Superpowers o la documentación fluida de OpenSpec, adoptar una metodología estructurada es la única manera de escalar tus esfuerzos de desarrollo en solitario sin perder la cordura.
+
+## Un Análisis Técnico Más Profundo: Integración con Herramientas Existentes
+
+Para apreciar completamente la divergencia entre estos dos frameworks, debemos observar cómo se integran con el ecosistema existente del desarrollador. Esto no se trata solo de filosofía abstracta; se trata de lo que sucede en tu terminal y en tu IDE.
+
+### Superpowers: La Dependencia del Entorno (Harness)
+
+Superpowers es fundamentalmente un conjunto de técnicas avanzadas de ingeniería de prompts y scripts de flujo de trabajo que deben inyectarse en un entorno o "harness" de agente existente. Soporta explícitamente herramientas como Claude Code, Codex CLI, Cursor y GitHub Copilot CLI.
+
+La integración se basa en el concepto de "Habilidades" (*Skills*). Cuando instalas Superpowers en Claude Code, por ejemplo, esencialmente estás cargando una biblioteca de comportamientos predefinidos (`test-driven-development`, `subagent-driven-development`, `writing-plans`). El framework depende del LLM subyacente para reconocer el contexto de tu solicitud y activar autónomamente la habilidad adecuada.
+
+Esto crea una experiencia sumamente mágica cuando funciona a la perfección. Dices, "Necesito arreglar el bug de autenticación", y el agente decide autónomamente activar la habilidad `systematic-debugging`, te hace preguntas de sondeo, formula una hipótesis, crea un git worktree, escribe una prueba que falla y soluciona el error.
+
+Sin embargo, esta profunda integración tiene una desventaja significativa: **Dependencia Frágil del Entorno**. Si Claude Code actualiza su prompt del sistema interno, o si el comportamiento del LLM sufre deriva (*drift*), los mecanismos de activación de las habilidades de Superpowers pueden romperse. El framework está luchando constantemente contra las tendencias nativas del agente subyacente. Además, la característica más potente —el despacho de subagentes— depende por completo de si el entorno anfitrión soporta la creación de instancias de agentes paralelas y aisladas. Si usas un entorno que solo soporta un historial de chat secuencial, Superpowers pierde su mayor ventaja y se convierte en un compañero conversacional que consume muchísimos tokens.
+
+### OpenSpec: El Enfoque Agnóstico al CLI
+
+OpenSpec, por el contrario, adopta un enfoque más desacoplado. Es principalmente una herramienta CLI de Node.js (`npm install -g @fission-ai/openspec`) que gestiona el sistema de archivos.
+
+La "integración" con tu agente de programación es mucho más laxa y resiliente. OpenSpec genera el directorio `/openspec` y los artefactos markdown. Luego confía en que el agente de programación (ya sea Cursor, Windsurf o una simple integración de terminal) lea esos archivos como contexto estándar.
+
+Cuando escribes `/opsx:propose` en la interfaz de chat de tu IA, no estás activando una compleja máquina de estados interna del LLM como en Superpowers. Simplemente estás ejecutando un comando que le dice a la CLI de OpenSpec que genere algunas carpetas y una plantilla markdown basada en tu prompt.
+
+Esta arquitectura desacoplada hace que OpenSpec sea increíblemente resiliente. No le importa si cambias de Claude 3.5 Sonnet a GPT-4o, o si te mudas de Cursor a una herramienta CLI personalizada. Mientras el agente pueda leer archivos markdown en tu repositorio, OpenSpec funciona. Los artefactos —`proposal.md`, `design.md`, `tasks.md`— son formatos universalmente comprendidos.
+
+Esta resiliencia hace que OpenSpec sea mucho más fácil de adoptar para un desarrollador independiente que podría estar experimentando con diferentes herramientas de programación de IA. No te estás encerrando en el ecosistema de plugins de un entorno específico.
+
+## Escenarios del Mundo Real: Dónde Brillan
+
+Aterricemos esta comparación en escenarios prácticos y cotidianos que encuentro mientras mantengo el portafolio de ArceApps.
+
+### Escenario A: La Refactorización de un Componente UI
+
+**La Tarea:** Necesito refactorizar el componente de la tarjeta del blog (`BlogCard.astro`) para usar las nuevas propiedades CSS lógicas definidas en Tailwind v4, asegurando la compatibilidad RTL sin cambiar el diseño visual.
+
+**Usando Superpowers:**
+El agente probablemente activaría la habilidad de `brainstorming`, haciéndome preguntas aclaratorias sobre casos límite en RTL. Luego crearía un nuevo worktree, escribiría una suite de pruebas verificando el diseño visual (lo cual es notoriamente difícil para componentes UI sin pruebas de regresión visual) y luego implementaría los cambios CSS. La sobrecarga de TDD para una refactorización CSS puramente estilística es inmensa y a menudo contraproducente. Pasaría más tiempo discutiendo con el agente sobre cómo probar clases CSS que escribiendo el CSS en sí.
+
+**Usando OpenSpec:**
+Ejecutaría `/opsx:propose refactor-blog-card-css`. Genera un `design.md` anotando el cambio a propiedades lógicas (ej., cambiando `ml-4` a `ms-4`). Apruebo el markdown. Ejecuto `/opsx:apply`. El agente lee el diseño, modifica `BlogCard.astro` y termina. Rápido, limpio y perfectamente alineado con la complejidad de la tarea.
+
+### Escenario B: Implementando un Algoritmo de Búsqueda Complejo
+
+**La Tarea:** Necesito reemplazar la búsqueda básica del lado del cliente con un script de indexación TF-IDF personalizado que se ejecute durante el proceso de build de Astro y produzca un índice JSON altamente optimizado para que el cliente lo consuma.
+
+**Usando OpenSpec:**
+Propongo el cambio, y OpenSpec genera un documento de diseño sólido detallando la matemática TF-IDF y los puntos de integración con Astro. Aplico el cambio. El agente intenta escribir el script de build y el consumidor del lado del cliente de una sola vez. Debido a que la tarea abarca múltiples límites arquitectónicos (paso de build en Node.js vs. hidratación en el navegador) y requiere lógica matemática precisa, el agente se confunde a mitad del `tasks.md`. Alucina una dependencia que falta, rompe el build de Astro y tengo que intervenir, revertir los cambios y guiarlo manualmente paso a paso.
+
+**Usando Superpowers:**
+El agente reconoce la complejidad y activa `writing-plans`. Desglosa el algoritmo TF-IDF en funciones pequeñas y matemáticamente verificables. Activa `subagent-driven-development`. El Subagente A escribe una prueba para el cálculo de la frecuencia del término, ve que falla y la implementa a la perfección. El Subagente B maneja la frecuencia inversa de documento. El Subagente C escribe la prueba de integración de Astro. Debido a que cada subagente opera en un contexto aislado, no confunden la lógica del script de build con la lógica de UI del cliente. El riguroso TDD asegura que la matemática sea correcta antes de que toque siquiera el proceso de build de Astro. La funcionalidad aterriza perfectamente, probada de extremo a extremo.
+
+## Conclusión: La Ingeniería es Contextual
+
+La comparación entre Superpowers y OpenSpec no se trata de encontrar la "mejor" herramienta en el vacío; se trata de encontrar la herramienta adecuada para el contexto específico de tu desafío de ingeniería.
+
+Superpowers es la caballería pesada. Aporta disciplina de ingeniería rigurosa, pruebas impuestas y técnicas de aislamiento avanzadas a la programación con IA. Es ideal para trabajos de backend complejos, algorítmicos o de misión crítica donde la exactitud no es negociable.
+
+OpenSpec es la infantería ágil. Proporciona una estructura ligera, guiada por artefactos, que respeta tu flujo de trabajo existente y escala a la perfección con proyectos *brownfield*. Es perfecto para el desarrollo de funcionalidades del día a día, ajustes de UI y las iteraciones rápidas que definen la experiencia del desarrollador indie.
+
+Para el portafolio de ArceApps, me encuentro recurriendo a OpenSpec la inmensa mayoría de las veces. Su naturaleza fluida y sus contratos basados en markdown encajan perfectamente con un proyecto construido en Astro y contenido estático. Sin embargo, saber que herramientas como Superpowers existen —y entender la filosofía detrás del aislamiento de subagentes y la aplicación estricta de TDD— ha cambiado profundamente cómo escribo mis prompts y estructuro mis propios flujos de trabajo, incluso cuando no estoy usando explícitamente el framework.
+
+En última instancia, el cambio hacia el Desarrollo Guiado por Especificaciones es la lección más importante. Ya sea que elijas el proceso estricto de Superpowers o los artefactos fluidos de OpenSpec, alejarse del chat no estructurado y avanzar hacia metodologías definidas es la clave para desbloquear el verdadero potencial de los agentes de IA en la ingeniería de software.


### PR DESCRIPTION
I have authored the two requested articles comparing Superpowers and OpenSpec, and diving deep into the Superpowers framework. Both articles have been generated in English and Spanish, exceeding the 3,000-word constraint requested.

The articles use the required "indie spirit" tone, include relevant references to existing blog posts within the repository, and are backed by the requested web research.

During my testing, I realized some accidental modifications to other blog posts were introduced that caused link-validation tests to fail. I reverted these regressions, ran the test suite again to verify a clean state, and successfully addressed the code review feedback. The new articles are now ready.

---
*PR created automatically by Jules for task [11629022895784714795](https://jules.google.com/task/11629022895784714795) started by @ArceApps*