### PR TITLE
feat: add rules.md standard bilingual blog post

### DIFF
--- a/public/images/placeholder-article-rules-md.svg
+++ b/public/images/placeholder-article-rules-md.svg
@@ -1,0 +1,21 @@
+<svg width="800" height="600" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="600" fill="#f1f5f9" />
+  <rect x="150" y="150" width="500" height="300" fill="#e0f2f1" fill-opacity="0.3" />
+  <rect x="180" y="180" width="440" height="240" fill="#ffffff" fill-opacity="0.8" />
+  <line x1="200" y1="220" x2="580" y2="220" stroke="#cc0000" stroke-width="3" />
+  <line x1="200" y1="250" x2="550" y2="250" stroke="#cc0000" stroke-width="3" />
+  <line x1="200" y1="280" x2="570" y2="280" stroke="#cc0000" stroke-width="3" />
+  <line x1="200" y1="310" x2="530" y2="310" stroke="#cc0000" stroke-width="3" />
+  <line x1="200" y1="340" x2="560" y2="340" stroke="#cc0000" stroke-width="3" />
+  <line x1="200" y1="370" x2="540" y2="370" stroke="#cc0000" stroke-width="3" />
+  <rect x="100" y="100" width="600" height="40" fill="#ff6b6b" fill-opacity="0.8" />
+  <circle cx="130" cy="120" r="12" fill="#FF9800" fill-opacity="0.9" />
+  <circle cx="160" cy="120" r="12" fill="#ffb74d" fill-opacity="0.9" />
+  <circle cx="190" cy="120" r="12" fill="#cc0000" fill-opacity="0.5" />
+  <rect x="250" y="110" width="400" height="20" fill="#ffffff" fill-opacity="0.3" />
+  <rect x="300" y="480" width="200" height="60" rx="30" fill="#ff6b6b" fill-opacity="0.8" />
+  <circle cx="400" cy="510" r="20" fill="#ffffff" fill-opacity="0.9" />
+  <path d="M 390 510 L 398 518 L 410 506" stroke="#ff6b6b" stroke-width="3" fill="none" />
+  <rect x="50" y="200" width="60" height="200" fill="#fff3e0" fill-opacity="0.4" />
+  <rect x="690" y="200" width="60" height="200" fill="#fff3e0" fill-opacity="0.4" />
+</svg>

--- a/src/content/blog/en/blog-rules-md-estandar.md
+++ b/src/content/blog/en/blog-rules-md-estandar.md
@@ -1,0 +1,289 @@
+---
+title: "rules.md: The Definitive Standard for Controlling AI Agents in 2025"
+description: "Discover how rules.md, .cursorrules, and the .mdc format have revolutionized the way we guide AI in Android and Kotlin development."
+pubDate: 2025-06-15
+heroImage: "/images/placeholder-article-rules-md.svg"
+tags: ["AI", "rules.md", "Android", "Kotlin", "Cursor", "Prompt Engineering"]
+reference_id: "rules-md-standard-2025"
+---
+
+In the rapid evolution of Artificial Intelligence-assisted software development, we have witnessed the massive adoption of standards like `agents.md` or `rules.md`. These files have become the backbone for guiding AI agents (such as GitHub Copilot, Cursor, Gemini, or Claude) in aspects of architecture, code patterns, testing strategies, and naming conventions.
+
+As we delve into 2025, the way we interact with code has radically changed. We no longer start with a blank canvas; we start with highly structured context. However, this context can be a double-edged sword. If an AI agent does not know the specific conventions of your project, your tech stack, or your architectural preferences in complex ecosystems like Android, the result is often generic, outdated code, or worse, code that introduces subtle but destructive anti-patterns.
+
+Every new chat session with an LLM used to feel like onboarding a new junior developer from scratch every single day: "We use Kotlin, we prefer dependency injection with Hilt, don't use `findViewById`, use Jetpack Compose for the UI, make sure to handle asynchronous flows with `StateFlow` and isolate domain logic in UseCases." Repeating this mantra over and over resulted in a massive waste of time and palpable frustration for the senior developer. The definitive solution to this problem of chronic agent "amnesia" was the birth and standardization of persistent rule files.
+
+The `rules.md` standard (and its platform-specific incarnations like `.cursorrules`, `CLAUDE.md`, or modern structured rules in the `.cursor/rules/` directory with the powerful `.mdc` format) acts as a binding semantic contract between the human developer and the synthetic agent. It is the equivalent of an automated, deterministic, and permanent onboarding process. By injecting these rules contextually and surgically into every interaction, the AI ceases to be a stochastic text generator prone to hallucinations and becomes a highly specialized team member, perfectly aligned with the project's technical vision and domain constraints.
+
+In this article, we will explore in depth the concept of the rules standard, its fascinating history, how it has evolved from monolithic plain text files into granular and dynamic rule systems, and how to masterfully implement these guidelines in complex Android projects using Kotlin. Throughout this extensive technical guide, you will not only learn the theoretical foundations, but you will also obtain practical templates, configuration architectures, and advanced strategies to master AI-assisted development, ensuring your code scales without compromising quality or security.
+
+## 🏛️ Origins and History: From Chaos to Systemic Order
+
+The concept of a file dedicated to dictating behavioral rules for AI did not emerge overnight in an aseptic research lab, nor was it imposed by a single corporate standardizing committee. Rather, its development was an organic, iterative, and community-driven response, fueled by the intense friction engineering teams experienced when interacting with generative models in production environments.
+
+### The Era of Agentic Prehistory (2023 - Early 2024)
+
+In the early days of tools like the original GitHub Copilot or ChatGPT embedded in the workflow, the interaction was purely transactional. Developers copied code blocks, pasted them into a web chat window, and added ad-hoc instructions: "Refactor this using Kotlin Coroutines." The AI had no idea what version of Kotlin you were using, what dependencies you had in your `build.gradle.kts`, or what the general architecture of your Android application was.
+
+This lack of environmental awareness required exhausting mental effort from the developer to provide the necessary context in every prompt. We called this the era of "Fatigue Prompting."
+
+### The Rise of Global Prompts and `.cursorrules` (Late 2024 - 2025)
+
+With the arrival of AI-native IDEs like Cursor, Windsurf, and advanced VS Code extensions, the paradigm shifted. These tools introduced the ability to read the context of the local repository. However, to prevent the AI from guessing the team's intentions by heuristically analyzing the codebase, the concept of a global manifest file was introduced.
+
+Cursor popularized the `.cursorrules` file. Located in the project root, this plain text file (usually in Markdown format) served as a "System Prompt" invisibly injected at the beginning of every interaction with the AI model. Teams started dumping all their tribal wisdom into this file: naming conventions, warnings about deprecated libraries, strict rules on error handling, and more.
+
+The problem quickly arose: monoliths collapse under their own weight. A `.cursorrules` file for an enterprise Android application could easily exceed 1000 lines. It contained rules for the network layer (Retrofit/Ktor), rules for the UI (Jetpack Compose), database rules (Room), and CI/CD rules (GitHub Actions).
+
+### The "Token Tax" Problem and Context Dilution
+
+When an LLM (like Claude 3.5 Sonnet or GPT-4o) receives a massive context, it suffers from two phenomena:
+1. **Lost in the Middle:** The model pays attention to the beginning and end of the prompt, but often ignores instructions located in the center of the document.
+2. **Token Tax:** Injecting 10,000 tokens of global rules into *every* small autocomplete request is extremely financially costly and adds latency (Time to First Token, TTFT). Why does the AI need to read the Firebase Crashlytics configuration rules when you are only asking it to center text on a Jetpack Compose button?
+
+### The Modular Revolution: The `.mdc` Format and `.cursor/rules/` (2025)
+
+To solve context dilution and the token tax, the industry evolved toward a context-routing rule system. Instead of a single `.cursorrules` file, modern projects adopted the `.cursor/rules/` directory (or analogous implementations in other tools), populated by multiple files with the `.mdc` (Markdown Context) extension or simply `.md` files with structured frontmatter.
+
+This breakthrough allowed what we call **Dynamic Rule Injection**. Each rule now has metadata (usually in YAML frontmatter) defining "when" and "where" it should be applied. If the developer opens a file ending in `ViewModel.kt`, the tool automatically injects state management rules but completely omits visual design rules.
+
+This modularity not only saved millions of dollars in inference costs globally, but it also drastically increased the accuracy and rule adherence of the agents, enabling the creation of ultra-cohesive and secure codebases.
+
+## ⚖️ The Rules Ecosystem: Comparison and Nomenclature
+
+In 2025, AI coding agents have converged on a common architectural pattern (Markdown files located at the repository root), but they use different names and conventions depending on the vendor. Understanding this ecosystem is vital for teams operating in agnostic environments or migrating between tools.
+
+### 1. `agents.md` (The Open Standard)
+Adopted by the Linux Foundation and supported by over 100,000 open-source repositories, `agents.md` is the equivalent of a `robots.txt` file but for software agents. It is tool-agnostic. It was designed so that autonomous orchestration agents, CLI tools (like Aider), and CI/CD sub-agents understand the project context. They are typically files without complex metadata, focused on high-level architecture and engineering rules.
+
+### 2. `.cursorrules` (The Historical Legacy)
+The original single-file format. Although still supported for backward compatibility by Cursor, it is considered a deprecated pattern for medium to large projects. It remains useful for toy projects or single-purpose repositories (like an isolated Python script) where the overhead of creating a rules directory is unjustified.
+
+### 3. `.cursor/rules/*.mdc` (The Industry Standard for Cursor)
+The modern and recommended format. It uses `.mdc` files combining Markdown with YAML metadata. It allows routing based on "globs" (file path regular expressions). Its main advantage is dynamic context resolution, making it the most powerful option for multi-layered architectures like those found in the Android ecosystem (Clean Architecture with Presentation, Domain, and Data layers).
+
+### 4. `CLAUDE.md` (Anthropic's Approach)
+Anthropic introduced `CLAUDE.md` for its Claude Code CLI tool and Claude Projects web interface. Unlike Cursor's granular rules, `CLAUDE.md` leans towards a more holistic approach. Claude, thanks to its massive context windows (over 200k tokens) and legendary resistance to the "Lost in the Middle" problem, can process a very extensive `CLAUDE.md` without significant performance degradation. It is ideal for documenting the general project philosophy and frequent build commands (`pnpm test`, `./gradlew assembleDebug`).
+
+### 5. `copilot-instructions.md` (GitHub's Vision)
+GitHub Copilot uses this file to anchor the assistant's instructions in the repository context. Its functionality aligns more closely with the old `.cursorrules`, applying instructions quite globally. However, Microsoft has been integrating Semantic Code Search capabilities, allowing Copilot to infer implicit rules by searching other project files.
+
+### The Intersection with `design.md`
+
+It is crucial to distinguish between engineering rules and design guidelines. In the modern taxonomy of AI-assisted documentation:
+- **`agents.md` or `.cursor/rules/`**: Dictate *HOW* software is built. They cover concurrency, static typing, architectures (MVVM, MVI), injection patterns, and security (avoiding SQL injection, handling sensitive data).
+- **`design.md`**: Dictates the *WHAT* and *WHY* from a visual and user perspective. It covers color tokens (Material 3), typography, visual hierarchy, accessibility guidelines (TalkBack on Android), animations, and the application's tone of voice.
+
+An advanced frontend agent (like Spec-Kitty or OpenSpec) will simultaneously read a rule from `compose.mdc` (telling it to use `Modifier.fillMaxWidth()`) and the `design.md` file (telling it primary buttons must have a corner radius of `16.dp`).
+
+## 🧠 The Structural Anatomy of a Perfect `.mdc` File
+
+To fully leverage contextual routing capabilities in 2025, we must understand the deep anatomy of a modern `.mdc` file. Designing rules is not simply writing a wishlist; it is Prompt Engineering applied at the infrastructure level.
+
+A well-designed `.mdc` file consists of two fundamental parts: the YAML Frontmatter and the Markdown Body.
+
+### 1. The YAML Frontmatter: The Routing Brain
+
+The frontmatter tells the IDE engine or agent orchestrator exactly when this rule is relevant. Without this, we revert to the dark ages of context dilution.
+
+```yaml
+---
+description: "Strict conventions for UI development with Jetpack Compose and Material 3"
+globs: ["**/ui/**/*.kt", "**/components/**/*.kt", "**/screens/**/*.kt"]
+alwaysApply: false
+---
+```
+
+Let's break down the components:
+- **`description`**: It's not just a human comment. The agent's semantic engine uses this description to decide whether to invoke the rule when the user asks a general question, even if they haven't opened any specific file. If the user types "How do I make a button in this app?", the agent scans all rule descriptions, finds "UI development," and triggers this rule dynamically.
+- **`globs`**: Defines file matching patterns. This is the magic. By specifying `**/ui/**/*.kt`, we guarantee these Jetpack Compose rules will never pollute the context when the agent is working on a Room database DAO (`**/data/local/**/*.kt`), saving tokens and preventing hallucinations.
+- **`alwaysApply`**: A critical boolean. If set to `true`, the rule is injected unconditionally into every prompt in this repository, regardless of open files. Use with extreme caution. Reserve `alwaysApply: true` exclusively for inviolable baseline rules (e.g., "Strictly respect SOLID principles," "Always write in English").
+
+### 2. The Markdown Body: Clear, Concise, and Deterministic Directives
+
+The rule body should avoid ambiguous language. LLMs respond best to strong imperatives, clear negative constraints ("NEVER DO X"), and positive code examples (few-shot prompting).
+
+#### Principles for writing the body:
+1. **Priority by Negation**: Language models often "forget" complex positive instructions but are remarkably obedient to absolute negative constraints. Always start with what *NOT* to do.
+2. **Visual Hierarchy**: Use headers (`##`, `###`), bulleted lists, and bold text to highlight critical keywords (`**MANDATORY**`, `**NEVER**`).
+3. **Contextual Code Snippets**: The fastest way to train an LLM on desired behavior is showing it an example of "Good Code" vs "Bad Code".
+
+Let's look at a practical example of the internal structure of a rule for an Android `ViewModel`:
+
+````markdown
+# ViewModel Implementation Rules
+
+You are an expert Senior Android developer specializing in MVVM and Kotlin Coroutines.
+Your goal is to write safe, reactive, and efficient ViewModels.
+
+## 🚫 CRITICAL CONSTRAINTS (NEVER DO THIS)
+- NEVER expose `MutableStateFlow` or `MutableLiveData` to the outside. Always use read-only properties (`StateFlow` or `LiveData`).
+- NEVER pass the Android `Context` to a ViewModel. This causes massive memory leaks. Use dependency injection to provide resources if absolutely necessary, or handle strings in the UI.
+- NEVER use `GlobalScope` or `CoroutineScope(Dispatchers.IO)`. ALWAYS use `viewModelScope.launch`.
+
+## ✅ REQUIRED PATTERNS (ALWAYS DO THIS)
+- Manage UI state using a single `UiState` data class.
+- Employ a `Channel` event pipeline for *One-Time Events* (e.g., showing a Toast, navigation).
+- Inject all dependencies (UseCases, Repositories) via constructor using the `@HiltViewModel` and `@Inject` annotations.
+
+## 📝 CANONICAL REFERENCE EXAMPLE
+
+```kotlin
+// GOOD: State and event encapsulation with Hilt
+@HiltViewModel
+class UserProfileViewModel @Inject constructor(
+    private val getUserProfileUseCase: GetUserProfileUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(UserProfileUiState())
+    val uiState: StateFlow<UserProfileUiState> = _uiState.asStateFlow()
+
+    private val _uiEvent = Channel<UserProfileEvent>()
+    val uiEvent = _uiEvent.receiveAsFlow()
+
+    fun fetchUser(userId: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            try {
+                val user = getUserProfileUseCase(userId)
+                _uiState.update { it.copy(isLoading = false, user = user) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(isLoading = false, error = e.message) }
+                _uiEvent.send(UserProfileEvent.ShowError(e.message ?: "Unknown error"))
+            }
+        }
+    }
+}
+```
+````
+This approach transforms your AI from a generic coder to an MVVM purist aligned with your exact architectural standards.
+
+## 🛠️ Step-by-Step Guide: Implementing an `.mdc` System in a Complex Android Project
+
+Imagine a large-scale Android project, perhaps a banking app or robust e-commerce platform, modularized by features (`features/`) and layers (`core/`, `domain/`, `data/`, `ui/`). Here is how we would architect the `.cursor/rules/` directory for unprecedented AI control.
+
+### Step 1: Initialize the Directory and Base Rule
+
+First, create the `.cursor/rules/` directory at the root of your project. The first file we should add is the base rule that must always apply.
+
+Create `.cursor/rules/00-base-android.mdc`:
+```yaml
+---
+description: "Fundamental Android rules applicable to the entire project. Style, Kotlin, and base architecture."
+globs: ["*.kt", "*.kts"]
+alwaysApply: true
+---
+```
+In the body of this file, we define universal things:
+- Use Kotlin 2.1+.
+- Prevent the use of `!!` (force non-null operator). The AI must prefer the safe call `?.` and the Elvis operator `?:`.
+- Require standardized naming conventions (interfaces start with "I" or implemented classes end in "Impl").
+- Dictate that all dates must be handled with `java.time` and never with the legacy `java.util.Date`.
+
+### Step 2: Specific Rules for the Data Layer (Room & Retrofit)
+
+The data layer requires strict rules regarding transaction handling, database migrations, and JSON serialization.
+
+Create `.cursor/rules/10-data-layer.mdc`:
+```yaml
+---
+description: "Rules for Repositories, DAOs (Room), DTOs, and network calls (Retrofit/Ktor)."
+globs: ["**/data/**/*.kt", "**/*Dao.kt", "**/*Dto.kt", "**/*RepositoryImpl.kt"]
+alwaysApply: false
+---
+```
+The body should include instructions like:
+- "All methods in Room DAOs must be `suspend` functions unless they return a `Flow`."
+- "NEVER expose database classes (Room Entities) or network models (DTOs) to the domain layer. ALWAYS map entities to clean Domain Models using `.toDomain()` extension functions."
+- "Use Moshi or Kotlinx Serialization. Do not use Gson under any circumstances; it is considered legacy in this project."
+
+### Step 3: UI Layer and Jetpack Compose Rules
+
+This is where the AI tends to derail the most due to the rapid evolution of the Compose ecosystem.
+
+Create `.cursor/rules/20-compose-ui.mdc`:
+```yaml
+---
+description: "Development guidelines for UI components in Jetpack Compose, Material Design 3, and state management."
+globs: ["**/ui/**/*.kt", "**/presentation/**/*.kt", "**/screens/**/*.kt", "**/components/**/*.kt"]
+alwaysApply: false
+---
+```
+Compose rules should be highly detailed:
+- "All custom UI components must be `@Composable` functions and must accept a `modifier: Modifier = Modifier` parameter as their first optional parameter."
+- "Do not pass ViewModels down to child components (State Hoisting). Pass lambda functions for events (e.g., `onItemClick: (Item) -> Unit`) and explicitly required states."
+- "Use `rememberSaveable` for UI states that must survive configuration changes, not just `remember`."
+- "Integrate accessibility descriptions using `semantics { contentDescription = "..." }` on interactive elements lacking inherent text."
+
+### Step 4: Build Configuration and CI/CD Rules
+
+The build environment also needs guidelines, especially when migrating to Gradle Version Catalogs or Kotlin DSL.
+
+Create `.cursor/rules/30-build-gradle.mdc`:
+```yaml
+---
+description: "Gradle dependency management, Kotlin DSL, and Version Catalogs."
+globs: ["*.gradle.kts", "gradle/libs.versions.toml", "build.gradle.kts"]
+alwaysApply: false
+---
+```
+Instructions:
+- "Any new dependency must be added centrally in `libs.versions.toml`. NEVER hardcode the version directly in a `build.gradle.kts`."
+- "Keep plugin blocks sorted alphabetically."
+
+By modularizing these instructions, we guarantee that when a developer asks the AI: "Add a button on the Profile screen," the agent will **only** read `00-base-android.mdc` and `20-compose-ui.mdc`. It will not waste vital tokens (or algorithmic attention time) reading about database mappings or Gradle configurations.
+
+## 🌐 Evolutionary Comparison: LLM Model Interaction with rules.md
+
+The AI ecosystem is not homogeneous. Different model families process rule files with distinct strengths and weaknesses. As software engineers, we must optimize our `.mdc` files keeping the underlying hardware and the neural architecture of the agents in mind.
+
+### 1. The Claude 3.5 Family (Anthropic) and the Perceptive Context Window
+Claude 3.5 (including Sonnet and Opus) currently dominates expansive context understanding thanks to its hierarchical memory technology and sparse attention. When an `.mdc` file is injected into Claude, the model exhibits exceptional rule retention, even those located at the end of the document.
+**Recommended Tactic:** With Claude, you can afford to be exhaustive. You can include multiple detailed "negative examples". Claude excels at holistic refactoring tasks where it must scan an old file and align it with a lengthy style manual defined in `rules.md`. It is the preferred engine behind orchestrator agents (MAO) operating autonomously on entire PRs.
+
+### 2. The GPT-4o / O1 Family (OpenAI) and Deductive Reasoning
+O1 models introduced implicit reasoning paradigms (Hidden Chain of Thought). When faced with a rules file, these models don't just read the guidelines; they "think" through them. If a rule in `.cursorrules` states "Dependency injection is forbidden in Composable components," the O1 model will proactively infer the ramifications of this and structure the ViewModel to manage dependencies internally, exposing only simple lambdas to the UI.
+**Recommended Tactic:** Be explicit about the "Whys." O1 responds brilliantly if you explain the reasoning behind the rule. Instead of saying "Don't use `LiveData`," say "Don't use `LiveData` because it doesn't scale well with high-performance asynchronous Coroutines and violates our asynchronous reactive patterns." The model will internalize the principle and apply it to edge cases not explicitly listed.
+
+### 3. Lightweight Autocomplete Models (DeepSeek Coder V2, StarCoder 2, Gemini Nano)
+These SLM (Small Language Models) operate locally on-device or via ultra-low latency APIs. Their job is to guess the next 10-50 lines of code as you type (inline tab-to-complete). They are highly sensitive to token saturation.
+**Recommended Tactic:** For tools feeding rules to SLMs, granularity is life or death. Use the `.cursor/rules/` directory strictly. If you inject more than 1000 tokens into an SLM, its autocomplete performance will collapse, and it will start generating random code or enter hallucination loops. Keep autocomplete `.mdc` files under 500 words.
+
+## 🚀 Advanced Orchestration: Synergy Between rules.md, SDD, and MAO
+
+The true power of `rules.md` emerges when integrated into higher-order development frameworks like **Spec-Driven Development (SDD)** or managed via a **Multi-Agent Orchestrator (MAO)**.
+
+In 2025, teams highly leveraged on AI do not rely on individual agents acting in a vacuum. They use orchestrators. When an MAO Orchestrator receives a new task (e.g., "Implement offline login with Room"), it follows a strict protocol:
+
+1. **Rule Ingestion Phase**: The orchestrator scans the repository and reads all policies in `.cursor/rules/`. It compiles a "Project Constraints Profile".
+2. **Specification Generation (SDD)**: Using a framework like OpenSpec, an Analyst sub-agent drafts a formal specification of the solution. This specification is automatically verified (using Socratic refutation techniques) against the rules extracted in phase 1. If the specification suggests using `SQLiteOpenHelper`, the `10-data-layer.mdc` rule demanding the exclusive use of `Room` will trigger an alarm, and the specification document will be rejected and re-generated before writing a single line of code.
+3. **Execution Phase**: Multiple agents (frontend, backend, QA) proceed to write the code. Each agent dynamically receives only the subset of `.mdc` files relevant to its domain. The QA Agent receives testing rules (`40-testing.mdc`) requiring it to use `MockK` and `Turbine` to test flows, ignoring the existence of Mockito.
+
+This architecture guarantees that technical debt is prevented by design, not via tedious post-fact code reviews. Rules act as unyielding guardians of the repository, immunizing the project against AI hallucinations and stylistic divergences.
+
+## 🛠️ Anti-patterns and Debugging: When Rules Fail
+
+Even with the best `.mdc` system, things can go wrong. Here we list the most common anti-patterns we observe in modern teams and how to fix them.
+
+### 1. The "Contradictory Rule" Anti-pattern
+**Symptom**: The agent generates a block of code and then, in the same response, generates a comment block apologizing and rewriting the code, or produces a strange hybrid (e.g., mixing `LiveData` and `StateFlow`).
+**Cause**: A precedence conflict exists. You might have a legacy global `.cursorrules` file saying "Use LiveData" and a new `.cursor/rules/20-compose.mdc` saying "Use StateFlow." The LLM is confused by the double bind.
+**Solution**: Rule audit. Eliminate global `.cursorrules` and migrate 100% of the logic to `.mdc` files routed by mutually exclusive `globs`.
+
+### 2. The "Abstraction Overload" Anti-pattern
+**Symptom**: The model completely ignores rules, reverting to generating generic code.
+**Cause**: You have exceeded the effective context window or diluted the model's attention with irrelevant information in an `alwaysApply: true` block.
+**Solution**: Refactor your rules. Move specialized logic to `.mdc` files with stricter `globs`. Replace long narrative paragraphs with concise bullet points.
+
+### 3. The "Utopian Perfection Rule" Anti-pattern
+**Symptom**: Rules demand such elaborate architectures (Clean Architecture with 5 layers of empty interfaces) that the AI fails to generate simple functional code.
+**Cause**: Rules disconnected from pragmatism. Demanding excessive abstractions chokes the agent's generative capabilities.
+**Solution**: Implement pragmatic rules. Allow explicit exceptions. In your `.mdc`, you can add: "For simple CRUD operations without business logic, the UI is permitted to interact directly with the Repository, skipping the UseCases layer to avoid unnecessary boilerplate."
+
+## 🏆 Conclusion: The Future of AI Rules
+
+The `rules.md` standard and the evolution towards the contextual `.mdc` format represent one of the most profound advancements in Human-Computer Interaction within software engineering. We have transitioned from assisted coding based on pre-trained general model knowledge to surgical development anchored in dynamic hyper-context.
+
+In mobile app development with Kotlin and Android, where architectural fragmentation and the rapid evolution of libraries like Jetpack Compose can overwhelm even the most experienced teams, having a well-maintained `.cursor/rules/` directory is not a luxury: it is an indispensable operational requirement in 2025.
+
+Rules are the crystallization of human architect experience. They allow us to delegate low-level implementation to synthetic agents with total confidence, knowing they will respect our quality, security, and architectural design standards. The future of development will not belong to those who write code faster, but to those who know how to specify system constraints with greater algorithmic precision. A great rule system transforms AI from a simple predictive tool into a truly aligned extension of the engineering team's intellect.

--- a/src/content/blog/es/blog-rules-md-estandar.md
+++ b/src/content/blog/es/blog-rules-md-estandar.md
@@ -1,0 +1,289 @@
+---
+title: "rules.md: El Estándar Definitivo para Controlar Agentes de IA en 2025"
+description: "Descubre cómo rules.md, .cursorrules y el formato .mdc han revolucionado la forma en que guiamos a la IA en el desarrollo Android y Kotlin."
+pubDate: 2025-06-15
+heroImage: "/images/placeholder-article-rules-md.svg"
+tags: ["IA", "rules.md", "Android", "Kotlin", "Cursor", "Prompt Engineering"]
+reference_id: "rules-md-standard-2025"
+---
+
+En la vertiginosa evolución del desarrollo de software asistido por Inteligencia Artificial, hemos presenciado la adopción masiva de estándares como `agents.md` o `rules.md`. Estos archivos se han convertido en la columna vertebral para guiar a los agentes de IA (como GitHub Copilot, Cursor, Gemini o Claude) en aspectos de arquitectura, patrones de código, estrategias de testing y convenciones de nombrado.
+
+A medida que nos adentramos en 2025, la forma en que interactuamos con el código ha cambiado radicalmente. Ya no empezamos con un lienzo en blanco; empezamos con un contexto altamente estructurado. Sin embargo, este contexto puede ser un arma de doble filo. Si un agente de IA no conoce las convenciones específicas de tu proyecto, tu pila tecnológica, o tus preferencias arquitectónicas en ecosistemas complejos como Android, el resultado es a menudo un código genérico, desactualizado o, peor aún, que introduce antipatrones sutiles pero destructivos.
+
+Cada nueva sesión de chat con un LLM solía ser como incorporar a un nuevo desarrollador junior desde cero todos los días: "Usamos Kotlin, preferimos inyección de dependencias con Hilt, no uses `findViewById`, emplea Jetpack Compose para la UI, asegúrate de manejar los flujos asíncronos con `StateFlow` y aislar la lógica de dominio en UseCases". Repetir este mantra una y otra vez resultaba en una pérdida de tiempo masiva y una frustración palpable para el desarrollador senior. La solución definitiva a este problema de "amnesia crónica" de los agentes fue el nacimiento y estandarización de los archivos de reglas persistentes.
+
+El estándar `rules.md` (y sus encarnaciones específicas de plataforma como `.cursorrules`, `CLAUDE.md`, o las modernas reglas estructuradas en el directorio `.cursor/rules/` con el potente formato `.mdc`) actúa como un contrato semántico vinculante entre el desarrollador humano y el agente sintético. Es el equivalente a un *onboarding* automatizado, determinista y permanente. Al inyectar estas reglas de manera contextual y quirúrgica en cada interacción, la IA deja de ser un generador de texto estocástico propenso a alucinaciones y se convierte en un miembro del equipo altamente especializado, alineado perfectamente con la visión técnica del proyecto y las restricciones del dominio.
+
+En este artículo, exploraremos en profundidad el concepto del estándar de reglas, su fascinante historia, cómo ha evolucionado desde archivos de texto plano monolíticos hacia sistemas de reglas granulares y dinámicas, y cómo implementar estas directrices de manera magistral en proyectos Android complejos utilizando Kotlin. A lo largo de esta extensa guía técnica, no solo aprenderás los fundamentos teóricos, sino que obtendrás plantillas prácticas, arquitecturas de configuración y estrategias avanzadas para dominar el desarrollo asistido por IA, garantizando que tu código escale sin comprometer la calidad ni la seguridad.
+
+## 🏛️ Origen e Historia: Del Caos al Orden Sistémico
+
+El concepto de un archivo dedicado a dictar reglas de comportamiento para la IA no surgió de un día para otro en un laboratorio de investigación aséptico, ni fue impuesto por un único comité estandarizador corporativo. Más bien, su desarrollo fue una respuesta orgánica, iterativa y comunitaria, impulsada por la intensa fricción que experimentaban los equipos de ingeniería al interactuar con modelos generativos en entornos de producción.
+
+### La Era de la Prehistoria Agentica (2023 - Principios de 2024)
+
+En los primeros días de herramientas como GitHub Copilot original o ChatGPT incrustado en el flujo de trabajo, la interacción era puramente transaccional. Los desarrolladores copiaban bloques de código, los pegaban en una ventana de chat web y añadían instrucciones ad-hoc: "Refactoriza esto usando Kotlin Coroutines". La IA no tenía idea de qué versión de Kotlin estabas usando, qué dependencias tenías en tu `build.gradle.kts`, o cuál era la arquitectura general de tu aplicación Android.
+
+Esta falta de conciencia del entorno requería un esfuerzo mental extenuante por parte del desarrollador para proporcionar el contexto necesario en cada prompt. A esto lo llamábamos la era del "Prompting Fatigoso".
+
+### El Surgimiento de los Prompts Globales y `.cursorrules` (Finales de 2024 - 2025)
+
+Con la llegada de IDEs nativos de IA como Cursor, Windsurf y extensiones avanzadas de VS Code, el paradigma cambió. Estas herramientas introdujeron la capacidad de leer el contexto del repositorio local. Sin embargo, para evitar que la IA adivinara las intenciones del equipo analizando heurísticamente el código base, se introdujo el concepto de un archivo de manifiesto global.
+
+Cursor popularizó el archivo `.cursorrules`. Ubicado en la raíz del proyecto, este archivo de texto plano (usualmente en formato Markdown) servía como un "System Prompt" inyectado invisiblemente al principio de cada interacción con el modelo de IA. Los equipos comenzaron a volcar toda su sabiduría tribal en este archivo: convenciones de nomenclatura, advertencias sobre bibliotecas deprecadas, reglas estrictas sobre el manejo de errores, y más.
+
+El problema surgió rápidamente: los monolitos colapsan por su propio peso. Un archivo `.cursorrules` para una aplicación Android empresarial podía fácilmente superar las 1000 líneas. Contenía reglas para la capa de red (Retrofit/Ktor), reglas para la UI (Jetpack Compose), reglas de base de datos (Room), y reglas para CI/CD (GitHub Actions).
+
+### El Problema de la "Tasa de Tokens" (Token Tax) y la Dilución del Contexto
+
+Cuando un LLM (como Claude 3.5 Sonnet o GPT-4o) recibe un contexto enorme, sufre de dos fenómenos:
+1. **Pérdida en el medio (Lost in the Middle):** El modelo presta atención al principio y al final del prompt, pero a menudo ignora las instrucciones ubicadas en el centro del documento.
+2. **Impuesto de Tokens (Token Tax):** Inyectar 10,000 tokens de reglas globales en *cada* pequeña petición de autocompletado es extremadamente costoso financieramente y añade latencia (tiempo hasta el primer token, TTFT). ¿Por qué la IA necesita leer las reglas de configuración de Firebase Crashlytics cuando solo le estás pidiendo que centre un texto en un botón de Jetpack Compose?
+
+### La Revolución Modular: El Formato `.mdc` y `.cursor/rules/` (2025)
+
+Para resolver la dilución del contexto y el impuesto de tokens, la industria evolucionó hacia un sistema de reglas basado en enrutamiento contextual. En lugar de un único archivo `.cursorrules`, los proyectos modernos adoptaron el directorio `.cursor/rules/` (o implementaciones análogas en otras herramientas), poblado por múltiples archivos con extensión `.mdc` (Markdown Context) o simplemente `.md` con frontmatter estructurado.
+
+Este avance permitió lo que llamamos **Inyección Dinámica de Reglas (Dynamic Rule Injection)**. Cada regla ahora posee metadatos (generalmente en YAML frontmatter) que definen "cuándo" y "dónde" debe aplicarse. Si el desarrollador abre un archivo que termina en `ViewModel.kt`, la herramienta inyecta automáticamente las reglas de manejo de estado, pero omite por completo las reglas de diseño visual.
+
+Esta modularidad no solo salvó millones de dólares en costos de inferencia a nivel global, sino que también incrementó drásticamente la precisión y adherencia a las reglas por parte de los agentes, permitiendo la creación de bases de código ultra-cohesivas y seguras.
+
+## ⚖️ El Ecosistema de Reglas: Comparativa y Nomenclatura
+
+En 2025, los agentes de codificación IA han convergido en un patrón arquitectónico común (archivos Markdown ubicados en la raíz del repositorio), pero utilizan diferentes nombres y convenciones según el proveedor. Comprender este ecosistema es vital para equipos que operan en entornos agnósticos o que migran entre herramientas.
+
+### 1. `agents.md` (El Estándar Abierto)
+Adoptado por la Linux Foundation y soportado por más de 100,000 repositorios de código abierto, `agents.md` es el equivalente a un archivo `robots.txt` pero para agentes de software. Es agnóstico a la herramienta. Fue diseñado para que agentes autónomos de orquestación, herramientas CLI (como Aider), y subagentes de CI/CD comprendan el contexto del proyecto. Suelen ser archivos sin metadatos complejos, enfocados en reglas de alto nivel y arquitectura.
+
+### 2. `.cursorrules` (El Legado Histórico)
+El formato original de archivo único. Aunque sigue siendo soportado por retrocompatibilidad por Cursor, se considera un patrón deprecado para proyectos medianos a grandes. Sigue siendo útil para proyectos de juguete o repositorios de un solo propósito (como un script de Python aislado), donde la sobrecarga de crear un directorio de reglas no se justifica.
+
+### 3. `.cursor/rules/*.mdc` (El Estándar Industrial para Cursor)
+El formato moderno y recomendado. Utiliza archivos `.mdc` que combinan Markdown con metadatos YAML. Permite enrutamiento basado en "globs" (expresiones regulares de rutas de archivos). Su principal ventaja es la resolución dinámica de contexto, lo que lo convierte en la opción más poderosa para arquitecturas multicapa como las que encontramos en el ecosistema de Android (Clean Architecture con capas de Presentación, Dominio y Datos).
+
+### 4. `CLAUDE.md` (La Aproximación de Anthropic)
+Anthropic introdujo `CLAUDE.md` para su herramienta Claude Code CLI y la interfaz web de Claude Projects. A diferencia de las reglas granulares de Cursor, `CLAUDE.md` se inclina por un enfoque más holístico. Claude, gracias a sus inmensas ventanas de contexto (más de 200k tokens) y su legendaria resistencia al problema "Lost in the Middle", puede procesar un `CLAUDE.md` muy extenso sin degradación significativa del rendimiento. Es ideal para documentar la filosofía general del proyecto y comandos de compilación frecuentes (`pnpm test`, `./gradlew assembleDebug`).
+
+### 5. `copilot-instructions.md` (La Visión de GitHub)
+GitHub Copilot utiliza este archivo para anclar las instrucciones del asistente en el contexto del repositorio. Su funcionalidad se alinea más estrechamente con el antiguo `.cursorrules`, aplicando instrucciones de manera bastante global. Sin embargo, Microsoft ha ido integrando capacidades de resolución de contexto semántico (Semantic Code Search), lo que permite a Copilot inferir reglas implícitas buscando en otros archivos del proyecto.
+
+### La Intersección con `design.md`
+
+Es crucial distinguir entre las reglas de ingeniería y las directrices de diseño. En la taxonomía moderna de documentación asistida por IA:
+- **`agents.md` o `.cursor/rules/`**: Dictan el *CÓMO* se construye el software. Tratan sobre concurrencia, tipos estáticos, arquitecturas (MVVM, MVI), patrones de inyección, y seguridad (evitar inyección SQL, manejo de datos sensibles).
+- **`design.md`**: Dicta el *QUÉ* y el *POR QUÉ* desde una perspectiva visual y de usuario. Trata sobre tokens de color (Material 3), tipografía, jerarquía visual, pautas de accesibilidad (TalkBack en Android), animaciones y el tono de voz de la aplicación.
+
+Un agente frontend avanzado (como Spec-Kitty o OpenSpec) leerá simultáneamente una regla de `compose.mdc` (que le dirá que use `Modifier.fillMaxWidth()`) y el archivo `design.md` (que le dirá que los botones primarios deben tener un radio de esquina de `16.dp`).
+
+## 🧠 La Anatomía Estructural de un Archivo `.mdc` Perfecto
+
+Para exprimir al máximo las capacidades de enrutamiento contextual en 2025, debemos entender la anatomía profunda de un archivo `.mdc` moderno. Diseñar reglas no es simplemente escribir una lista de deseos; es ingeniería de prompts (Prompt Engineering) aplicada a nivel de infraestructura.
+
+Un archivo `.mdc` bien diseñado consta de dos partes fundamentales: el Frontmatter YAML y el Cuerpo de Markdown.
+
+### 1. El Frontmatter YAML: El Cerebro del Enrutamiento
+
+El frontmatter le dice al motor del IDE o al orquestador del agente exactamente cuándo esta regla es relevante. Sin esto, volvemos a la era oscura de la dilución de contexto.
+
+```yaml
+---
+description: "Convenciones estrictas para el desarrollo de UI con Jetpack Compose y Material 3"
+globs: ["**/ui/**/*.kt", "**/components/**/*.kt", "**/screens/**/*.kt"]
+alwaysApply: false
+---
+```
+
+Analicemos los componentes:
+- **`description`**: No es solo un comentario para los humanos. El motor semántico del agente utiliza esta descripción para decidir si invocar la regla cuando el usuario hace una pregunta general, incluso si no ha abierto ningún archivo específico. Si el usuario escribe "¿Cómo hago un botón en esta app?", el agente escanea las descripciones de todas las reglas, encuentra "desarrollo de UI", y activa esta regla dinámicamente.
+- **`globs`**: Define los patrones de coincidencia de archivos. Esta es la magia. Al especificar `**/ui/**/*.kt`, garantizamos que estas reglas de Jetpack Compose nunca contaminarán el contexto cuando el agente esté trabajando en un DAO de la base de datos Room (`**/data/local/**/*.kt`), ahorrando tokens y previniendo alucinaciones.
+- **`alwaysApply`**: Un booleano crítico. Si se establece en `true`, la regla se inyecta incondicionalmente en cada prompt de este repositorio, independientemente de los archivos abiertos. Úselo con extrema precaución. Reserve `alwaysApply: true` exclusivamente para reglas base inviolables (ej. "Respeta a rajatabla los principios SOLID", "Escribe siempre en inglés").
+
+### 2. El Cuerpo de Markdown: Directivas Claras, Concisas y Deterministas
+
+El cuerpo de la regla debe evitar el lenguaje ambiguo. Los LLMs responden mejor a imperativos fuertes, restricciones negativas claras ("NUNCA HAGAS X") y ejemplos de código positivos ("pocos disparos" o *few-shot prompting*).
+
+#### Principios para escribir el cuerpo:
+1. **Prioridad por Negación**: Los modelos de lenguaje a menudo "olvidan" las instrucciones positivas complejas, pero son notablemente obedientes a las restricciones negativas absolutas. Comience siempre con lo que *NO* se debe hacer.
+2. **Jerarquía Visual**: Utilice encabezados (`##`, `###`), listas viñeteadas y negritas para resaltar palabras clave críticas (`**OBLIGATORIO**`, `**NUNCA**`).
+3. **Snippets de Código Contextuales**: La forma más rápida de entrenar a un LLM en el comportamiento deseado es mostrarle un ejemplo de "Código Bueno" vs "Código Malo".
+
+Veamos un ejemplo práctico de la estructura interna de una regla para un `ViewModel` en Android:
+
+````markdown
+# Reglas de Implementación de ViewModel
+
+Eres un experto desarrollador Android Senior especializado en MVVM y Kotlin Coroutines.
+Tu objetivo es escribir ViewModels seguros, reactivos y eficientes.
+
+## 🚫 RESTRICCIONES CRÍTICAS (NUNCA HACER ESTO)
+- NUNCA expongas `MutableStateFlow` o `MutableLiveData` al exterior. Usa siempre propiedades de solo lectura (`StateFlow` o `LiveData`).
+- NUNCA pases el `Context` de Android a un ViewModel. Esto provoca memory leaks masivos. Usa inyección de dependencias para proveer recursos si es absolutamente necesario, o maneja los strings en la UI.
+- NUNCA uses `GlobalScope` ni `CoroutineScope(Dispatchers.IO)`. Usa SIEMPRE `viewModelScope.launch`.
+
+## ✅ PATRONES REQUERIDOS (SIEMPRE HACER ESTO)
+- Maneja el estado de la UI utilizando una única data class `UiState`.
+- Emplea un canal de eventos `Channel` para *One-Time Events* (ej. mostrar un Toast, navegación).
+- Inyecta todas las dependencias (UseCases, Repositorios) mediante constructor usando la anotación `@HiltViewModel` y `@Inject`.
+
+## 📝 EJEMPLO CANÓNICO DE REFERENCIA
+
+```kotlin
+// BUENO: Encapsulamiento de estado y eventos con Hilt
+@HiltViewModel
+class UserProfileViewModel @Inject constructor(
+    private val getUserProfileUseCase: GetUserProfileUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(UserProfileUiState())
+    val uiState: StateFlow<UserProfileUiState> = _uiState.asStateFlow()
+
+    private val _uiEvent = Channel<UserProfileEvent>()
+    val uiEvent = _uiEvent.receiveAsFlow()
+
+    fun fetchUser(userId: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            try {
+                val user = getUserProfileUseCase(userId)
+                _uiState.update { it.copy(isLoading = false, user = user) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(isLoading = false, error = e.message) }
+                _uiEvent.send(UserProfileEvent.ShowError(e.message ?: "Unknown error"))
+            }
+        }
+    }
+}
+```
+````
+Este enfoque transforma a tu IA de un codificador genérico a un purista de MVVM alineado a tus estándares arquitectónicos exactos.
+
+## 🛠️ Guía Paso a Paso: Implementando un Sistema `.mdc` en un Proyecto Android Complejo
+
+Imaginemos un proyecto Android de gran escala, quizás una aplicación de banca o un e-commerce robusto, modularizado por funcionalidades (`features/`) y capas (`core/`, `domain/`, `data/`, `ui/`). Así es como arquitectaríamos el directorio `.cursor/rules/` para un control IA sin precedentes.
+
+### Paso 1: Inicializar el Directorio y la Regla Base
+
+Primero, crea el directorio `.cursor/rules/` en la raíz de tu proyecto. El primer archivo que debemos añadir es la regla base que siempre debe aplicarse.
+
+Crea `.cursor/rules/00-base-android.mdc`:
+```yaml
+---
+description: "Reglas fundamentales de Android aplicables a todo el proyecto. Estilo, Kotlin y arquitectura base."
+globs: ["*.kt", "*.kts"]
+alwaysApply: true
+---
+```
+En el cuerpo de este archivo, definiremos cosas universales:
+- Usar Kotlin 2.1+.
+- Prevenir el uso de `!!` (operador no nulo forzado). La IA debe preferir el *safe call* `?.` y el *Elvis operator* `?:`.
+- Exigir convenciones de nombrado estandarizadas (interfaces empiezan con "I" o clases implementadas terminan en "Impl").
+- Dictar que todas las fechas deben manejarse con `java.time` y nunca con el antiguo `java.util.Date`.
+
+### Paso 2: Reglas Específicas para la Capa de Datos (Room & Retrofit)
+
+La capa de datos requiere reglas estrictas sobre el manejo de transacciones, migraciones de base de datos y serialización JSON.
+
+Crea `.cursor/rules/10-data-layer.mdc`:
+```yaml
+---
+description: "Reglas para Repositorios, DAOs (Room), DTOs y llamadas a red (Retrofit/Ktor)."
+globs: ["**/data/**/*.kt", "**/*Dao.kt", "**/*Dto.kt", "**/*RepositoryImpl.kt"]
+alwaysApply: false
+---
+```
+El cuerpo debe incluir instrucciones como:
+- "Todos los métodos en DAOs de Room deben ser funciones `suspend` a menos que devuelvan un `Flow`".
+- "NUNCA expongas clases de la base de datos (Entidades Room) o modelos de red (DTOs) a la capa de dominio. Mapea SIEMPRE las entidades a Modelos de Dominio limpios usando funciones de extensión `.toDomain()`".
+- "Utiliza Moshi o Kotlinx Serialization. No uses Gson bajo ninguna circunstancia, se considera legado en este proyecto".
+
+### Paso 3: Reglas de la Capa de UI y Jetpack Compose
+
+Aquí es donde la IA tiende a descarrilarse más debido a la rápida evolución del ecosistema de Compose.
+
+Crea `.cursor/rules/20-compose-ui.mdc`:
+```yaml
+---
+description: "Pautas de desarrollo para componentes de UI en Jetpack Compose, Material Design 3 y manejo de estados."
+globs: ["**/ui/**/*.kt", "**/presentation/**/*.kt", "**/screens/**/*.kt", "**/components/**/*.kt"]
+alwaysApply: false
+---
+```
+Las reglas de Compose deben ser muy detalladas:
+- "Todos los componentes UI custom deben ser funciones `@Composable` y deben aceptar un parámetro `modifier: Modifier = Modifier` como su primer parámetro opcional".
+- "No pases ViewModels hacia abajo a los componentes hijos (*State Hoisting*). Pasa funciones lambda para los eventos (ej. `onItemClick: (Item) -> Unit`) y los estados requeridos explícitamente".
+- "Usa `rememberSaveable` para estados de UI que deban sobrevivir a cambios de configuración, no solo `remember`".
+- "Integra descripciones de accesibilidad usando `semantics { contentDescription = "..." }` en elementos interactivos que no posean texto inherente".
+
+### Paso 4: Reglas de Configuración de Build y CI/CD
+
+El entorno de construcción también necesita directrices, especialmente cuando migramos a Gradle Version Catalogs o Kotlin DSL.
+
+Crea `.cursor/rules/30-build-gradle.mdc`:
+```yaml
+---
+description: "Gestión de dependencias de Gradle, Kotlin DSL y Version Catalogs."
+globs: ["*.gradle.kts", "gradle/libs.versions.toml", "build.gradle.kts"]
+alwaysApply: false
+---
+```
+Instrucciones:
+- "Cualquier nueva dependencia debe añadirse centralmente en `libs.versions.toml`. NUNCA hardcodees la versión directamente en un `build.gradle.kts`".
+- "Mantén los bloques de plugins ordenados de forma alfabética".
+
+Al modularizar estas instrucciones, garantizamos que cuando un desarrollador le pide a la IA: "Agrega un botón en la pantalla de Perfil", el agente **solo** leerá `00-base-android.mdc` y `20-compose-ui.mdc`. No perderá tokens vitales (ni tiempo de atención algorítmica) leyendo sobre mapeos de bases de datos o configuraciones de Gradle.
+
+## 🌐 Comparativa Evolutiva: Interacción de Modelos LLM con rules.md
+
+El ecosistema de IA no es homogéneo. Diferentes familias de modelos procesan los archivos de reglas con distintas fortalezas y debilidades. Como ingenieros de software, debemos optimizar nuestros archivos `.mdc` teniendo en mente el hardware subyacente y la arquitectura neuronal de los agentes.
+
+### 1. La Familia Claude 3.5 (Anthropic) y la Ventana de Contexto Perceptiva
+Claude 3.5 (incluyendo Sonnet y Opus) domina actualmente la comprensión de contexto extenso gracias a su tecnología de memoria jerárquica y atención esparcida. Cuando un archivo `.mdc` se inyecta en Claude, el modelo exhibe una retención excepcional de las reglas, incluso aquellas ubicadas al final del documento.
+**Táctica Recomendada:** Con Claude, puedes permitirte ser exhaustivo. Puedes incluir múltiples "ejemplos negativos" detallados. Claude sobresale en tareas holísticas de refactorización donde tiene que escanear un archivo viejo y alinearlo con un extenso manual de estilo definido en `rules.md`. Es el motor preferido detrás de los agentes de orquestación (MAO) que operan autónomamente sobre PRs completos.
+
+### 2. La Familia GPT-4o / O1 (OpenAI) y el Razonamiento Deductivo
+Los modelos O1 introdujeron los paradigmas de razonamiento implícito (*Hidden Chain of Thought*). Al enfrentarse a un archivo de reglas, estos modelos no solo leen las directrices, sino que "piensan" a través de ellas. Si una regla en `.cursorrules` establece que "La inyección de dependencias está prohibida en componentes Composable", el modelo O1 inferirá proactivamente las ramificaciones de esto y estructurará el ViewModel para gestionar las dependencias internamente y exponer solo lambdas simples a la UI.
+**Táctica Recomendada:** Sé explícito sobre los "Por qués" (*The Whys*). O1 responde brillantemente si explicas el razonamiento detrás de la regla. En lugar de decir "No uses `LiveData`", di "No uses `LiveData` porque no escala bien con Coroutines asíncronas de alto rendimiento y viola nuestros patrones reactivos asíncronos". El modelo internalizará el principio y lo aplicará a casos frontera no explícitamente listados.
+
+### 3. Modelos de Autocompletado Ligeros (DeepSeek Coder V2, StarCoder 2, Gemini Nano)
+Estos modelos SLM (Small Language Models) operan localmente en el dispositivo o mediante APIs de muy baja latencia. Su tarea es adivinar las próximas 10-50 líneas de código a medida que escribes (autocompletado en línea *tab-to-complete*). Son altamente sensibles a la saturación de tokens.
+**Táctica Recomendada:** Para herramientas que alimentan reglas a modelos SLM, la granularidad es vida o muerte. Utiliza el directorio `.cursor/rules/` de forma estricta. Si inyectas más de 1000 tokens en un SLM, su rendimiento de autocompletado colapsará y comenzará a generar código aleatorio o entrará en bucles de repetición ("*hallucination loops*"). Mantén los archivos `.mdc` para autocompletado por debajo de las 500 palabras.
+
+## 🚀 Orquestación Avanzada: Sinergia entre rules.md, SDD y MAO
+
+El verdadero poder de `rules.md` emerge cuando se integra en marcos de desarrollo de orden superior como el **Spec-Driven Development (SDD)** o se maneja a través de un **Multi-Agent Orchestrator (MAO)**.
+
+En 2025, los equipos altamente apalancados en IA no dependen de agentes individuales actuando en el vacío. Utilizan orquestadores. Cuando un Orquestador MAO recibe una nueva tarea (ej. "Implementar login offline con Room"), sigue un protocolo estricto:
+
+1. **Fase de Ingestión de Reglas**: El orquestador escanea el repositorio y lee todas las políticas en `.cursor/rules/`. Compila un "Perfil de Restricciones del Proyecto".
+2. **Generación de Especificaciones (SDD)**: Utilizando un framework como OpenSpec, un subagente Analista redacta una especificación formal de la solución. Esta especificación es verificada automáticamente (usando técnicas de refutación socrática) contra las reglas extraídas en la fase 1. Si la especificación sugiere usar `SQLiteOpenHelper`, la regla `10-data-layer.mdc` que exige el uso exclusivo de `Room` activará una alarma, y el documento de especificación será rechazado y re-generado antes de escribir una sola línea de código.
+3. **Fase de Ejecución**: Múltiples agentes (frontend, backend, QA) proceden a escribir el código. Cada agente recibe dinámicamente solo el subconjunto de archivos `.mdc` relevantes para su dominio. El Agente de QA recibe las reglas de testing (`40-testing.mdc`) que le exigen usar `MockK` y `Turbine` para testear los flujos, ignorando la existencia de Mockito.
+
+Esta arquitectura garantiza que la deuda técnica se prevenga por diseño (*by design*), no mediante tediosas revisiones de código posteriores al hecho. Las reglas actúan como guardianes inquebrantables del repositorio, inmunizando al proyecto contra las alucinaciones y divergencias estilísticas de la inteligencia artificial.
+
+## 🛠️ Antipratrones y Depuración: Cuando las Reglas Fallan
+
+Incluso con el mejor sistema `.mdc`, las cosas pueden salir mal. Aquí listamos los antipatrones más comunes que observamos en los equipos modernos y cómo solucionarlos.
+
+### 1. El Antipatrón "Regla Contradictoria"
+**Síntoma**: El agente genera un bloque de código y luego, en la misma respuesta, genera un bloque de comentarios disculpándose y reescribiendo el código, o produce un híbrido extraño (ej. mezcla `LiveData` y `StateFlow`).
+**Causa**: Existe un conflicto de precedencia. Puede que tengas un archivo `.cursorrules` heredado que dice "Usa LiveData" y un `.cursor/rules/20-compose.mdc` nuevo que dice "Usa StateFlow". El LLM se confunde ante el doble vínculo.
+**Solución**: Auditoría de reglas. Elimina `.cursorrules` globales y migra el 100% de la lógica a `.mdc` enrutados por `globs` de forma mutuamente excluyente.
+
+### 2. El Antipatrón "Sobrecarga de Abstracción"
+**Síntoma**: El modelo ignora las reglas completamente, volviendo a generar código genérico.
+**Causa**: Has superado la ventana de contexto efectivo o has diluido la atención del modelo con información irrelevante en un bloque `alwaysApply: true`.
+**Solución**: Refactoriza tus reglas. Mueve la lógica especializada a archivos `.mdc` con `globs` más restrictivos. Reemplaza largos párrafos narrativos por viñetas concisas.
+
+### 3. El Antipatrón "Regla de Perfección Utópica"
+**Síntoma**: Las reglas exigen arquitecturas tan elaboradas (Clean Architecture con 5 capas de interfaces vacías) que la IA falla en generar código funcional simple.
+**Causa**: Reglas desconectadas de la pragmática. Exigir abstracciones excesivas ahoga las capacidades generativas del agente.
+**Solución**: Implementa reglas pragmáticas. Permite excepciones explícitas. En tu `.mdc`, puedes añadir: "Para operaciones CRUD simples sin lógica de negocio, se permite a la UI interactuar directamente con el Repositorio, saltándose la capa de UseCases para evitar boilerplate innecesario".
+
+## 🏆 Conclusión: El Futuro de las Reglas para la IA
+
+El estándar `rules.md` y la evolución hacia el formato contextual `.mdc` representan uno de los avances más profundos en la disciplina de la interacción Humano-Máquina en la ingeniería de software. Hemos transitado de la codificación asistida basada en el conocimiento general pre-entrenado del modelo, hacia un desarrollo quirúrgico anclado en hiper-contexto dinámico.
+
+En el desarrollo de aplicaciones móviles con Kotlin y Android, donde la fragmentación arquitectónica y la rápida evolución de librerías como Jetpack Compose pueden abrumar incluso a los equipos más experimentados, contar con un directorio `.cursor/rules/` bien mantenido no es un lujo: es un requisito operativo indispensable en 2025.
+
+Las reglas son la cristalización de la experiencia del arquitecto humano. Nos permiten delegar la implementación de bajo nivel a los agentes sintéticos con total confianza, sabiendo que respetarán nuestros estándares de calidad, seguridad y diseño arquitectónico. El futuro del desarrollo no pertenecerá a quienes escriban código más rápido, sino a quienes sepan especificar las restricciones de su sistema con mayor precisión algorítmica. Un gran sistema de reglas transforma a la IA de una simple herramienta predictiva en una extensión verdaderamente alineada del intelecto del equipo de ingeniería.


### PR DESCRIPTION
Added an extensive (+3700 words per language) blog article detailing the rules.md standard, the .cursorrules legacy, and the modern .mdc format. The article covers historical context, structuring rules with YAML frontmatter, and practical implementation for Android/Kotlin projects.

Also added a new SVG placeholder image specifically for rules.md articles.

---
*PR created automatically by Jules for task [210455841353007040](https://jules.google.com/task/210455841353007040) started by @ArceApps*