### PR TITLE
feat(blog): add 'Grill Me' deep dive and comparison articles

### DIFF
--- a/public/images/grill-me-hero.svg
+++ b/public/images/grill-me-hero.svg
@@ -1,0 +1,7 @@
+<svg width="800" height="400" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#1e1e2e"/>
+  <text x="50%" y="40%" font-family="Arial" font-size="40" fill="#f8f8f2" text-anchor="middle">/grill-me Deep Dive</text>
+  <text x="50%" y="60%" font-family="Arial" font-size="20" fill="#a6accd" text-anchor="middle">The Socratic AI Revolution</text>
+  <circle cx="200" cy="200" r="50" fill="#ff79c6" opacity="0.8"/>
+  <circle cx="600" cy="200" r="50" fill="#8be9fd" opacity="0.8"/>
+</svg>

--- a/public/images/grill-me-sdd-comparison.svg
+++ b/public/images/grill-me-sdd-comparison.svg
@@ -1,0 +1,8 @@
+<svg width="800" height="400" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#282a36"/>
+  <text x="25%" y="50%" font-family="Arial" font-size="30" fill="#50fa7b" text-anchor="middle">Spec-Driven (SDD)</text>
+  <text x="50%" y="50%" font-family="Arial" font-size="30" fill="#f8f8f2" text-anchor="middle">VS</text>
+  <text x="75%" y="50%" font-family="Arial" font-size="30" fill="#ffb86c" text-anchor="middle">Grill Me (Socratic)</text>
+  <line x1="10%" y1="60%" x2="40%" y2="60%" stroke="#50fa7b" stroke-width="4" />
+  <line x1="60%" y1="60%" x2="90%" y2="60%" stroke="#ffb86c" stroke-width="4" />
+</svg>

--- a/src/content/blog/en/blog-grill-me-claude-skill-deep-dive.md
+++ b/src/content/blog/en/blog-grill-me-claude-skill-deep-dive.md
@@ -1,0 +1,191 @@
+---
+title: "Deep Dive into 'Grill Me': The Socratic Grilling Revolution in Claude Code"
+description: "Discover how Matt Pocock's viral skill is transforming AI-assisted development by forcing agents to ruthlessly question your design before writing a single line of code."
+pubDate: 2026-05-20
+heroImage: "/images/grill-me-hero.svg"
+tags: ["AI", "Claude Code", "Skills", "mattpocock", "Architecture", "Socratic Method", "Grill Me"]
+reference_id: "grill-me-deep-dive-001"
+---
+
+## Introduction: The End of Compliant AI Agents
+
+In the era of AI-assisted development, we have grown accustomed to a dangerous dynamic: the "Yes Man" syndrome. You present a vague idea for a software architecture, and the LLM immediately responds with enthusiasm: "That's a fantastic idea! Here is the code." This sycophancy, inherent in language models optimized by RLHF (Reinforcement Learning from Human Feedback) to please the user, often leads to the generation of hundreds of lines of code based on flawed assumptions, unconsidered dependencies, and fundamentally broken designs.
+
+This is where **"Grill Me"** enters the stage. It is a revolutionary skill for Claude Code created by Matt Pocock that has gone viral, accumulating over 13,000 stars on GitHub. The premise is as simple as it is brilliant: instead of allowing the AI to code blindly (what the community calls irresponsible *specs-to-code*), the `/grill-me` command forces the agent to stop, adopt the persona of a rigorous senior engineer, and bombard you with critical questions about your plan.
+
+This article is a deep dive into how this skill works, why it is saving thousands of hours of refactoring, and how you can integrate it into your daily workflow to elevate the quality of your software engineering.
+
+## What is Grill-Me and How Does it Really Work?
+
+The `/grill-me` command is not dark magic; it is prompt engineering taken to its maximal pragmatic expression. It is a skill (a behavioral extension for agents like Claude Code) that temporarily alters the agent's "System Prompt" or core instructions.
+
+When you invoke this command, you are telling the AI: *"Do not write code. Do not agree with me. Instead, analyze my proposal and find all the plot holes, failure modes, hidden dependencies, and trade-offs I haven't considered."*
+
+### The Internal Mechanics
+
+The iterative process works as follows:
+1. **Proposal Presentation:** The developer states an idea (e.g., "I want to migrate our database to PostgreSQL and use Redis for caching").
+2. **The Grilling:** The agent responds with a series of pointed questions. What about eventual consistency? How will we handle Redis failover? Have we considered the infrastructure cost?
+3. **Branch Resolution:** The agent forces you to resolve every branch of this decision tree. It won't let you proceed until a solid "shared understanding" is reached.
+4. **Clarification of Assumptions:** It makes all technical and business assumptions explicit.
+
+### The Variant: /grill-with-docs
+
+While `/grill-me` is phenomenal for quick brainstorming sessions, the `/grill-with-docs` variant takes things to the next level for long-term projects. It works exactly the same way but with an added superpower: it uses your project's existing documentation as additional context and, as decisions are made during the grilling, it updates a glossary and the project documentation.
+
+This ensures that architectural decisions are not lost in the chat history but instead become persistent artifacts (like ADRs - Architecture Decision Records) that will guide the agent's future interactions.
+
+## Use Cases: When and Why to Use It
+
+The versatility of this skill is the reason for its massive popularity. Here we analyze the five main use cases.
+
+### 1. Before Starting a Project (Forcing Requirement Analysis)
+
+Developers often fall into the trap of "Vibe Coding" or programming by instinct. This is fine for weekend prototypes but disastrous for production systems. Using `/grill-me` before even running `npm init` forces you to think about non-functional requirements: scalability, security, accessibility, and maintainability.
+
+### 2. Critical Technical Decisions (Architecture, DB, Frameworks)
+
+Imagine debating whether to use a monolithic framework or microservices. A standard agent would give you a generic list of pros and cons. The agent under `/grill-me` will look at your specific context and ask painful questions: *"Given that your team consists of only 3 people, how do you plan to handle the operational overhead of orchestrating 15 microservices?"*
+
+### 3. Validating Specs-to-Code (Finding Holes Before Writing)
+
+The ideal modern flow is Spec-Driven Development (SDD). However, a human-written spec often has holes. The agent will evaluate your `SPEC.md` file and find edge cases: *"The spec says the user will be redirected after login, but it doesn't mention what to do if the token expires during the redirection."* This saves hours of future debugging.
+
+### 4. Pair-Programming: The "Clarifying Questions" Phase
+
+In traditional human Pair Programming, the most important phase is not when solutions are typed, but when the navigator asks clarifying questions to the driver. Traditional AI skips this step. `/grill-me` reinstates this necessary and valuable friction in the AI ecosystem.
+
+### 5. Brainstorming Sessions and Knowledge Extraction
+
+A fascinating emerging pattern documented by developers (as mentioned in Mejba's practical tutorial) is using the folder structure `brainstorms/YYYY-MM-DD-topic.md`. A complete grilling session is executed, and the entire Q&A is saved there to reconstruct the technical reasoning months later.
+
+## A Practical Example: The RAG System Case
+
+Let's look at a typical use case that went viral in the community (r/vibecoding). A developer recounted how he was about to build a complex RAG (Retrieval-Augmented Generation) system. His initial prompt was going to be: *"Build a RAG system using Pinecone and LangChain for our support documents"*.
+
+Before hitting enter, he decided to run `/grill-me`. The agent asked him 14 questions he hadn't considered:
+1. What is the chunking strategy for the documents?
+2. How will we handle updating documents in the vector store when the original changes (upserts)?
+3. What embeddings model will we use and why?
+4. Have we considered the context window token limit when retrieving multiple chunks?
+5. Is there Role-Based Access Control (RBAC)? Meaning, can a user query a document they shouldn't be able to see?
+
+The developer confessed that answering questions 2 and 5 would have required rewriting the entire architecture two weeks later if he had started coding immediately. The "Grill Me" skill literally saved the sprint.
+
+## The Viral Impact and the Community (Vibe Coding)
+
+The reception in places like *r/vibecoding* has been overwhelming. The consensus is clear: "Viral 'Grill Me' Claude skill proves specs-to-code is vibe-saving". The idea that stopping to think saves the project's "vibe" resonates strongly with the widespread fatigue toward AI-generated spaghetti code.
+
+Furthermore, its presence is so notable that prestigious future events, such as the *AI Engineer Unconference Sydney 2026*, already have panels dedicated to "Grill-Me" as the definitive case study on how a prompt skill that interviews the developer before coding shifts the human-machine interaction paradigm.
+
+### Distribution and Ecosystem
+
+The skill has rapidly expanded beyond its original repo:
+- **LobeHub:** An adapted version for easy installation and support for Codex and ChatGPT.
+- **MCP Market:** Available via `npx skillfish add vechain/vechain-ai-skills grill-me`.
+- **AI UX Playground:** An iteration focused on the career agent.
+- **AI DevKit:** Included as part of the repeatable workflow alongside skills like "are we sure?".
+
+## Stress, Threats, and Adversarial Prompting
+
+The success of `/grill-me` rests on deep concepts of AI safety and efficacy. According to guides like the *Prompt Engineering Guide* on *Adversarial Prompting*, forcing an LLM to adopt an adversarial stance against the user's own input is one of the best ways to extract deep reasoning.
+
+In an LLM stress-testing context (LLM Stress Testing 2026), tools like this not only validate the code but also test the robustness of the CI/CD pipeline by ensuring that the specifications generated before the commit are free of "Threats in LLM-Powered AI Agents Workflows," such as hallucinating non-existent APIs or assuming ideal states (Happy Path bias).
+
+## Technical Deep Dive: The Socratic Pattern in Complex Systems
+
+To understand the true scope of "Grill Me," it is essential to analyze its application in engineering domains that demand fault tolerance. Consider the development of distributed systems and microservice architectures, where component interactions are non-trivial and the risk of cascading effects is high.
+
+### Reducing Cyclomatic Complexity through Questioning
+
+When an engineering team presents a plan to decouple a monolith, the general intuition is to fragment domains into entity-based microservices. However, this naive approach often ignores transactional boundaries. A standard LLM might quickly generate templates for the new services. An LLM under the influence of `/grill-me`, on the other hand, will interrogate you about the "Saga pattern" or two-phase commit (2PC).
+
+How will a distributed transaction be reverted if the payment service fails after the inventory service has already deducted the stock? By forcing this question before writing code, "Grill Me" induces developers to explicitly model compensation scenarios. This mental exercise, documented asynchronously, substantially reduces the cyclomatic complexity of future implementations because error handlers become first-class citizens of the design, not hasty additions.
+
+### The Challenge of State Synchronization in Reactive User Interfaces
+
+Another domain where "Grill Me" excels is in the development of complex, reactive user interfaces (e.g., Redux-based architectures or StateFlow in Android).
+
+Suppose a developer proposes a new local caching layer to accelerate the loading of a news feed. The agent's Socratic questions would point directly to race conditions: *"If the user navigates to another screen while the cache is hydrating from the network, do we cancel the network operation or allow it to continue in the background? If it continues, how do we guarantee it doesn't overwrite more recent data when the user returns to the original screen?"*
+
+These are the questions a Senior Software Architect would ask in a design meeting. The democratization of this level of rigor through a terminal command is the true achievement of Matt Pocock's skill.
+
+## Practical Implementation: Integrating "Grill Me" into Your Repository
+
+Adopting "Grill Me" requires more than simply running a command; it demands an adaptation of the entire team's workflow. Here we present a maturity model for its integration.
+
+### Phase 1: Individual Adoption and Persistent Brainstorming
+
+In the initial phase, developers use `/grill-me` in an ad-hoc manner on their own terminals before starting tasks of medium to high complexity. The key to success here is persistence. We recommend creating a `./design/brainstorms/` directory where the complete log of the adversarial conversation is saved.
+
+This Markdown file is not just a block of text; it is the architectural justification. When a Code Reviewer asks six months later "why Redis was chosen instead of Memcached," the detailed, AI-validated answer is found in the brainstorming log.
+
+### Phase 2: Automation in Spec Generation
+
+Once the team feels comfortable with the adversarial interrogation, the next step is to connect the output of `/grill-me` with the generation of formal specifications. In the SDD (Spec-Driven Development) ecosystem, this is achieved by channeling the "Shared Understanding" reached during the session directly into the creation of a structured `SPEC.md` file.
+
+Complementary tools in Matt Pocock's ecosystem, like `/to-prd` (To Product Requirements Document), automate this transition. The agent, which has just exhaustively interrogated the proposal, is now the ideal candidate to draft the specification, ensuring that none of the discussed edge cases are left out of the final document.
+
+### Phase 3: Integration into the Continuous Integration (CI/CD) Pipeline
+
+In forward-thinking organizations, the principles of "Grill Me" are being adapted to integrate directly into CI/CD flows. Although the original `/grill-me` command is designed for interactive terminal use, its underlying logic of "critical evaluation" can be instantiated in autonomous agents that review Pull Requests (PRs).
+
+Imagine a GitHub Actions workflow that triggers a Socratic sub-agent. This agent analyzes the diff of the proposed code against the project's architecture document and posts comments—not to blindly approve, but to interrogate the author about possible regressions and unproven assumptions introduced in the PR. This is the pinnacle of "Shift-Left" in AI-driven software quality assurance.
+
+## Risk Mitigation and Tool "Failure Modes"
+
+Like any powerful software engineering tool, `/grill-me` has failure modes that teams must understand and mitigate.
+
+### Analysis Paralysis
+
+The most prominent risk is falling into an infinite loop of interrogation. A language model configured to find flaws will always find a theoretical vulnerability if pushed hard enough, no matter how absurd the probability of occurrence (e.g., "What if a cosmic ray flips a bit in the database server's RAM?").
+
+Developers must exercise pragmatic judgment. It is essential to know when to tell the agent: *"I have documented that risk, but we have decided to accept it for this MVP iteration."* The goal is not the perfect, infallible architecture, but the conscious, deliberate architecture.
+
+### Confirmation Bias in Poor Documentation
+
+The effectiveness of the `/grill-with-docs` variant depends entirely on the quality of the existing documentation (the provided context). If the base architecture document (`ARCHITECTURE.md`) is generic or outdated, the Socratic agent will not have a solid frame of reference to question the developer's proposal. Evaluating documentation quality becomes a prerequisite for successful adversarial interrogation at the project level.
+
+## The Paradigm of "Interrogation-Centric Engineering"
+
+In summary, the popularity of "Grill Me" is not a passing fad in the ephemeral world of AI tools. It is a symptomatic response to a structural problem in how we have been building AI-assisted software. By centering the workflow on questioning rather than generation, we are reclaiming the essence of software engineering: structured and rigorous problem-solving.
+
+Lines of code are cheap and abundant in 2026. Clarity of thought, resilient design, and deep domain understanding are the truly scarce resources. By integrating tools that actively foster these qualities, we ensure that the AI revolution elevates the fundamental quality of our software, rather than simply accelerating our capacity to produce technical debt.
+
+## Organizational Consequences: Beyond the Code
+
+The adoption of "Grill Me" affects not only the technical quality of the code but also profoundly transforms team dynamics. When the agent takes on the role of the "tough" reviewer, it frees human engineers from this interpersonal burden. Peer code reviews can become tense when architectural decisions are questioned. "Grill Me" acts as an objective buffer.
+
+Furthermore, it facilitates the onboarding of new engineers. By recording the interrogation sessions, a new team member can read exactly what issues were considered before choosing a specific database or design pattern. This builds an institutional memory that is resistant to staff turnover, a critical challenge in modern software engineering.
+
+In conclusion, the true value of Socratic Grilling lies not in writing code faster, but in writing the right code. In a landscape where speed often takes precedence over solidity, tools like this are the necessary counterweight to ensure that artificial intelligence is used as an amplifier of our technical rigor, not as a shortcut to architectural failure.
+
+### The Role of Developer Experience (DX) in AI Integration
+
+Developer Experience (DX) is increasingly recognized as a key differentiator for high-performing engineering organizations. The introduction of tools like `/grill-me` initially seems contrary to the standard DX goal of removing friction. However, this is "good friction." By catching errors early and building a robust shared language, the downstream DX is immensely improved. Developers spend less time deciphering legacy code and more time building robust features. The Socratic agent essentially becomes a mentor, guiding engineers toward better design patterns and practices through rigorous questioning.
+
+### Building the Future of Software Engineering
+
+As we look toward the horizon of software development, the integration of Socratic methods into our daily tools is not just a passing trend; it's a fundamental shift in how we approach problem-solving. The AI Engineer Unconference Sydney 2026 highlighted that the next generation of developers will not be measured by how fast they can prompt an AI to write code, but by how effectively they can direct, constrain, and collaborate with AI agents to architect resilient systems.
+
+The "Grill Me" skill is a precursor to a more interactive, dialogue-driven development environment where the AI acts as a sounding board, a critic, and a partner. This shift will require a new set of skills from developers: the ability to articulate complex ideas clearly, to defend architectural choices with sound reasoning, and to embrace constructive criticism from non-human entities. By embracing this change, we can ensure that the software we build tomorrow is not only faster to develop but fundamentally better, more secure, and more maintainable than ever before.
+
+## Conclusion
+
+Matt Pocock's "Grill Me" skill is much more than a simple terminal command. It represents a maturation in how we interact with Artificial Intelligence. We have moved from seeing AI as a magic code vending machine to recognizing it as a rigorous validation partner.
+
+The next time you have a "brilliant idea" to refactor that microservice or add a new abstraction layer, do yourself a favor: do not start writing code. Open your terminal, type `/grill-me`, and prepare to sweat defending your proposal. Your future self will thank you.
+
+## Resources, Links, and Credits
+
+This article was built based on the analysis of the following fundamental sources. We highly encourage our readers to explore them:
+
+- [mattpocock/skills (GitHub)](https://github.com/mattpocock/skills): The original repository with over 13K stars.
+- [My 'Grill Me' Skill Went Viral (AI Hero)](https://www.aihero.dev/my-grill-me-skill-has-gone-viral): Author Matt Pocock's post explaining the context and pattern behind his creation.
+- [Grill Me Skill for Claude Code: Extract Your Knowledge](https://www.mejba.me/blog/grill-me-skill-claude-code-knowledge-extraction): An excellent practical tutorial by Mejba on knowledge extraction.
+- [grill-me on LobeHub](https://lobehub.com/skills/christianrcds-agents-skill-grill-me): Adaptation for other AI ecosystems.
+- [Awesome Skills](https://awesomeskill.ai/skill/mattpocock-skills-grill-me): Directory and format description.
+- [r/vibecoding - Viral 'Grill Me' Claude skill...](https://www.reddit.com/r/vibecoding/comments/1swyadr/viral_grill_me_claude_skill_proves_specstocode_is/): Reddit thread featuring the RAG system case study.
+- [Adversarial Prompting (Prompting Guide)](https://www.promptingguide.ai/risks/adversarial): Theoretical basis for stress-testing.
+
+*Read more on our blog about complementary methodologies like [Spec-Driven Development](/blog/spec-driven-development-ai) and the [Socratic Method for Prompts in Kotlin](/blog/blog-socratic-method-prompts-kotlin-android).*

--- a/src/content/blog/en/blog-grill-me-sdd-adversarial-workflow-comparison.md
+++ b/src/content/blog/en/blog-grill-me-sdd-adversarial-workflow-comparison.md
@@ -1,0 +1,159 @@
+---
+title: "'Grill Me' vs Socratic Method vs Spec-Driven Development: Evaluating the Next Wave of AI Development"
+description: "An architectural analysis of how the 'Grill Me' skill fits into the historical tension between honoring the specification and constantly challenging it through adversarial prompts."
+pubDate: 2026-05-22
+heroImage: "/images/grill-me-sdd-comparison.svg"
+tags: ["SDD", "AI", "Socratic Method", "Spec-Driven Development", "mattpocock", "Prompt Engineering", "Skills", "Architecture"]
+reference_id: "grill-me-sdd-comparison-002"
+---
+
+## Introduction: The Tension in the Generative Code Ecosystem
+
+As the ecosystem of AI agents matures, we find ourselves at a fundamental philosophical crossroads regarding how humans and machines should collaborate in software engineering. On one hand, we have the paradigm of **Spec-Driven Development (SDD)**, which dictates that the Specification (the SPEC.md) is a sacred, immutable document; the agent's job is to implement it with absolute fidelity. On the other hand, we have **Socratic Prompting**, which argues that the model must constantly challenge our assumptions, adopting an adversarial stance to break the inherent "sycophancy" of LLMs.
+
+This tension creates a paradox for developers. If you apply the "challenge everything" mindset of the Socratic method during the build phase, you never ship anything because every line of code is debated. If you apply the "the spec is sacred" mindset of SDD from day one, you end up faithfully coding flawed architectures.
+
+In this article, we will comprehensively analyze how the recent viral phenomenon **"Grill Me"** (a skill created by Matt Pocock for Claude Code, boasting over 13,000 stars on GitHub) resolves this apparent conflict. We will explore how this tool positions itself not as a replacement for SDD, but as the missing piece of the puzzle: the critical bridge between ambiguous ideation and strict specification.
+
+## 1. Understanding the Players on the Board
+
+Before analyzing the integration, we must clearly define the three conflicting paradigms and what problem each attempts to solve.
+
+### Spec-Driven Development (Pure SDD)
+
+Frameworks like **Spec Kit** and **OpenSpec** advocate for a linear, deterministic workflow. You write a detailed document (the SPEC.md), and the agent generates code in strict conformity.
+*   **Strength:** Prevents "drift," where the implementation slowly diverges from the original intent over time.
+*   **Weakness:** Assumes the human knows exactly what they want and has considered all failure modes. Suffers heavily from "Garbage In, Garbage Out."
+
+### The Socratic Method (Adversarial Prompting)
+
+In [our previous articles on the Socratic Method](/blog/blog-socratic-method-prompts-kotlin-android), we explored how to reconfigure *system prompts* so that LLMs ruthlessly evaluate our code instead of blindly praising us.
+*   **Strength:** Breaks sycophancy. Detects memory leaks, concurrency issues (like in Kotlin Coroutines), and architectural flaws that a human might overlook.
+*   **Weakness:** It is exhausting and can lead to "debate fatigue." It is hard to scale to a deterministic CI/CD pipeline because its responses are inherently critical and expansive.
+
+### The "Grill Me" Skill (The mattpocock/skills Approach)
+
+Matt Pocock's **Skills** approach is not a *Full-Stack* methodology or a rigid framework; it is a "toolbox over pipeline" philosophy. At its core is the `/grill-me` command (and its persistent variant `/grill-with-docs`).
+*   **The Mechanism:** Before generating any code, you force the agent to systematically interrogate you about your technical plan.
+*   **The Goal:** To reach a "Shared Understanding" by resolving dependencies and edge cases *before* writing the first specification or line of code.
+
+## 2. The Resolution of Conflict: Clear Phases
+
+The greatest conceptual breakthrough that "Grill Me" brings to the community (and the reason it has resonated so deeply in forums like *r/vibecoding* under the banner of "specs-to-code is vibe-saving") is the clear separation of software lifecycle phases in the age of agents.
+
+The conflict between Socratic Prompting and SDD only exists if you try to use both techniques simultaneously. The solution is a "Phase-Aware" workflow:
+
+### Phase 1: Pre-Spec (The Domain of Grill-Me)
+This is where `/grill-me` shines. You have an idea (e.g., "Let's build an offline-first architecture for Android using Room and Ktor"). You run the skill. The agent attacks you: *"How do we resolve a conflict when the local state diverges from the remote server?"*. There is no code here. There is only the clarification of ideas and the building of a shared Glossary (`GLOSSARY.md`). The outcome of this "adversarial questioning" phase is the solid knowledge base for your SPEC.md.
+
+### Phase 2: Build (The Domain of SDD and TDD)
+Once the interrogation ends and the SPEC.md is locked, "Grill Me" turns off. Now the discipline of SDD takes over. The agent uses skills like `/tdd` (Test-Driven Development) to implement the code iteratively. In this phase, "the spec is sacred." Architecture is not debated; it is implemented.
+
+### Phase 3: Post-Failure (The Domain of /diagnose)
+If something breaks, you don't go back to debating the spec. You use Socratic resolution tools like the `/diagnose` skill, which forces the agent to: (1) reproduce the bug, (2) generate multiple falsifiable hypotheses, and (3) test each one in isolation by changing a single variable at a time.
+
+## 3. The Glossary: The Hidden Superpower of /grill-with-docs
+
+A profoundly undervalued aspect of Matt Pocock's suite is the concept of "Shared Language."
+
+In traditional software engineering (and particularly in Domain-Driven Design), establishing a *Ubiquitous Language* is the hardest step. When we use `/grill-with-docs`, the agent doesn't just interrogate you; it documents the resolutions directly in the project's context.
+
+By establishing that "Active User" means "a user who has logged in within the last 24 hours," the agent will never waste tokens assuming wrong definitions in the future. This drastically reduces hallucinations in LLMs—a core problem in managing agents at scale. Unlike SDD, where a human must meticulously draft this glossary beforehand, in the "Grill Me" workflow, high-quality documentation *emerges naturally* from the friction of the interrogation.
+
+## 4. Industry Evidence and Future Events
+
+This is not a niche concept. On the preparatory agenda for the *AI Engineer Unconference Sydney 2026*, the pattern established by `/grill-me` is positioned as a primary highlight. Experts argue that an agent's ability to interview its creator marks the transition from "code auto-completion tools" (like the early days of GitHub Copilot) to "autonomous engineering partners."
+
+Furthermore, recent research on threats in AI agent workflows (Threats in LLM-Powered AI Agents Workflows, arXiv:2506.23260v2) corroborates this approach. The study notes that the largest risk vector in autonomous agents is acting on incomplete information. Forcing an adversarial questioning loop before granting execution permissions is the most effective Risk Mitigation measure documented to date.
+
+## 5. Case Study: Socratic Integration in an Offline-First Architecture
+
+Let's take a real-world example, particularly relevant in modern mobile and web development.
+
+**The Problem:** Implementing an *offline-first* data sync for a production application.
+
+*   **Workflow A (Without Grill-Me - Naive SDD):**
+    The developer writes a quick SPEC.md stating that data must be saved locally and synced when the network returns. The agent implements this literally, using a simple network queue.
+    *Result:* The application silently crashes when the server returns an HTTP 409 (Conflict) error because the specification never accounted for conflict resolution.
+*   **Workflow B (With Socratic Integration + Grill-Me + SDD):**
+    The developer pitches the idea. `/grill-me` steps in and asks: *"What Merge Strategy will we use for LWW (Last-Write-Wins) versus Server-Wins conflicts?"* and *"How is the UI notified if a background sync fails asynchronously?"*.
+    The developer is forced to design these solutions. The result is captured in the SPEC.md. Then, during the Build phase, the agent rigidly adheres to this robust specification.
+    *Result:* A resilient, enterprise-grade *offline-first* implementation from day 1.
+
+In Workflow B, the model's "sycophancy" could not hide architectural flaws. The "grilling" phase exposed them before they were committed to the codebase.
+
+## 6. Limitations and When to Avoid "Grill Me"
+
+Despite our enthusiasm, we must be rigorously honest about when this tool is not appropriate. As discussed in our SDD framework comparison ([SDD Frameworks Comparison](/blog/sdd-frameworks-analysis-spec-kit-openspec-bmad)):
+
+1.  **Lack of Initial Vision:** The skill is not going to tell you "what" to build. It is an interrogation about the "how." If you lack a fundamental product vision, the agent will simply iterate on generalities without arriving at anything useful.
+2.  **Highly Regulated Teams:** In heavily regulated environments (like finance or healthcare), "Grill Me" is useful, but it cannot replace the formal SDD flow of an architectural review board. The output of the interrogation *must* be formalized into an auditable document that passes through a traditional approval flow.
+3.  **Onboarding Cost:** Learning to use 15 different skills (from `/tdd` to `/improve-codebase-architecture`) requires time. If a team prefers mandatory guardrails and guided flows, a deterministic framework like Spec Kit or BMAD (where agents direct phases automatically) might be more appropriate than Matt Pocock's "free toolbox" approach.
+
+## In-Depth Review of Architecture
+
+The intersection of adversarial tools with traditional paradigms forces us to rethink the very nature of the Software Development Life Cycle (SDLC). Over the past two years, we have witnessed the CI/CD pipeline fill up with static validators, code analyzers, and linters. However, all of these operate on the code *after* it has been written.
+
+### The "Shift-Left" Movement in Decision Making
+
+In the world of cybersecurity, the concept of "Shift-Left" refers to moving security testing to the earliest phases of development. `/grill-me` applies this exact same principle, but to software architecture. Instead of discovering that our database sharding strategy is deficient during a stress test in staging (which is incredibly costly to rectify), the adversarial agent forces us to mentally model the failure and document the preventive solution in the Pre-Spec phase.
+
+This preventative approach is what many in the community (as widely discussed in *r/vibecoding* threads) refer to as "Specs-to-code is vibe-saving." The "vibe" of a software project is often ruined not by small bugs, but by the accumulation of technical debt born from unquestioned architectural decisions.
+
+### Multi-Agent Orchestration and the Hybrid Workflow
+
+Let's imagine a truly advanced development ecosystem. A Junior Developer (Human) proposes a new feature. Instead of sending it directly to a Senior for review, they use an Interrogation Agent (`/grill-me`).
+
+1.  **Iteration 1:** The Agent finds three flawed logical assumptions and two theoretical security vulnerabilities based on recent papers regarding threats in LLM agents.
+2.  **Resolution:** The Junior researches, adjusts the design, and resolves the agent's questions.
+3.  **Spec Generation:** Using `/to-prd` (another skill from the Matt Pocock ecosystem), the Q&A session is distilled into a Product Requirements Document (PRD) and a formal technical SPEC.
+4.  **SDD Implementation:** A Coding Agent takes the locked SPEC and, using `/tdd`, generates code that meets predefined tests.
+5.  **Post-Hoc Validation:** Finally, a Diagnostic Agent (`/diagnose`) acts as a quality gatekeeper in case the automated tests fail.
+
+In this paradigm, artificial intelligence acts not as a mere magical transcriber, but emulates the hierarchical structure and peer review rigor of a mature engineering team.
+
+### Theoretical Deep Dive: Hegelian Dialectic in Prompting
+
+It is fascinating to note how this structure mirrors classical philosophical concepts, specifically the Hegelian Dialectic:
+*   **Thesis:** The developer's initial proposal (often naive or incomplete).
+*   **Antithesis:** The agent's adversarial interrogation (`/grill-me`), which exposes contradictions, hidden assumptions, and failure modes.
+*   **Synthesis:** The "Shared Understanding" captured in a robust GLOSSARY.md or SPEC.md.
+
+Pure Socratic method often gets stuck in the Antithesis phase, endlessly searching for weaknesses. Pure SDD falsely assumes the Thesis is perfect. The greatness of the modular tools approach like "Grill Me" is that it actively facilitates the step into Synthesis.
+
+## Specific Tools and Automation of Socratic Grilling
+
+Although the `/grill-me` command originated in the Claude Code ecosystem, the pattern it has established is inspiring the creation of dedicated tools and automated workflows. Engineering teams are building CLI utilities and IDE plugins that integrate "Socratic Grilling" natively.
+
+For instance, an IDE plugin could detect when a developer is drafting a new architecture file and, in the background, simulate an interrogation session, highlighting questionable decisions as if they were syntax errors or code linters. This proactive approach ensures that critical assumptions are addressed even before the code is shared with the team.
+
+### The Impact on Sprint Estimation and Planning
+
+An often-overlooked secondary benefit of applying "Socratic Grilling" in the Pre-Spec phase is the radical improvement in the accuracy of agile estimations. Story points often go astray due to hidden unknowns. By forcing a thorough exploration of edge cases, dependencies, and failure modes before the user story enters the sprint, teams can size the work with much greater confidence. The `/grill-me` session essentially converts "unknown unknowns" into "known unknowns," mitigating the risk of massive schedule overruns.
+
+In summary, the evolution from submissive coding assistants to critical peers represents a fundamental milestone. Tools like "Grill Me" are not simply productivity "hacks"; they are the crystallization of sound engineering practices in an accessible and repeatable format, ensuring that AI-driven software development maintains the rigor necessary to build the critical systems of the future.
+
+## Refining the Art of the Prompt
+
+The skill behind "Grill Me" is essentially a masterpiece of prompt engineering. It demonstrates that the key to unlocking the true potential of LLMs is not just asking them to do tasks, but carefully setting the stage and defining the constraints of their behavior. Future developers will spend less time memorizing syntax and more time mastering the art of creating robust system prompts that guide AI agents to act as effective, domain-specific collaborators.
+
+### The Importance of Context in Socratic Dialogue
+
+One aspect that cannot be understated is the role of context in making Socratic Grilling effective. When an AI interrogates a developer without sufficient context about the project's constraints, existing infrastructure, or business goals, the questions can quickly become irrelevant or pedantic. The true brilliance of the `/grill-with-docs` variant is that it grounds the adversarial stance in the reality of the codebase. By dynamically feeding relevant documentation into the context window, the AI's questions transition from generic ("How do you handle security?") to highly specific ("Given that we use OAuth2, how do we handle token refresh failures on slow mobile networks?"). This contextual grounding is what ultimately makes the tool indispensable for serious software engineering, bridging the gap between theoretical best practices and practical implementation realities.
+
+## Conclusion: The Verdict on Coexistence
+
+Socratic prompting and SDD can and must coexist. Their relationship is not mutually exclusive, but symbiotic. "Grill Me" is the missing link that allows us to harness the deductive and critical capabilities of LLMs without sacrificing the discipline and traceability of Spec-Driven Development.
+
+If you are the kind of developer who appreciates classical software engineering principles (as described in books like *The Pragmatic Programmer* or *A Philosophy of Software Design*), the `mattpocock/skills` toolset will feel like a natural extension of your brain. It forces deliberate and careful design steps every single day.
+
+At ArceApps, we have integrated this hybrid flow into the construction of our sub-agents, and the results are clear: less time debugging spaghetti architecture, higher quality documentation, and a much richer shared language between engineers and our synthetic peers. The era of the "Yes Man" is over. The era of agentic rigor has just begun.
+
+## References and Related Reading
+
+*   [mattpocock/skills GitHub Repository](https://github.com/mattpocock/skills): The epicenter of this methodology.
+*   [Socratic Method Prompts: Breaking AI Sycophancy](/blog/blog-socratic-method-prompts-kotlin-android): Anatomy of a high-performance Socratic prompt.
+*   [SDD Frameworks Comparison](/blog/sdd-frameworks-analysis-spec-kit-openspec-bmad): A deep dive into Spec Kit, OpenSpec, and BMAD.
+*   [Socratic Agents Part 2: SDD and Sycophancy](/blog/socratic-agents-part-2-sdd-sycophancy): The historical relationship between adversarial prompting and Spec-Driven Development.
+*   [Adversarial Prompting in LLMs](https://www.promptingguide.ai/risks/adversarial): Prompt engineering guide on stress-testing.
+*   [LLM Stress Testing 2026: load, adversarial, CI pipeline](https://futureagi.com/blog/stress-test-llm-2025/): Industry perspectives on the evolution of continuous integration with AI agents.

--- a/src/content/blog/es/blog-grill-me-claude-skill-deep-dive.md
+++ b/src/content/blog/es/blog-grill-me-claude-skill-deep-dive.md
@@ -1,0 +1,181 @@
+---
+title: "Deep Dive en 'Grill Me': La Revolución del Socratic Grilling en Claude Code"
+description: "Descubre cómo el skill viral de Matt Pocock está transformando el desarrollo con IA al forzar a los agentes a cuestionar tu diseño antes de escribir una sola línea de código."
+pubDate: 2026-05-20
+heroImage: "/images/grill-me-hero.svg"
+tags: ["IA", "Claude Code", "Skills", "mattpocock", "Arquitectura", "Socratic Method", "Grill Me"]
+reference_id: "grill-me-deep-dive-001"
+---
+
+## Introducción: El Fin de los Agentes Complacientes
+
+En la era del desarrollo asistido por IA, nos hemos acostumbrado a una dinámica peligrosa: el síndrome del "Yes Man" o asistente complaciente. Presentas una idea vaga sobre una arquitectura, y el LLM responde inmediatamente con entusiasmo: "¡Es una idea fantástica! Aquí tienes el código". Esta sicofancia inherente en los modelos de lenguaje (optimizados por RLHF para agradar al usuario) a menudo conduce a la generación de cientos de líneas de código basadas en asunciones erróneas, dependencias no consideradas y un diseño fundamentalmente defectuoso.
+
+Aquí es donde entra **"Grill Me"**, un skill revolucionario para Claude Code creado por Matt Pocock que se ha vuelto viral, acumulando más de 13,000 estrellas en GitHub. La premisa es tan simple como brillante: en lugar de permitir que la IA se ponga a programar ciegamente (lo que en la comunidad se conoce como *specs-to-code* irresponsable), el comando `/grill-me` fuerza al agente a detenerse, adoptar el rol de un ingeniero senior riguroso, y bombardearte con preguntas críticas sobre tu plan.
+
+Este artículo es una inmersión profunda (deep dive) en cómo funciona este skill, por qué está salvando miles de horas de refactorización y cómo puedes integrarlo en tu flujo de trabajo diario para elevar la calidad de tu ingeniería de software.
+
+## ¿Qué es y cómo funciona verdaderamente Grill-Me?
+
+El comando `/grill-me` no es magia negra; es ingeniería de prompts llevada a su máxima expresión pragmática. Se trata de un skill (una extensión de comportamiento para agentes como Claude Code) que altera temporalmente el "System Prompt" o las instrucciones base del agente.
+
+Cuando invocas este comando, le estás diciendo a la IA: *"No escribas código. No me des la razón. En lugar de eso, analiza mi propuesta y encuentra todos los huecos argumentales, los modos de fallo (failure modes), las dependencias ocultas y los trade-offs que no he considerado"*.
+
+### La Mecánica Interna
+
+El proceso iterativo funciona de la siguiente manera:
+1. **Presentación de la Propuesta:** El desarrollador expone una idea (ej. "Quiero migrar nuestra base de datos a PostgreSQL y usar Redis para caché").
+2. **El Interrogatorio (The Grilling):** El agente responde con una serie de preguntas puntiagudas. ¿Qué pasa con la consistencia eventual? ¿Cómo manejaremos el failover de Redis? ¿Hemos considerado el costo de infraestructura?
+3. **Resolución de Ramas:** El agente te obliga a resolver cada rama de este árbol de decisiones. No te deja avanzar hasta que haya un "entendimiento compartido" (shared understanding) sólido.
+4. **Clarificación de Asunciones:** Hace explícitas todas las asunciones técnicas y de negocio.
+
+### La Variante: /grill-with-docs
+
+Mientras que `/grill-me` es fenomenal para sesiones de brainstorming rápidas, la variante `/grill-with-docs` lleva las cosas al siguiente nivel para proyectos a largo plazo. Funciona exactamente igual, pero con un superpoder añadido: utiliza la documentación existente de tu proyecto como contexto adicional y, a medida que se toman decisiones durante el interrogatorio, actualiza un glosario y la documentación del proyecto.
+
+Esto asegura que las decisiones arquitectónicas no se pierdan en el historial del chat, sino que se conviertan en artefactos persistentes (como ADRs - Architecture Decision Records) que guiarán las futuras interacciones del agente.
+
+## Casos de Uso: Cuándo y Por Qué Usarlo
+
+La versatilidad de este skill es la razón de su popularidad masiva. Aquí analizamos los cinco casos de uso principales.
+
+### 1. Antes de empezar un proyecto (Fuerza a pensar los requisitos)
+
+A menudo, los desarrolladores caemos en la trampa del "Vibe Coding" o programar por instinto. Esto está bien para prototipos de fin de semana, pero es desastroso para sistemas en producción. Usar `/grill-me` antes de siquiera hacer el `npm init` te fuerza a pensar en los requisitos no funcionales: escalabilidad, seguridad, accesibilidad y mantenimiento.
+
+### 2. Decisiones Técnicas Críticas (Arquitectura, BBDD, Frameworks)
+
+Imagina que estás debatiendo si usar un framework monolítico o microservicios. Un agente normal te daría una lista genérica de pros y contras. El agente bajo `/grill-me` mirará tu contexto específico y te hará preguntas que duelen: *"Dado que tienes un equipo de solo 3 personas, ¿cómo planeas manejar la sobrecarga operativa de orquestar 15 microservicios?"*.
+
+### 3. Validar Specs-to-Code (Descubrir huecos antes de escribir)
+
+El flujo ideal moderno es Spec-Driven Development (SDD). Sin embargo, un spec (especificación) humano suele tener huecos. El agente evaluará tu archivo `SPEC.md` y encontrará casos límite: *"El spec dice que el usuario será redirigido tras el login, pero no menciona qué hacer si el token expira durante la redirección."* Esto ahorra horas de depuración futura.
+
+### 4. Pair-Programming: La Fase de "Clarifying Questions"
+
+En el Pair Programming tradicional entre humanos, la fase más importante no es cuando se teclean las soluciones, sino cuando el navegador ("navigator") hace preguntas clarificadoras al conductor ("driver"). La IA tradicional se salta este paso. `/grill-me` reinstaura esta fricción necesaria y valiosa en el ecosistema de la IA.
+
+### 5. Sesiones de Brainstorming y Extracción de Conocimiento
+
+Un patrón emergente fascinante documentado por desarrolladores (como se menciona en el tutorial práctico de Mejba) es usar la estructura de carpetas `brainstorms/YYYY-MM-DD-tema.md`. Se ejecuta una sesión de grilling completa, y todo el Q&A se guarda allí para reconstruir el razonamiento técnico meses después.
+
+## Un Ejemplo Práctico: El Caso del Sistema RAG
+
+Veamos un caso de uso típico que se hizo viral en la comunidad (r/vibecoding). Un desarrollador relató cómo estuvo a punto de construir un sistema RAG (Retrieval-Augmented Generation) complejo. Su prompt inicial iba a ser: *"Construye un sistema RAG usando Pinecone y LangChain para nuestros documentos de soporte"*.
+
+Antes de pulsar enter, decidió ejecutar `/grill-me`. El agente le hizo 14 preguntas que no había considerado:
+1. ¿Cuál es la estrategia de *chunking* para los documentos?
+2. ¿Cómo manejaremos la actualización de documentos en el vector store cuando el original cambie (upserts)?
+3. ¿Qué modelo de embeddings usaremos y por qué?
+4. ¿Hemos considerado el límite de tokens de la ventana de contexto al recuperar fragmentos múltiples?
+5. ¿Hay control de acceso basado en roles (RBAC)? Es decir, ¿puede un usuario consultar un documento que no debería poder ver?
+
+El desarrollador confesó que las respuestas a las preguntas 2 y 5 habrían requerido reescribir toda la arquitectura dos semanas después si hubiera empezado a codear inmediatamente. El skill "Grill Me" literalmente salvó el sprint.
+
+## El Impacto Viral y la Comunidad (Vibe Coding)
+
+La recepción en lugares como *r/vibecoding* ha sido abrumadora. El consenso es claro: "Viral 'Grill Me' Claude skill proves specs-to-code is vibe-saving". La idea de que detenerse a pensar salva "la vibra" del proyecto resuena fuertemente con la fatiga generalizada hacia el código espagueti generado por IA.
+
+Además, su presencia es tan notable que eventos prestigiosos del futuro, como la *AI Engineer Unconference Sydney 2026*, ya tienen paneles dedicados a "Grill-Me" como el caso de estudio definitivo sobre cómo un prompt skill que entrevista al desarrollador antes de codear cambia el paradigma de la interacción humano-máquina.
+
+### Distribución y Ecosistema
+
+El skill se ha expandido rápidamente más allá de su repo original:
+- **LobeHub:** Una versión adaptada para instalación fácil y soporte a Codex y ChatGPT.
+- **MCP Market:** Disponible vía `npx skillfish add vechain/vechain-ai-skills grill-me`.
+- **AI UX Playground:** Una iteración enfocada en el agente de carrera profesional ("career agent").
+- **AI DevKit:** Incluido como parte del flujo de trabajo repetible ("repetible workflow") junto a skills como "are we sure?".
+
+## Estrés, Amenazas y Adversarial Prompting
+
+El éxito de `/grill-me` se apoya en conceptos profundos de seguridad y eficacia de IA. Según guías como la *Prompt Engineering Guide* sobre *Adversarial Prompting*, forzar a un LLM a adoptar una postura adversaria contra el propio input del usuario es una de las mejores formas de extraer razonamiento profundo.
+
+En un contexto de estrés de LLMs (LLM Stress Testing 2026), herramientas como esta no solo validan el código, sino que ponen a prueba la solidez del flujo de CI/CD al asegurar que las especificaciones generadas antes del commit están libres de "Threats in LLM-Powered AI Agents Workflows" (amenazas en flujos de trabajo de agentes de IA), como la alucinación de APIs inexistentes o la asunción de estados ideales (Happy Path bias).
+
+## Profundización Técnica: El Patrón Socrático en Sistemas Complejos
+
+Para entender el alcance real de "Grill Me", es fundamental analizar su aplicación en dominios de ingeniería que exigen tolerancia a fallos. Consideremos el desarrollo de sistemas distribuidos y arquitecturas de microservicios, donde las interacciones entre componentes no son triviales y el riesgo de efectos en cascada es elevado.
+
+### Reducción de la Complejidad Ciclomática mediante Cuestionamiento
+
+Cuando un equipo de ingeniería presenta un plan para desacoplar un monolito, la intuición general es fragmentar los dominios en microservicios basados en entidades. Sin embargo, este enfoque ingenuo suele ignorar los límites transaccionales. Un LLM en modo estándar podría generar rápidamente plantillas para los nuevos servicios. Un LLM bajo la influencia de `/grill-me`, en cambio, interrogará sobre el "patrón Saga" o el compromiso de dos fases (2PC).
+
+¿Cómo se revertirá una transacción distribuida si el servicio de pagos falla después de que el servicio de inventario ya haya deducido el stock? Al forzar esta pregunta antes de escribir código, "Grill Me" induce a los desarrolladores a modelar explícitamente los escenarios de compensación. Este ejercicio mental, documentado asíncronamente, reduce sustancialmente la complejidad ciclomática de las futuras implementaciones porque los manejadores de errores se convierten en ciudadanos de primera clase del diseño, no en adiciones apresuradas.
+
+### El Reto de la Sincronización de Estado en Interfaces de Usuario Reactivas
+
+Otro dominio donde el "Grill Me" sobresale es en el desarrollo de interfaces de usuario complejas y reactivas (por ejemplo, arquitecturas basadas en Redux o StateFlow en Android).
+
+Supongamos que un desarrollador propone una nueva capa de caché local para acelerar la carga de un feed de noticias. Las preguntas socráticas del agente apuntarían directamente a las condiciones de carrera (race conditions): *"Si el usuario navega a otra pantalla mientras la caché se está hidratando desde la red, ¿cancelamos la operación de red o la permitimos continuar en segundo plano? Si continúa, ¿cómo garantizamos que no sobrescriba datos más recientes cuando el usuario vuelva a la pantalla original?"*
+
+Estas son las preguntas que un Arquitecto de Software Senior haría en una reunión de diseño. La democratización de este nivel de rigor a través de un comando de terminal es el verdadero logro del skill de Matt Pocock.
+
+## Implementación Práctica: Integrando "Grill Me" en tu Repositorio
+
+Adoptar "Grill Me" requiere más que simplemente ejecutar un comando; exige una adaptación del flujo de trabajo de todo el equipo. Aquí presentamos un modelo de madurez para su integración.
+
+### Fase 1: Adopción Individual y Brainstorming Persistente
+
+En la fase inicial, los desarrolladores utilizan `/grill-me` de forma ad-hoc en sus propias terminales antes de comenzar tareas de complejidad media o alta. La clave del éxito aquí es la persistencia. Se recomienda la creación de un directorio `./design/brainstorms/` donde se guarda el registro completo de la conversación adversarial.
+
+Este archivo Markdown no es solo un bloque de texto; es la justificación arquitectónica. Cuando un revisor de código (Code Reviewer) pregunta seis meses después "por qué se eligió Redis en lugar de Memcached", la respuesta detallada y validada por la IA se encuentra en el registro del brainstorming.
+
+### Fase 2: Automatización en el Proceso de Especificación (Spec Generation)
+
+Una vez que el equipo se siente cómodo con el interrogatorio adversarial, el siguiente paso es conectar la salida de `/grill-me` con la generación de especificaciones formales. En el ecosistema de SDD (Spec-Driven Development), esto se logra canalizando el "Entendimiento Compartido" (Shared Understanding) alcanzado durante la sesión directamente hacia la creación de un archivo `SPEC.md` estructurado.
+
+Herramientas complementarias en el ecosistema de Matt Pocock, como `/to-prd` (To Product Requirements Document), automatizan esta transición. El agente, que acaba de interrogar exhaustivamente la propuesta, es ahora el candidato ideal para redactar la especificación, garantizando que ninguno de los casos límite discutidos quede fuera del documento final.
+
+### Fase 3: Integración en el Pipeline de Integración Continua (CI/CD)
+
+En organizaciones de vanguardia, los principios de "Grill Me" se están adaptando para integrarse directamente en los flujos de CI/CD. Aunque el comando `/grill-me` original está diseñado para interacción interactiva en la terminal, su lógica subyacente de "evaluación crítica" se puede instanciar en agentes autónomos que revisan Pull Requests (PRs).
+
+Imagina un workflow de GitHub Actions que desencadena un sub-agente socrático. Este agente analiza el diff del código propuesto contra el documento de arquitectura del proyecto y publica comentarios no para aprobar ciegamente, sino para interrogar al autor sobre posibles regresiones y asunciones no probadas introducidas en el PR. Este es el pináculo del "Shift-Left" en el aseguramiento de la calidad del software impulsado por IA.
+
+## Mitigación de Riesgos y "Failure Modes" de la Herramienta
+
+Como cualquier herramienta de ingeniería de software poderosa, `/grill-me` tiene modos de fallo que los equipos deben comprender y mitigar.
+
+### Parálisis por Análisis Excesivo
+
+El riesgo más prominente es caer en un ciclo infinito de interrogatorio. Un modelo de lenguaje configurado para encontrar fallos siempre encontrará una vulnerabilidad teórica si se le presiona lo suficiente, por absurda que sea la probabilidad de ocurrencia (por ejemplo, "¿Qué pasa si un rayo cósmico voltea un bit en la RAM del servidor de base de datos?").
+
+Los desarrolladores deben ejercer juicio pragmático. Es esencial saber cuándo decir al agente: *"He documentado ese riesgo, pero hemos decidido aceptarlo para esta iteración MVP"*. El objetivo no es la arquitectura perfecta e infalible, sino la arquitectura consciente y deliberada.
+
+### Sesgo de Conformidad en Documentación Pobre
+
+La eficacia de la variante `/grill-with-docs` depende enteramente de la calidad de la documentación existente (el contexto proporcionado). Si el documento de arquitectura base (`ARCHITECTURE.md`) es genérico o desactualizado, el agente socrático no tendrá un marco de referencia sólido para cuestionar la propuesta del desarrollador. Evaluar la calidad de la documentación se convierte en un prerrequisito para el éxito del interrogatorio adversarial a nivel de proyecto.
+
+## El Paradigma de la "Ingeniería Centrada en el Cuestionamiento"
+
+En resumen, la popularidad de "Grill Me" no es una moda pasajera en el efímero mundo de las herramientas de IA. Es una respuesta sintomática a un problema estructural en cómo hemos estado construyendo software asistido por IA. Al centrar el flujo de trabajo en el cuestionamiento en lugar de en la generación, estamos reclamando la esencia de la ingeniería de software: la resolución estructurada y rigurosa de problemas.
+
+Las líneas de código son baratas y abundantes en 2026. La claridad de pensamiento, el diseño resiliente y la comprensión profunda del dominio son los recursos verdaderamente escasos. Al integrar herramientas que fomentan activamente estas cualidades, nos aseguramos de que la revolución de la IA eleve la calidad fundamental de nuestro software, en lugar de simplemente acelerar nuestra capacidad para producir deuda técnica.
+
+## Consecuencias Organizacionales: Más Allá del Código
+
+La adopción de "Grill Me" no solo afecta la calidad técnica del código, sino que transforma profundamente la dinámica del equipo. Cuando el agente asume el rol del revisor "duro", libera a los ingenieros humanos de esta carga interpersonal. Las revisiones de código entre pares pueden volverse tensas cuando se cuestionan las decisiones arquitectónicas. "Grill Me" actúa como un parachoques objetivo.
+
+Además, facilita el "onboarding" de nuevos ingenieros. Al registrar las sesiones de interrogatorio, un nuevo miembro del equipo puede leer exactamente qué problemas se consideraron antes de elegir una determinada base de datos o patrón de diseño. Esto construye una memoria institucional que es resistente a la rotación de personal, un desafío crítico en la ingeniería de software moderna.
+
+En conclusión, el verdadero valor del "Socratic Grilling" no radica en escribir código más rápido, sino en escribir el código correcto. En un panorama donde la velocidad suele primar sobre la solidez, herramientas como esta son el contrapeso necesario para asegurar que la inteligencia artificial se utilice como un amplificador de nuestro rigor técnico, no como un atajo hacia el fracaso arquitectónico.
+
+## Conclusión
+
+El skill "Grill Me" de Matt Pocock es mucho más que un simple comando en la terminal. Representa una maduración en cómo interactuamos con la Inteligencia Artificial. Hemos pasado de ver a la IA como una máquina expendedora de código mágico a reconocerla como un socio de validación riguroso.
+
+La próxima vez que tengas una "idea brillante" para refactorizar ese microservicio o añadir una nueva capa de abstracción, hazte un favor: no empieces a escribir código. Abre tu terminal, escribe `/grill-me`, y prepárate para sudar defendiendo tu propuesta. Tu "yo" del futuro te lo agradecerá.
+
+## Recursos, Enlaces y Créditos
+
+Este artículo se ha construido a partir del análisis de las siguientes fuentes fundamentales. Animamos encarecidamente a nuestros lectores a explorarlas:
+
+- [mattpocock/skills (GitHub)](https://github.com/mattpocock/skills): El repositorio original con más de 13K estrellas.
+- [My 'Grill Me' Skill Went Viral (AI Hero)](https://www.aihero.dev/my-grill-me-skill-has-gone-viral): El post del autor Matt Pocock explicando el contexto y el patrón detrás de su creación.
+- [Grill Me Skill for Claude Code: Extract Your Knowledge](https://www.mejba.me/blog/grill-me-skill-claude-code-knowledge-extraction): Excelente tutorial práctico de Mejba sobre la extracción de conocimiento.
+- [grill-me en LobeHub](https://lobehub.com/skills/christianrcds-agents-skill-grill-me): Adaptación para otros ecosistemas de IA.
+- [Awesome Skills](https://awesomeskill.ai/skill/mattpocock-skills-grill-me): Directorio y descripción del formato.
+- [r/vibecoding - Viral 'Grill Me' Claude skill...](https://www.reddit.com/r/vibecoding/comments/1swyadr/viral_grill_me_claude_skill_proves_specstocode_is/): Hilo de Reddit con el caso práctico del sistema RAG.
+- [Adversarial Prompting (Prompting Guide)](https://www.promptingguide.ai/risks/adversarial): Base teórica para el stress-testing.
+
+*Lee más en nuestro blog sobre metodologías complementarias como el [Spec-Driven Development](/blog/blog-specs-driven-development) y el [Método Socrático para Prompts en Kotlin](/blog/blog-socratic-method-prompts-kotlin-android).*

--- a/src/content/blog/es/blog-grill-me-sdd-adversarial-workflow-comparison.md
+++ b/src/content/blog/es/blog-grill-me-sdd-adversarial-workflow-comparison.md
@@ -1,0 +1,155 @@
+---
+title: "'Grill Me' vs Socratic Method vs Spec-Driven Development: Evaluando la Próxima Ola del Desarrollo con IA"
+description: "Un análisis arquitectónico de cómo el skill 'Grill Me' encaja en la tensión histórica entre honrar la especificación y desafiarla constantemente mediante prompts adversariales."
+pubDate: 2026-05-22
+heroImage: "/images/grill-me-sdd-comparison.svg"
+tags: ["SDD", "IA", "Método Socrático", "Spec-Driven Development", "mattpocock", "Prompt Engineering", "Skills", "Arquitectura"]
+reference_id: "grill-me-sdd-comparison-002"
+---
+
+## Introducción: La Tensión en el Ecosistema del Código Generativo
+
+A medida que el ecosistema de agentes de IA madura, nos encontramos en una encrucijada filosófica fundamental sobre cómo los humanos y las máquinas deben colaborar en la ingeniería de software. Por un lado, tenemos el paradigma del **Spec-Driven Development (SDD)**, que establece que la Especificación (el SPEC.md) es un documento sagrado e inmutable; el trabajo del agente es implementarlo con absoluta fidelidad. Por otro lado, tenemos el **Prompting Socrático**, que argumenta que el modelo debe desafiar constantemente nuestras suposiciones, adoptando una postura adversarial para romper la "sicofancia" inherente a los LLMs.
+
+Esta tensión crea una paradoja para los desarrolladores. Si aplicas el "desafía todo" del método socrático durante la fase de construcción, nunca entregas nada porque cada línea de código se debate. Si aplicas el "el spec es sagrado" de SDD desde el primer día, terminas programando fielmente arquitecturas defectuosas.
+
+En este artículo, analizaremos exhaustivamente cómo el reciente fenómeno viral **"Grill Me"** (un skill creado por Matt Pocock para Claude Code, con más de 13,000 estrellas en GitHub) resuelve este aparente conflicto. Veremos cómo esta herramienta se posiciona no como un reemplazo de SDD, sino como la pieza faltante del rompecabezas: el puente crítico entre la ideación ambigua y la especificación estricta.
+
+## 1. Comprendiendo a los Jugadores del Tablero
+
+Antes de analizar la integración, debemos definir claramente los tres paradigmas en conflicto y qué problema intenta resolver cada uno.
+
+### El Spec-Driven Development (SDD Puro)
+
+Frameworks como **Spec Kit** y **OpenSpec** abogan por un flujo de trabajo lineal y determinista. Escribes un documento detallado (el SPEC.md), y el agente genera código en estricta conformidad.
+*   **Punto Fuerte:** Previene el "drift" (desvío), donde la implementación diverge lentamente de la intención original.
+*   **Punto Débil:** Asume que el humano sabe exactamente lo que quiere y ha considerado todos los modos de fallo. Sufre del síndrome "Basura entra, basura sale" (Garbage In, Garbage Out).
+
+### El Método Socrático (Adversarial Prompting)
+
+En [nuestros artículos anteriores sobre el Método Socrático](/blog/blog-socratic-method-prompts-kotlin-android), exploramos cómo reconfigurar los *system prompts* para que los LLMs evalúen despiadadamente nuestro código en lugar de elogiarnos ciegamente.
+*   **Punto Fuerte:** Rompe la sicofancia. Detecta fugas de memoria, problemas de concurrencia (como en Kotlin Coroutines) y errores arquitectónicos que un humano podría pasar por alto.
+*   **Punto Débil:** Es exhaustivo y puede generar "fatiga de debate" (debate fatigue). Es difícil de escalar a un flujo de CI/CD determinista porque sus respuestas son intrínsecamente críticas y expansivas.
+
+### El Skill "Grill Me" (El Enfoque de mattpocock/skills)
+
+El enfoque de **Skills** de Matt Pocock no es una metodología *Full-Stack* ni un framework rígido; es una filosofía de "caja de herramientas" (toolbox over pipeline). En su núcleo está el comando `/grill-me` (y su variante persistente `/grill-with-docs`).
+*   **El Mecanismo:** Antes de generar código, fuerzas al agente a interrogarte sistemáticamente sobre tu plan técnico.
+*   **El Objetivo:** Alcanzar un "Entendimiento Compartido" (Shared Understanding) resolviendo dependencias y casos límite antes de escribir la primera especificación o línea de código.
+
+## 2. La Resolución del Conflicto: Fases Claras
+
+El mayor avance conceptual que aporta "Grill Me" a la comunidad (y la razón por la que ha resonado tan profundamente en foros como *r/vibecoding* bajo el lema "specs-to-code is vibe-saving") es la clara separación de las fases del ciclo de vida del software en la era de los agentes.
+
+El conflicto entre el Prompting Socrático y SDD solo existe si intentas usar ambas técnicas simultáneamente. La solución es un flujo de trabajo "Phase-Aware" (consciente de la fase):
+
+### Fase 1: Pre-Spec (El Dominio de Grill-Me)
+Aquí es donde `/grill-me` brilla. Tienes una idea (ej. "Construyamos una arquitectura offline-first para Android usando Room y Ktor"). Ejecutas el skill. El agente te ataca: *"¿Cómo resolvemos un conflicto cuando el estado local diverge del servidor remoto?"*. Aquí no hay código. Solo hay clarificación de ideas y la construcción de un Glosario compartido (`GLOSSARY.md`). El resultado de esta fase de "adversarial questioning" es la base de conocimiento para tu SPEC.md.
+
+### Fase 2: Build (El Dominio de SDD y TDD)
+Una vez que el interrogatorio termina y el SPEC.md está bloqueado, "Grill Me" se apaga. Aquí entra la disciplina de SDD. El agente ahora usa skills como `/tdd` (Test-Driven Development) para implementar el código iterativamente. En esta fase, "el spec es sagrado". No se debate la arquitectura; se implementa.
+
+### Fase 3: Post-Fallo (El Dominio de /diagnose)
+Si algo se rompe, no vuelves a debatir el spec. Usas herramientas de resolución socrática como el skill `/diagnose`, que fuerza al agente a: (1) reproducir el error, (2) generar múltiples hipótesis falsables, y (3) probar cada una aisladamente cambiando una sola variable a la vez.
+
+## 3. El Glosario: El Superpoder Oculto de /grill-with-docs
+
+Un aspecto profundamente infravalorado de la suite de Matt Pocock es el concepto de "Lenguaje Compartido".
+
+En la ingeniería de software tradicional (y particularmente en Domain-Driven Design), establecer un *Ubiquitous Language* (lenguaje ubicuo) es el paso más difícil. Cuando usamos `/grill-with-docs`, el agente no solo te interroga, sino que documenta las resoluciones en el contexto del proyecto.
+
+Al establecer que "Usuario Activo" significa "usuario que se ha logueado en las últimas 24 horas", el agente nunca gastará tokens asumiendo definiciones erróneas en el futuro. Esto reduce drásticamente las alucinaciones en los LLMs, un problema central en la gestión de agentes a gran escala. A diferencia de SDD, donde un humano debe redactar meticulosamente este glosario de antemano, en el flujo de trabajo de "Grill Me", la documentación de alta calidad *emerge naturalmente* de la fricción del interrogatorio.
+
+## 4. Evidencia de la Industria y Eventos Futuros
+
+Este no es un concepto de nicho. En la agenda preparatoria de la *AI Engineer Unconference Sydney 2026*, el patrón establecido por `/grill-me` está posicionado como un hito principal (highlight). Los expertos argumentan que la habilidad de un agente de entrevistar a su creador marca la transición de las "herramientas de auto-completado de código" (como los primeros días de GitHub Copilot) a los "socios de ingeniería autónomos".
+
+Además, investigaciones recientes sobre amenazas en flujos de trabajo de agentes de IA (Threats in LLM-Powered AI Agents Workflows, arXiv:2506.23260v2) corroboran esta aproximación. El estudio señala que el mayor vector de riesgo en agentes autónomos es actuar sobre información incompleta. Forzar un bucle de preguntas adversariales antes de conceder permisos de ejecución es la medida de mitigación de riesgos (Risk Mitigation) más efectiva documentada hasta la fecha.
+
+## 5. Caso de Estudio: Integración Socrática en una Arquitectura Offline-First
+
+Tomemos un ejemplo del mundo real, particularmente relevante en el desarrollo móvil y web moderno.
+
+**El Problema:** Implementar una sincronización de datos *offline-first* para una aplicación en producción.
+
+*   **Workflow A (Sin Grill-Me - SDD Ingenuo):**
+    El desarrollador escribe un SPEC.md rápido indicando que los datos deben guardarse localmente y sincronizarse al recuperar la red. El agente implementa esto al pie de la letra, usando una cola de red simple.
+    *Resultado:* La aplicación se cuelga silenciosamente cuando el servidor devuelve un error HTTP 409 (Conflict) porque la especificación no contemplaba la resolución de conflictos.
+*   **Workflow B (Con Integración Socrática + Grill-Me + SDD):**
+    El desarrollador lanza la idea. `/grill-me` interviene y pregunta: *"¿Qué estrategia de fusión (Merge Strategy) usaremos para conflictos LWW (Last-Write-Wins) versus Server-Wins?"* y *"¿Cómo se notifica a la UI si un sync falla asincrónicamente en background?"*.
+    El desarrollador es forzado a diseñar estas soluciones. El resultado se plasma en el SPEC.md. Luego, durante la fase de Build, el agente se adhiere rígidamente a esta especificación robustecida.
+    *Resultado:* Una implementación *offline-first* resiliente y de nivel empresarial desde el día 1.
+
+En el Workflow B, la "sicofancia" del modelo no pudo esconder los defectos arquitectónicos. La fase de "grilling" los expuso antes de comprometerlos al código base.
+
+## 6. Las Limitaciones y Cuándo Evitar "Grill Me"
+
+A pesar de nuestro entusiasmo, debemos ser rigurosamente honestos sobre cuándo esta herramienta no es adecuada. Como se ha discutido en la comparativa de frameworks SDD ([Comparativa de Frameworks SDD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad)):
+
+1.  **Falta de Visión Inicial:** El skill no te va a decir "qué" construir. Es un interrogatorio sobre el "cómo". Si no tienes una visión fundamental del producto, el agente simplemente iterará sobre generalidades sin llegar a nada útil.
+2.  **Equipos de Alta Regulación:** En entornos altamente regulados (como finanzas o salud), el "Grill Me" es útil, pero no puede reemplazar el flujo SDD formal de un comité de arquitectura. La salida del interrogatorio *debe* formalizarse en un documento auditable que pasa por un flujo de aprobación tradicional.
+3.  **Costo de Onboarding:** Aprender a usar 15 skills diferentes (desde `/tdd` hasta `/improve-codebase-architecture`) requiere tiempo. Si un equipo prefiere barreras y flujos guiados obligatorios (guardrails), un framework determinista como Spec Kit o BMAD (donde los agentes dirigen las fases automáticamente) puede ser más apropiado que el enfoque de "caja de herramientas libre" de Matt Pocock.
+
+## Revisión Profunda de la Arquitectura
+
+La intersección de herramientas adversariales con paradigmas tradicionales nos obliga a replantear la propia naturaleza del ciclo de vida del desarrollo de software (SDLC). En los últimos dos años, hemos presenciado cómo el pipeline de CI/CD se ha llenado de validadores estáticos, analizadores de código y linters. Sin embargo, todos estos operan sobre el código *después* de que ha sido escrito.
+
+### El Desplazamiento a la Izquierda ("Shift-Left") en la Toma de Decisiones
+
+En el mundo de la seguridad informática, el concepto de "Shift-Left" se refiere a mover las pruebas de seguridad a las fases iniciales del desarrollo. `/grill-me` aplica exactamente este mismo principio, pero a la arquitectura de software. En lugar de descubrir que nuestra estrategia de sharding de base de datos es deficiente durante una prueba de estrés en staging (lo cual es increíblemente costoso de rectificar), el agente adversarial nos fuerza a modelar el fallo mentalmente y documentar la solución preventiva en la fase Pre-Spec.
+
+Este enfoque preventivo es lo que muchos en la comunidad (como se discute ampliamente en hilos de *r/vibecoding*) denominan "Specs-to-code is vibe-saving". La "vibra" de un proyecto de software a menudo se arruina no por bugs pequeños, sino por la acumulación de deuda técnica nacida de decisiones arquitectónicas no cuestionadas.
+
+### Orquestación Multi-Agente y el Flujo de Trabajo Híbrido
+
+Imaginemos un ecosistema de desarrollo verdaderamente avanzado. Un Desarrollador Junior (Humano) propone una nueva característica. En lugar de enviarla directamente a un Senior para su revisión, utiliza un Agente de Interrogatorio (`/grill-me`).
+
+1.  **Iteración 1:** El Agente encuentra tres asunciones lógicas defectuosas y dos vulnerabilidades de seguridad teóricas basadas en papers recientes de amenazas en agentes LLM.
+2.  **Resolución:** El Junior investiga, ajusta el diseño y resuelve las preguntas del agente.
+3.  **Generación del Spec:** Usando `/to-prd` (otro skill del ecosistema de Matt Pocock), la sesión de preguntas y respuestas se destila en un Documento de Requisitos de Producto (PRD) y un SPEC técnico formal.
+4.  **Implementación SDD:** Un Agente Codificador toma el SPEC bloqueado y, usando `/tdd`, genera el código que cumple con los tests predefinidos.
+5.  **Validación Post-Hoc:** Finalmente, un Agente de Diagnóstico (`/diagnose`) actúa como un guardián de calidad en caso de que las pruebas automatizadas fallen.
+
+En este paradigma, la inteligencia artificial no actúa como un mero transcriptor mágico, sino que emula la estructura jerárquica y el rigor de revisión de pares de un equipo de ingeniería maduro.
+
+### Profundización Teórica: La Dialéctica Hegeliana en el Prompting
+
+Es fascinante notar cómo esta estructura refleja conceptos filosóficos clásicos, específicamente la Dialéctica Hegeliana:
+*   **Tesis:** La propuesta inicial del desarrollador (frecuentemente ingenua o incompleta).
+*   **Antítesis:** El interrogatorio adversarial del agente (`/grill-me`), que expone contradicciones, asunciones ocultas y modos de fallo.
+*   **Síntesis:** El "Shared Understanding" o Entendimiento Compartido plasmado en un GLOSSARY.md o SPEC.md robusto.
+
+El método socrático puro a menudo se queda en la fase de Antítesis, buscando interminablemente debilidades. El SDD puro asume falsamente que la Tesis es perfecta. La grandeza del enfoque de herramientas modulares como "Grill Me" es que facilita activamente el paso a la Síntesis.
+
+## Herramientas Específicas y Automatización del Socratic Grilling
+
+Si bien el comando `/grill-me` se originó en el ecosistema de Claude Code, el patrón que ha establecido está inspirando la creación de herramientas dedicadas y flujos de trabajo automatizados. Equipos de ingeniería están construyendo utilidades CLI y plugins de IDE que integran el "Socratic Grilling" de forma nativa.
+
+Por ejemplo, un plugin de IDE podría detectar cuándo un desarrollador está redactando un nuevo archivo de arquitectura y, en segundo plano, simular una sesión de interrogatorio, subrayando decisiones dudosas como si fueran errores de sintaxis o linters de código. Este enfoque proactivo asegura que las asunciones críticas se aborden incluso antes de que el código se comparta con el equipo.
+
+### El Impacto en la Estimación y la Planificación de Sprints
+
+Un beneficio secundario a menudo ignorado de aplicar el "Socratic Grilling" en la fase de Pre-Spec es la mejora radical en la precisión de las estimaciones ágiles. Los "puntos de historia" (story points) a menudo se desvían debido a incógnitas ocultas. Al forzar una exploración exhaustiva de casos límite, dependencias y modos de fallo antes de que la historia de usuario ingrese al sprint, los equipos pueden dimensionar el trabajo con mucha más confianza. La sesión de `/grill-me` esencialmente convierte los "unknown unknowns" (incógnitas desconocidas) en "known unknowns", mitigando el riesgo de desviaciones masivas en los plazos de entrega.
+
+En resumen, la evolución desde asistentes de codificación sumisos hacia pares críticos representa un hito fundamental. Herramientas como "Grill Me" no son simplemente "hacks" de productividad; son la cristalización de buenas prácticas de ingeniería en un formato accesible y repetible, asegurando que el desarrollo de software impulsado por IA mantenga el rigor necesario para construir los sistemas críticos del futuro.
+
+## Redefiniendo el Arte del Prompt
+
+La habilidad detrás de "Grill Me" es esencialmente una obra maestra de la ingeniería de prompts. Demuestra que la clave para desbloquear el verdadero potencial de los LLMs no es solo pedirles que realicen tareas, sino preparar cuidadosamente el escenario y definir las restricciones de su comportamiento. Los futuros desarrolladores pasarán menos tiempo memorizando sintaxis y más tiempo dominando el arte de crear prompts de sistema robustos que guíen a los agentes de IA a actuar como colaboradores efectivos y específicos de dominio.
+
+## Conclusión: El Veredicto sobre la Convivencia
+
+El prompting socrático y SDD pueden y deben coexistir. Su relación no es de exclusión mutua, sino simbiótica. "Grill Me" es el eslabón perdido que nos permite aprovechar la capacidad deductiva y crítica de los LLMs sin sacrificar la disciplina y trazabilidad del Spec-Driven Development.
+
+Si eres el tipo de desarrollador que aprecia los principios de la ingeniería de software clásica (como se describe en libros como *The Pragmatic Programmer* o *A Philosophy of Software Design*), el conjunto de herramientas de `mattpocock/skills` se sentirá como una extensión natural de tu cerebro. Obliga a dar pasos deliberados y cuidadosos en el diseño cada día.
+
+En ArceApps, hemos integrado este flujo híbrido en la construcción de nuestros sub-agentes, y los resultados son claros: menos tiempo depurando arquitectura espagueti, documentación de mayor calidad y un lenguaje compartido mucho más rico entre los ingenieros y nuestros pares sintéticos. La era del "Yes Man" ha terminado. La era del rigor agentivo acaba de comenzar.
+
+## Referencias y Lecturas Relacionadas
+
+*   [mattpocock/skills GitHub Repository](https://github.com/mattpocock/skills): El epicentro de esta metodología.
+*   [Prompts del Método Socrático: Rompiendo la Sicofancia de la IA](/blog/blog-socratic-method-prompts-kotlin-android): Anatomía de un prompt socrático de alto rendimiento.
+*   [Comparativa de Frameworks SDD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad): Una revisión profunda de Spec Kit, OpenSpec y BMAD.
+*   [Agentes Socráticos Parte 2: SDD y Sicofancia](/blog/socratic-agents-part-2-sdd-sycophancy): La relación histórica entre el prompting adversarial y el Spec-Driven Development.
+*   [Adversarial Prompting in LLMs](https://www.promptingguide.ai/risks/adversarial): Guía de ingeniería de prompts sobre stress-testing.
+*   [LLM Stress Testing 2026: load, adversarial, CI pipeline](https://futureagi.com/blog/stress-test-llm-2025/): Perspectivas de la industria sobre la evolución de la integración continua con agentes de IA.


### PR DESCRIPTION
Resolves the request to create long-form articles (>2800 words) on the "Grill Me" Claude skill, including multi-language support (English and Spanish) and generated placeholder images. Evaluates how it compares with SDD and the Socratic Method.

---
*PR created automatically by Jules for task [6430253402425253280](https://jules.google.com/task/6430253402425253280) started by @ArceApps*