### PR TITLE
Fix missing hero images in superpower articles

### DIFF
--- a/src/content/blog/en/blog-superpowers-deep-dive.md
+++ b/src/content/blog/en/blog-superpowers-deep-dive.md
@@ -2,7 +2,7 @@
 title: "Inside Superpowers: The Framework That Forces AI to Engineer"
 description: "A comprehensive technical deep dive into the Superpowers methodology, exploring its subagent orchestration, strict TDD enforcement, and how it transforms AI from a chaotic coder into a disciplined engineering partner."
 pubDate: 2026-04-19
-heroImage: "/images/blog-superpowers-deep-dive.svg"
+heroImage: "/images/placeholder-article-ai-workflow.svg"
 tags: ["Superpowers", "AI Agents", "TDD", "Subagents", "Methodology", "Engineering", "Workflow", "Deep Dive"]
 reference_id: "b7c3e5d1-9a2f-4c8e-b1d6-8a9f2e3d4c5b"
 ---

--- a/src/content/blog/en/blog-superpowers-vs-openspec.md
+++ b/src/content/blog/en/blog-superpowers-vs-openspec.md
@@ -2,7 +2,7 @@
 title: "Agentic Engineering Methodologies: Superpowers vs OpenSpec"
 description: "A deep dive comparison of two distinct approaches to AI software development: the skill-based methodology of Superpowers and the artifact-guided workflow of OpenSpec."
 pubDate: 2026-04-12
-heroImage: "/images/blog-superpowers-vs-openspec.svg"
+heroImage: "/images/placeholder-article-ai-agents.svg"
 tags: ["SDD", "AI", "Superpowers", "OpenSpec", "Agentic AI", "Methodology", "Workflow", "Productivity"]
 reference_id: "e4d2a1c9-6f8b-4a3d-8e7c-2b1d9f4a5c6d"
 ---

--- a/src/content/blog/es/blog-superpowers-deep-dive.md
+++ b/src/content/blog/es/blog-superpowers-deep-dive.md
@@ -2,7 +2,7 @@
 title: "Dentro de Superpowers: El Framework que Obliga a la IA a Hacer Ingeniería"
 description: "Un análisis técnico exhaustivo de la metodología Superpowers, explorando su orquestación de subagentes, la aplicación estricta de TDD y cómo transforma a la IA de un programador caótico a un socio de ingeniería disciplinado."
 pubDate: 2026-04-19
-heroImage: "/images/blog-superpowers-deep-dive.svg"
+heroImage: "/images/placeholder-article-ai-workflow.svg"
 tags: ["Superpowers", "Agentes IA", "TDD", "Subagentes", "Metodología", "Ingeniería", "Workflow", "Análisis Profundo"]
 reference_id: "b7c3e5d1-9a2f-4c8e-b1d6-8a9f2e3d4c5b"
 ---

--- a/src/content/blog/es/blog-superpowers-vs-openspec.md
+++ b/src/content/blog/es/blog-superpowers-vs-openspec.md
@@ -2,7 +2,7 @@
 title: "Metodologías de Ingeniería Agéntica: Superpowers vs OpenSpec"
 description: "Una comparación profunda de dos enfoques distintos para el desarrollo de software con IA: la metodología basada en habilidades de Superpowers y el flujo de trabajo guiado por artefactos de OpenSpec."
 pubDate: 2026-04-12
-heroImage: "/images/blog-superpowers-vs-openspec.svg"
+heroImage: "/images/placeholder-article-ai-agents.svg"
 tags: ["SDD", "IA", "Superpowers", "OpenSpec", "IA Agéntica", "Metodología", "Workflow", "Productividad"]
 reference_id: "e4d2a1c9-6f8b-4a3d-8e7c-2b1d9f4a5c6d"
 ---


### PR DESCRIPTION
Fixes missing hero images for the superpower articles. The markdown files referenced SVGs that did not exist in the `/images/` directory. They now point to suitable existing placeholder art.

---
*PR created automatically by Jules for task [7691181918736436017](https://jules.google.com/task/7691181918736436017) started by @ArceApps*