### PR TITLE
🧹 [code health improvement] Remove deprecated matchMedia mock listeners

### DIFF
--- a/src/scripts/layout.test.ts
+++ b/src/scripts/layout.test.ts
@@ -30,8 +30,6 @@ describe('Layout Script', () => {
         matches: false,
         media: query,
         onchange: null,
-        addListener: vi.fn(), // deprecated
-        removeListener: vi.fn(), // deprecated
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
         dispatchEvent: vi.fn(),


### PR DESCRIPTION
🎯 **What:** Removed `addListener: vi.fn()` and `removeListener: vi.fn()` from the `matchMedia` mock in `src/scripts/layout.test.ts`.
💡 **Why:** These fields are deprecated in modern browser APIs in favor of `addEventListener` and `removeEventListener` (which were already mocked). Removing dead/deprecated code improves maintainability.
✅ **Verification:** Ran `pnpm test src/scripts/layout.test.ts` to ensure the tests still pass without these mock functions. Code Review confirmed this was correct.
✨ **Result:** A cleaner test setup that doesn't rely on or stub outdated APIs.

---
*PR created automatically by Jules for task [8754864722806041258](https://jules.google.com/task/8754864722806041258) started by @ArceApps*