### PR TITLE
🧪 test: add missing edge case tests for getRouteFromUrl

### DIFF
--- a/src/i18n/utils.test.ts
+++ b/src/i18n/utils.test.ts
@@ -90,6 +90,14 @@ describe('i18n utils', () => {
       const url = new URL('http://localhost:4321/blog/post-1');
       expect(getRouteFromUrl(url)).toBe('/blog/post-1');
     });
+
+    it('returns original path for URLs with invalid first path segments', () => {
+      const url = new URL('http://localhost:4321/invalid/blog');
+      expect(getRouteFromUrl(url)).toBe('/invalid/blog');
+
+      const url2 = new URL('http://localhost:4321/fr/about');
+      expect(getRouteFromUrl(url2)).toBe('/fr/about');
+    });
   });
 
   describe('normalizePath', () => {


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `getRouteFromUrl` edge cases where the first path segment is invalid or an unsupported language.
📊 **Coverage:** Specifically tested URLs like `/invalid/blog` and `/fr/about` to ensure the function properly falls back to returning the original pathname.
✨ **Result:** Increased testing confidence around the i18n routing utilities, proving that non-localized paths or incorrect language codes are handled gracefully without stripping the first path segment.

---
*PR created automatically by Jules for task [8674188123123692100](https://jules.google.com/task/8674188123123692100) started by @ArceApps*