### PR TITLE
⚡ Optimize getStaticPaths app lookup loop

### DIFF
--- a/scripts/benchmark-app-find.js
+++ b/scripts/benchmark-app-find.js
@@ -1,0 +1,73 @@
+import { performance } from 'perf_hooks';
+
+const NUM_APPS = 1000;
+const apps = Array.from({ length: NUM_APPS }, (_, i) => ({
+  data: { reference_id: `ref_${i}` },
+  slug: `es/app-${i}`
+}));
+
+const enApps = Array.from({ length: NUM_APPS }, (_, i) => ({
+  data: { reference_id: `ref_${i}` },
+  slug: `en/app-${i}`
+}));
+
+function baseline() {
+  const start = performance.now();
+  const result = apps.map((app) => {
+    let hreflangPath = undefined;
+    if (app.data.reference_id) {
+      const enApp = enApps.find(a => a.data.reference_id === app.data.reference_id);
+      if (enApp) {
+        hreflangPath = `/apps/${enApp.slug.split('/').pop()}`;
+      }
+    }
+    return hreflangPath;
+  });
+  return performance.now() - start;
+}
+
+function optimized() {
+  const start = performance.now();
+
+  const enAppsMap = new Map();
+  for (let i = 0; i < enApps.length; i++) {
+    const app = enApps[i];
+    if (app.data.reference_id) {
+      enAppsMap.set(app.data.reference_id, app);
+    }
+  }
+
+  const result = apps.map((app) => {
+    let hreflangPath = undefined;
+    if (app.data.reference_id) {
+      const enApp = enAppsMap.get(app.data.reference_id);
+      if (enApp) {
+        hreflangPath = `/apps/${enApp.slug.split('/').pop()}`;
+      }
+    }
+    return hreflangPath;
+  });
+  return performance.now() - start;
+}
+
+// Warmup
+for (let i = 0; i < 100; i++) {
+  baseline();
+  optimized();
+}
+
+let baselineTotal = 0;
+let optimizedTotal = 0;
+const iterations = 1000;
+
+for (let i = 0; i < iterations; i++) {
+  baselineTotal += baseline();
+  optimizedTotal += optimized();
+}
+
+const baselineAvg = baselineTotal / iterations;
+const optimizedAvg = optimizedTotal / iterations;
+
+console.log(`Baseline Avg: ${baselineAvg.toFixed(4)} ms`);
+console.log(`Optimized Avg: ${optimizedAvg.toFixed(4)} ms`);
+console.log(`Improvement: ${((baselineAvg - optimizedAvg) / baselineAvg * 100).toFixed(2)}%`);

--- a/src/pages/apps/[...slug].astro
+++ b/src/pages/apps/[...slug].astro
@@ -10,10 +10,17 @@ export async function getStaticPaths() {
   const apps = await getCollection("apps", ({ data, id }) => !data.draft && id.startsWith('en/'));
   const esApps = await getCollection("apps", ({ data, id }) => !data.draft && id.startsWith('es/'));
 
+  const esAppsMap = new Map();
+  for (const app of esApps) {
+    if (app.data.reference_id) {
+      esAppsMap.set(app.data.reference_id, app);
+    }
+  }
+
   return apps.map((app) => {
     let hreflangPath = undefined;
     if (app.data.reference_id) {
-      const esApp = esApps.find(a => a.data.reference_id === app.data.reference_id);
+      const esApp = esAppsMap.get(app.data.reference_id);
       if (esApp) {
         hreflangPath = `/es/apps/${esApp.slug.split('/').pop()}`;
       }

--- a/src/pages/es/apps/[...slug].astro
+++ b/src/pages/es/apps/[...slug].astro
@@ -10,10 +10,17 @@ export async function getStaticPaths() {
   const apps = await getCollection("apps", ({ data, id }) => !data.draft && id.startsWith('es/'));
   const enApps = await getCollection("apps", ({ data, id }) => !data.draft && id.startsWith('en/'));
 
+  const enAppsMap = new Map();
+  for (const app of enApps) {
+    if (app.data.reference_id) {
+      enAppsMap.set(app.data.reference_id, app);
+    }
+  }
+
   return apps.map((app) => {
     let hreflangPath = undefined;
     if (app.data.reference_id) {
-      const enApp = enApps.find(a => a.data.reference_id === app.data.reference_id);
+      const enApp = enAppsMap.get(app.data.reference_id);
       if (enApp) {
         hreflangPath = `/apps/${enApp.slug.split('/').pop()}`;
       }


### PR DESCRIPTION
💡 **What:** Replaced `Array.find()` with a `Map` lookup inside `apps.map()` for resolving translation links (`reference_id`) during static path generation in `src/pages/es/apps/[...slug].astro` and `src/pages/apps/[...slug].astro`.
🎯 **Why:** Previously, the code performed an O(N) `.find()` lookup inside an O(N) `.map()` loop, resulting in O(N^2) complexity. As the collection size grows, this causes exponential build time degradation. Pre-computing a dictionary ensures O(N) complexity for populating the Map and O(1) lookups during the mapping phase.
📊 **Measured Improvement:**
A dedicated script (`scripts/benchmark-app-find.js`) was added and used to simulate resolving 1,000 apps against 1,000 localized counterparts.
- **Baseline Avg:** ~6.8798 ms
- **Optimized Avg:** ~0.4149 ms
- **Improvement:** ~94% execution time reduction on simulated heavy workloads.

---
*PR created automatically by Jules for task [10490593733488340833](https://jules.google.com/task/10490593733488340833) started by @ArceApps*