### PR TITLE
🧹 refactor(security): improve type safety in `safeJsonLd` by replacing `any` with `unknown`

### DIFF
--- a/src/content/devlog/en/2026-05-16-w20-refactoring-optimization.md
+++ b/src/content/devlog/en/2026-05-16-w20-refactoring-optimization.md
@@ -114,7 +114,7 @@ We implemented `safeJsonLd` in `src/utils/security.ts`, which escapes problemati
 
 ```typescript
 // src/utils/security.ts
-export function safeJsonLd(data: any): string {
+export function safeJsonLd(data: unknown): string {
   return JSON.stringify(data)
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')

--- a/src/content/devlog/es/2026-05-16-w20-refactoring-optimization.md
+++ b/src/content/devlog/es/2026-05-16-w20-refactoring-optimization.md
@@ -114,7 +114,7 @@ Implementamos `safeJsonLd` en `src/utils/security.ts`, que escapa los caracteres
 
 ```typescript
 // src/utils/security.ts
-export function safeJsonLd(data: any): string {
+export function safeJsonLd(data: unknown): string {
   return JSON.stringify(data)
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -6,7 +6,7 @@
  * @param data The object to serialize
  * @returns A safe JSON string
  */
-export function safeJsonLd(data: any): string {
+export function safeJsonLd(data: unknown): string {
   return JSON.stringify(data)
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the `any` type with `unknown` in the `safeJsonLd` function (`src/utils/security.ts`). Also updated documentation devlogs reflecting this change.

💡 **Why:** How this improves maintainability
Using `unknown` is safer than `any` as it forces the type system to acknowledge that the parameter could be anything without implicitly turning off type checks downstream. `JSON.stringify` natively supports `unknown` or arbitrary values.

✅ **Verification:** How you confirmed the change is safe
Ran `pnpm test` (security tests passed) and `pnpm astro check` (no typescript errors were introduced). 

✨ **Result:** The improvement achieved
Better type safety for `safeJsonLd` with zero runtime changes.

---
*PR created automatically by Jules for task [17137352608146820262](https://jules.google.com/task/17137352608146820262) started by @ArceApps*