### PR TITLE
Add W25 Devlog and Fix Broken Links

### DIFF
--- a/src/content/blog/en/blog-mattpocock-skills.md
+++ b/src/content/blog/en/blog-mattpocock-skills.md
@@ -6,9 +6,9 @@ heroImage: "/images/blog-mattpocock-skills.svg"
 tags: ["SDD", "AI", "Skills", "Claude Code", "mattpocock", "Architecture"]
 reference_id: "b4e7c9a1-5f2d-4e8c-9b3a-7d6e1f2c8a0b"
 related_posts:
-  - blog-sdd-frameworks-analysis-spec-kit-openspec-bmad
-  - blog-socratic-agents-part-2-sdd-sycophancy
-  - blog-specs-driven-development
+  - blog-sdd-frameworks-spec-kit-openspec-bmad
+  - socratic-agents-part-2-sdd-sycophancy
+  - specs-driven-development
 ---
 
 ## The Problem With Monolithic AI Methodologies
@@ -19,7 +19,7 @@ That sentence is doing a lot of work. He's saying: when you hand your project to
 
 This is the core thesis of [`mattpocock/skills`](https://github.com/mattpocock/skills) — a collection of agent skills for coding agents (Claude Code, Codex, and others) that are small, composable, and explicitly *not* a full-stack methodology. Each skill does one thing. You pick the ones you need. You leave the rest.
 
-If you've been reading this blog's [SDD framework comparison](/blog/blog-sdd-frameworks-analysis-spec-kit-openspec-bmad), you know we spent a lot of words on what Spec Kit does, what OpenSpec does, and what BMAD does. Skills is a different answer to the same question: "how do I make AI agents actually useful instead of just compliant?"
+If you've been reading this blog's [SDD framework comparison](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad), you know we spent a lot of words on what Spec Kit does, what OpenSpec does, and what BMAD does. Skills is a different answer to the same question: "how do I make AI agents actually useful instead of just compliant?"
 
 Let's dig into what makes it genuinely different.
 
@@ -229,7 +229,7 @@ The skill that gets the most praise in the community is `/grill-with-docs`. The 
 
 ## How It Compares to the Frameworks We Reviewed
 
-In our [SDD framework comparison](/blog/blog-sdd-frameworks-analysis-spec-kit-openspec-bmad), we found three distinct philosophies:
+In our [SDD framework comparison](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad), we found three distinct philosophies:
 
 - **Spec Kit**: Constitutional approach — your project has a `SPEC.md` that's treated as the source of truth. Agents read it before generating code.
 - **OpenSpec**: Change-proposal approach — every modification goes through a review process that produces a titled document before any code is written.
@@ -266,7 +266,7 @@ That's worth something. The best practices in `/diagnose` and `/tdd` are not the
 - [mattpocock/skills GitHub Repository](https://github.com/mattpocock/skills)
 - [skills.sh Installer](https://skills.sh/b/mattpocock/skills)
 - [Matt Pocock's Newsletter (~60,000 subscribers)](https://www.aihero.dev/s/skills-newsletter)
-- [The Pragmatic Programmer, Thomas & Hunt](/blog/blog-sdd-frameworks-analysis-spec-kit-openspec-bmad)
-- [Domain-Driven Design, Eric Evans](/blog/blog-sdd-frameworks-analysis-spec-kit-openspec-bmad)
-- [A Philosophy of Software Design, John Ousterhout](/blog/blog-sdd-frameworks-analysis-spec-kit-openspec-bmad)
-- Previous SDD articles on this blog: [SDD Frameworks Comparison](/blog/blog-sdd-frameworks-analysis-spec-kit-openspec-bmad), [Socratic Agents and Sycophancy](/blog/blog-socratic-agents-part-2-sdd-sycophancy), [Specs-Driven Development](/blog/blog-specs-driven-development)
+- [The Pragmatic Programmer, Thomas & Hunt](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad)
+- [Domain-Driven Design, Eric Evans](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad)
+- [A Philosophy of Software Design, John Ousterhout](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad)
+- Previous SDD articles on this blog: [SDD Frameworks Comparison](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad), [Socratic Agents and Sycophancy](/blog/socratic-agents-part-2-sdd-sycophancy), [Specs-Driven Development](/blog/specs-driven-development)

--- a/src/content/blog/en/blog-semantic-code-search-tools.md
+++ b/src/content/blog/en/blog-semantic-code-search-tools.md
@@ -7,7 +7,7 @@ tags: ["AI", "Code Search", "Claude Code", "Development Tools", "CocoIndex", "Co
 reference_id: "b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e"
 ---
 
-> **Related reads:** [Spec-Driven Development with Agentic AI](/blog/spec-driven-development-ai) · [Complete Guide: Stack Recommended for Building AI Agents in 2026](/blog/complete-beginners-guide-ai-agents-stack-2026) · [AI Agents in Android Development](/blog/blog-ai-agents-workflow-android)
+> **Related reads:** [Spec-Driven Development with Agentic AI](/blog/spec-driven-development-ai) · [Complete Guide: Stack Recommended for Building AI Agents in 2026](/blog/complete-beginners-guide-ai-agents-stack-2026) · [AI Agents in Android Development](/blog/ai-agents-workflow-android)
 
 When you work with an AI coding agent on a large codebase, you have probably noticed something frustrating: the agent spends a significant portion of its token budget navigating the code. Before it can implement a feature or fix a bug, it needs to understand the surrounding context. It fires off grep commands, glob patterns, and find operations — searching for the right file, the relevant function, the correct abstraction. This exploration phase consumes tokens that could be spent actually writing code.
 

--- a/src/content/blog/en/blog-socratic-grilling-sdd.md
+++ b/src/content/blog/en/blog-socratic-grilling-sdd.md
@@ -8,7 +8,7 @@ reference_id: "c8a2f3d5-7e1b-4c9d-8f0a-3e6b9d2c1a0d"
 related_posts:
   - blog-mattpocock-skills
   - blog-socratic-method-prompts-kotlin-android
-  - blog-sdd-frameworks-analysis-spec-kit-openspec-bmad
+  - blog-sdd-frameworks-spec-kit-openspec-bmad
   - socratic-agents-part-2-sdd-sycophancy
 ---
 
@@ -248,7 +248,7 @@ The combined approach — Socratic pre-spec + SDD during build + Socratic post-g
 
 - [mattpocock/skills](/blog/blog-mattpocock-skills) — the composable skills approach
 - [Socratic Method Prompts: Breaking AI Sycophancy](/blog/blog-socratic-method-prompts-kotlin-android) — the four-component Socratic prompt anatomy
-- [SDD Frameworks Comparison](/blog/blog-sdd-frameworks-analysis-spec-kit-openspec-bmad) — Spec Kit, OpenSpec, and BMAD
-- [Socratic Agents Part 2: SDD and Sycophancy](/blog/blog-socratic-agents-part-2-sdd-sycophancy) — the relationship between adversarial prompting and SDD
+- [SDD Frameworks Comparison](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad) — Spec Kit, OpenSpec, and BMAD
+- [Socratic Agents Part 2: SDD and Sycophancy](/blog/socratic-agents-part-2-sdd-sycophancy) — the relationship between adversarial prompting and SDD
 - [/diagnose skill](https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md) — the six-phase disciplined debugging loop
 - [/grill-me skill](https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md) — the alignment-before-coding session

--- a/src/content/blog/en/blog-spec-kitty-mobile-development.md
+++ b/src/content/blog/en/blog-spec-kitty-mobile-development.md
@@ -7,7 +7,7 @@ tags: ["SDD", "Spec Kitty", "AI Agents", "Git Worktrees", "Spec-Driven Developme
 reference_id: "a8f92c3d-4e15-4b7a-9f2c-1d3e5f6a7b8c"
 ---
 
-> **Related reads:** [Spec-Driven Development with Agentic AI](/blog/blog-specs-driven-development) · [Git Worktrees for Parallel Development](/blog/blog-git-worktrees-android) · [AI Agents in Android Development](/blog/blog-ai-agents-workflow-android)
+> **Related reads:** [Spec-Driven Development with Agentic AI](/blog/specs-driven-development) · [Git Worktrees for Parallel Development](/blog/git-worktrees-android) · [AI Agents in Android Development](/blog/ai-agents-workflow-android)
 
 When a mobile development team works with one AI coding agent, the workflow feels manageable. You describe what you want, the agent writes code, you review it, and the feature lands in your codebase. But when you add a second agent — maybe one handling backend logic while another builds the UI — the cracks appear: which agent is working on what, where did requirements get lost, how do you merge two separate implementations without conflicts?
 

--- a/src/content/blog/es/blog-grill-me-claude-skill-deep-dive.md
+++ b/src/content/blog/es/blog-grill-me-claude-skill-deep-dive.md
@@ -178,4 +178,4 @@ Este artículo se ha construido a partir del análisis de las siguientes fuentes
 - [r/vibecoding - Viral 'Grill Me' Claude skill...](https://www.reddit.com/r/vibecoding/comments/1swyadr/viral_grill_me_claude_skill_proves_specstocode_is/): Hilo de Reddit con el caso práctico del sistema RAG.
 - [Adversarial Prompting (Prompting Guide)](https://www.promptingguide.ai/risks/adversarial): Base teórica para el stress-testing.
 
-*Lee más en nuestro blog sobre metodologías complementarias como el [Spec-Driven Development](/blog/blog-specs-driven-development) y el [Método Socrático para Prompts en Kotlin](/blog/blog-socratic-method-prompts-kotlin-android).*
+*Lee más en nuestro blog sobre metodologías complementarias como el [Spec-Driven Development](/blog/specs-driven-development) y el [Método Socrático para Prompts en Kotlin](/blog/blog-socratic-method-prompts-kotlin-android).*

--- a/src/content/blog/es/blog-lean-task-first-beads-leanspec-taskmaster.md
+++ b/src/content/blog/es/blog-lean-task-first-beads-leanspec-taskmaster.md
@@ -7,7 +7,7 @@ heroImage: "/images/blog-lean-task-first-beads-leanspec-taskmaster.svg"
 reference_id: "e9a3c571-2b4e-4f8d-93d1-7c0e2a5b8f16"
 ---
 
-> **Lectura relacionada:** [Paradigmas Alternativos en Ingeniería de Software con IA](/blog/blog-paradigmas-alternativos-ingenieria-software-ia) · [Spec-Driven Development con IA Agéntica](/blog/blog-specs-driven-development) · [Análisis de Frameworks SDD: Spec Kit, OpenSpec y BMAD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad)
+> **Lectura relacionada:** [Paradigmas Alternativos en Ingeniería de Software con IA](/blog/blog-paradigmas-alternativos-ingenieria-software-ia) · [Spec-Driven Development con IA Agéntica](/blog/specs-driven-development) · [Análisis de Frameworks SDD: Spec Kit, OpenSpec y BMAD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad)
 
 Hay una frustración particular que te golpea alrededor del tercer día de un proyecto con asistencia de IA. La primera sesión fue gloriosa: el agente entendió el objetivo, generó código sensato, hizo las preguntas correctas. Pero para el tercer día ya estás empezando cada sesión con un prólogo largo: "Okay, el proyecto es una app de gestión de tareas, decidimos usar PostgreSQL en vez de SQLite porque X, eliminamos la capa de Redux porque Y, y la última vez nos atascamos en Z." El agente asiente educadamente y luego procede a regenerar el archivo de Redux.
 
@@ -425,7 +425,7 @@ Empieza pequeño. Elige la que resuelve tu punto de dolor más inmediato. Constr
 - [LeanSpec (lean-spec)](https://github.com/codervisor/lean-spec) — Herramienta de desarrollo spec-driven minimalista con integración MCP
 - [Taskmaster (claude-task-master)](https://github.com/eyaltoledano/claude-task-master) — Motor de orquestación PRD-a-tareas por Eyal Toledano
 - [task-master-ai en npm](https://www.npmjs.com/package/task-master-ai) — Paquete npm oficial
-- [Spec-Driven Development con IA Agéntica](/blog/blog-specs-driven-development) — Lectura fundamental sobre principios SDD
+- [Spec-Driven Development con IA Agéntica](/blog/specs-driven-development) — Lectura fundamental sobre principios SDD
 - [Paradigmas Alternativos en Ingeniería de Software con IA](/blog/blog-paradigmas-alternativos-ingenieria-software-ia) — Contexto más amplio sobre metodologías emergentes
 - [Análisis de Frameworks SDD: Spec Kit, OpenSpec, BMAD-METHOD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad) — Comparación de frameworks SDD más pesados
 - Yegge, S. (2024). *Distributed Issue Tracking for the AI Age*. Blog personal.

--- a/src/content/blog/es/blog-mattpocock-skills.md
+++ b/src/content/blog/es/blog-mattpocock-skills.md
@@ -7,8 +7,8 @@ tags: ["SDD", "IA", "Skills", "Claude Code", "mattpocock", "Arquitectura"]
 reference_id: "b4e7c9a1-5f2d-4e8c-9b3a-7d6e1f2c8a0b"
 related_posts:
   - blog-sdd-frameworks-spec-kit-openspec-bmad
-  - blog-socratic-agents-part-2-sdd-sycophancy
-  - blog-specs-driven-development
+  - socratic-agents-part-2-sdd-sycophancy
+  - specs-driven-development
 ---
 
 ## El Problema Con Las Metodologías Monolíticas de IA
@@ -269,4 +269,4 @@ Eso vale algo. Las mejores prácticas en `/diagnose` y `/tdd` no son teóricas �
 - [The Pragmatic Programmer, Thomas & Hunt](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad)
 - [Domain-Driven Design, Eric Evans](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad)
 - [A Philosophy of Software Design, John Ousterhout](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad)
-- Artículos anteriores sobre SDD en este blog: [Comparativa de Frameworks SDD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad), [Agentes Socráticos y Sicofancia](/blog/blog-socratic-agents-part-2-sdd-sycophancy), [Specs-Driven Development](/blog/blog-specs-driven-development)
+- Artículos anteriores sobre SDD en este blog: [Comparativa de Frameworks SDD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad), [Agentes Socráticos y Sicofancia](/blog/socratic-agents-part-2-sdd-sycophancy), [Specs-Driven Development](/blog/specs-driven-development)

--- a/src/content/blog/es/blog-openspec-desarrollo-movil.md
+++ b/src/content/blog/es/blog-openspec-desarrollo-movil.md
@@ -7,7 +7,7 @@ tags: ["SDD", "OpenSpec", "Android", "Kotlin", "IA Agéntica", "Desarrollo Móvi
 reference_id: "e7f82a1b-3c45-4d9e-8f1a-2b3c4d5e6f7g"
 ---
 
-> **Lecturas relacionadas:** [Análisis Profundo de Frameworks SDD: Spec Kit, OpenSpec y BMAD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad) · [Desarrollo Impulsado por Especificaciones con IA Agéntica](/blog/blog-specs-driven-development) · [Stack Completo para Construir Agentes IA en 2026](/blog/blog-stack-completo-agentes-ia-2026)
+> **Lecturas relacionadas:** [Análisis Profundo de Frameworks SDD: Spec Kit, OpenSpec y BMAD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad) · [Desarrollo Impulsado por Especificaciones con IA Agéntica](/blog/specs-driven-development) · [Stack Completo para Construir Agentes IA en 2026](/blog/blog-stack-completo-agentes-ia-2026)
 
 El desarrollo móvil tiene una disciplina particular que el desarrollo web no comparte: la **fragmentación de contextos técnicos**. Cada plataforma móvil — Android con Kotlin, iOS con Swift — tiene sus propios ciclos de release, restricciones de hardware, APIs nativas y patrones arquitectónicos. Cuando introduces agentes de IA en este ecosistema, el riesgo de desalineación se multiplica: el agente puede sugerirte una API de Android obsoleta, usar un patrón de concurrencia inadecuado para Kotlin, o implementar una característica ignorando las directrices de Material Design.
 

--- a/src/content/blog/es/blog-paradigmas-alternativos-ingenieria-software-ia.md
+++ b/src/content/blog/es/blog-paradigmas-alternativos-ingenieria-software-ia.md
@@ -7,7 +7,7 @@ tags: ["IA", "Metodología", "IDD", "SDD", "BEADS", "Dark Factory", "Ingeniería
 draft: false
 ---
 
-> **Lectura relacionada:** [Spec-Driven Development con IA Agéntica](/blog/blog-specs-driven-development) · [Agentes IA Autónomos en Android: Más Allá del Asistente](/blog/blog-agentes-ia-autonomos-android) · [Construyendo Skills para Agentes IA](/blog/blog-agentes-ia-skills)
+> **Lectura relacionada:** [Spec-Driven Development con IA Agéntica](/blog/specs-driven-development) · [Agentes IA Autónomos en Android: Más Allá del Asistente](/blog/blog-agentes-ia-autonomos-android) · [Construyendo Skills para Agentes IA](/blog/blog-agentes-ia-skills)
 
 ---
 

--- a/src/content/blog/es/blog-primeros-principios-razonamiento-ia-quint-code.md
+++ b/src/content/blog/es/blog-primeros-principios-razonamiento-ia-quint-code.md
@@ -7,7 +7,7 @@ tags: ["IA", "Razonamiento", "Primeros Principios", "Quint Code", "FPF", "Agente
 reference_id: "5031f97d-df40-43f0-a398-2c6a58557c4a"
 ---
 
-> **Lectura relacionada:** [Desarrollo Dirigido por Especificaciones con IA Agéntica](/blog/blog-specs-driven-development) · [AI Agent Skills: Inyección Dinámica de Contexto](/blog/blog-agent-skills-contexto-dinamico) · [Modelos de Razonamiento: De o1 a R1](/blog/blog-reasoning-models-o1-r1)
+> **Lectura relacionada:** [Desarrollo Dirigido por Especificaciones con IA Agéntica](/blog/specs-driven-development) · [AI Agent Skills: Inyección Dinámica de Contexto](/blog/blog-agent-skills-contexto-dinamico) · [Modelos de Razonamiento: De o1 a R1](/blog/blog-reasoning-models-o1-r1)
 
 ---
 
@@ -275,5 +275,5 @@ El ciclo ADI — Abducción, Deducción, Inducción — es cómo la ingeniería 
 - [First Principles Framework (FPF)](https://github.com/ailev/FPF) por Anatoly Levenchuk — La especificación de razonamiento transdisciplinario que sustenta Quint Code.
 - [Documentación de Quint Code](https://quint.codes/learn) — Guías detalladas sobre modos de decisión, formato DRR, características calculadas y gestión del ciclo de vida.
 - Peirce, C.S. — *Collected Papers* (Volúmenes 5–6) — La fuente original de la lógica abductiva, deductiva e inductiva.
-- [Desarrollo Dirigido por Especificaciones con IA Agéntica](/blog/blog-specs-driven-development) — Cómo SDD complementa el razonamiento estilo FPF.
+- [Desarrollo Dirigido por Especificaciones con IA Agéntica](/blog/specs-driven-development) — Cómo SDD complementa el razonamiento estilo FPF.
 - [Modelos de Razonamiento: De o1 a R1](/blog/blog-reasoning-models-o1-r1) — La perspectiva a nivel de modelo de IA sobre el razonamiento estructurado.

--- a/src/content/blog/es/blog-sdd-frameworks-spec-kit-openspec-bmad.md
+++ b/src/content/blog/es/blog-sdd-frameworks-spec-kit-openspec-bmad.md
@@ -7,7 +7,7 @@ tags: ["SDD", "IA", "Workflow", "GitHub Copilot", "BMAD", "OpenSpec", "Spec Kit"
 reference_id: "a3f72b91-4c18-4e2d-9b5c-1d0e6f2a8c34"
 ---
 
-> **Lectura previa recomendada:** [Desarrollo Guiado por Especificaciones con IA Agéntica](/blog/blog-specs-driven-development) · [Paradigmas Alternativos en Ingeniería de Software con IA](/blog/blog-paradigmas-alternativos-ingenieria-software-ia) · [Orquestar Agentes de IA en Pipelines CI/CD](/blog/blog-orquestar-agentes-pipeline-cicd)
+> **Lectura previa recomendada:** [Desarrollo Guiado por Especificaciones con IA Agéntica](/blog/specs-driven-development) · [Paradigmas Alternativos en Ingeniería de Software con IA](/blog/blog-paradigmas-alternativos-ingenieria-software-ia) · [Orquestar Agentes de IA en Pipelines CI/CD](/blog/blog-orquestar-agentes-pipeline-cicd)
 
 El ecosistema SDD ha producido tres frameworks que abordan el mismo problema fundamental —mantener a los agentes de IA alineados con tu intención arquitectónica— desde tres ángulos completamente diferentes. **GitHub Spec Kit** trata tu proyecto como un documento constitucional. **OpenSpec** trata cada cambio como una propuesta que necesita aprobación antes de que se toque una sola línea de código. **BMAD-METHOD** trata toda tu organización de desarrollo como un escuadrón multi-agente a orquestar.
 

--- a/src/content/blog/es/blog-semantic-code-search-tools.md
+++ b/src/content/blog/es/blog-semantic-code-search-tools.md
@@ -8,7 +8,7 @@ reference_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 author: "ArceApps"
 ---
 
-> **Lecturas relacionadas:** [Desarrollo Guiado por Especificaciones con IA Agéntica](/es/blog/spec-driven-development-ai) · [Guía Completa: Stack Recomendado para Construir Agentes IA en 2026](/es/blog/complete-beginners-guide-ai-agents-stack-2026) · [Agentes IA en Desarrollo Android](/es/blog/blog-ai-agents-workflow-android)
+> **Lecturas relacionadas:** [Desarrollo Guiado por Especificaciones con IA Agéntica](/es/blog/spec-driven-development-ai) · [Guía Completa: Stack Recomendado para Construir Agentes IA en 2026](/es/blog/complete-beginners-guide-ai-agents-stack-2026) · [Agentes IA en Desarrollo Android](/es/blog/ai-agents-workflow-android)
 
 Si alguna vez has trabajado con un agente de programación IA en un proyecto grande, probablemente habrás notado algo frustrante: el agente dedica una porción significativa de su presupuesto de tokens a navegar por el código. Antes de implementar una funcionalidad o corregir un bug, necesita entender el contexto circundante. Dispara comandos grep, patrones glob y operaciones de búsqueda — buscando el archivo correcto, la función relevante, la abstracción apropiada. Esta fase de exploración consume tokens que podrían gastarse en escribir código realmente.
 

--- a/src/content/blog/es/blog-socratic-grilling-sdd.md
+++ b/src/content/blog/es/blog-socratic-grilling-sdd.md
@@ -8,7 +8,7 @@ reference_id: "c8a2f3d5-7e1b-4c9d-8f0a-3e6b9d2c1a0d"
 related_posts:
   - blog-mattpocock-skills
   - blog-socratic-method-prompts-kotlin-android
-  - blog-sdd-frameworks-analysis-spec-kit-openspec-bmad
+  - blog-sdd-frameworks-spec-kit-openspec-bmad
   - socratic-agents-part-2-sdd-sycophancy
 ---
 
@@ -229,7 +229,7 @@ La diferencia: en el primer workflow, la sicofancia del modelo permite que los d
 
 - [mattpocock/skills](/blog/blog-mattpocock-skills) — el enfoque de skills composables
 - [Prompts del Método Socrático: Rompiendo la Sicofancia de la IA](/blog/blog-socratic-method-prompts-kotlin-android) — la anatomía del prompt socrático de cuatro componentes
-- [Comparativa de Frameworks SDD](/blog/blog-sdd-frameworks-analysis-spec-kit-openspec-bmad) — Spec Kit, OpenSpec y BMAD
-- [Agentes Socráticos Parte 2: SDD y Sicofancia](/blog/blog-socratic-agents-part-2-sdd-sycophancy) — la relación entre prompting adversario y SDD
+- [Comparativa de Frameworks SDD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad) — Spec Kit, OpenSpec y BMAD
+- [Agentes Socráticos Parte 2: SDD y Sicofancia](/blog/socratic-agents-part-2-sdd-sycophancy) — la relación entre prompting adversario y SDD
 - [Skill /diagnose](https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md) — el loop de debugging disciplinado de 6 fases
 - [Skill /grill-me](https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md) — la sesión de alineación antes de programar

--- a/src/content/blog/es/blog-spec-kitty-mobile-development.md
+++ b/src/content/blog/es/blog-spec-kitty-mobile-development.md
@@ -7,7 +7,7 @@ tags: ["SDD", "Spec Kitty", "Agentes IA", "Git Worktrees", "Desarrollo Impulsado
 reference_id: "a8f92c3d-4e15-4b7a-9f2c-1d3e5f6a7b8c"
 ---
 
-> **Lecturas relacionadas:** [Desarrollo Impulsado por Especificaciones con IA Agéntica](/blog/blog-specs-driven-development) · [Git Worktrees para Desarrollo Paralelo](/blog/blog-git-worktrees-android) · [Agentes IA en Desarrollo Android](/blog/blog-ai-agents-workflow-android)
+> **Lecturas relacionadas:** [Desarrollo Impulsado por Especificaciones con IA Agéntica](/blog/specs-driven-development) · [Git Worktrees para Desarrollo Paralelo](/blog/git-worktrees-android) · [Agentes IA en Desarrollo Android](/blog/ai-agents-workflow-android)
 
 Cuando un equipo de desarrollo móvil trabaja con un agente de codificación con IA, el flujo se siente manejable. Describes lo que quieres, el agente escribe código, lo revisas, y la funcionalidad aterriza en tu codebase. Pero cuando agregas un segundo agente — quizás uno manejando lógica de backend mientras otro construye la UI — aparecen las grietas: ¿qué agente está trabajando en qué, dónde se perdieron los requisitos, cómo fusionas dos implementaciones separadas sin conflictos?
 

--- a/src/content/blog/es/blog-superpowers-vs-openspec.md
+++ b/src/content/blog/es/blog-superpowers-vs-openspec.md
@@ -7,7 +7,7 @@ tags: ["SDD", "IA", "Superpowers", "OpenSpec", "IA Agéntica", "Metodología", "
 reference_id: "e4d2a1c9-6f8b-4a3d-8e7c-2b1d9f4a5c6d"
 ---
 
-> **Lectura previa recomendada:** [Desarrollo Guiado por Especificaciones con IA Agéntica](/blog/blog-specs-driven-development) · [Paradigmas Alternativos en Ingeniería de Software con IA](/blog/blog-paradigmas-alternativos-ingenieria-software-ia) · [Análisis Profundo de Frameworks SDD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad)
+> **Lectura previa recomendada:** [Desarrollo Guiado por Especificaciones con IA Agéntica](/blog/specs-driven-development) · [Paradigmas Alternativos en Ingeniería de Software con IA](/blog/blog-paradigmas-alternativos-ingenieria-software-ia) · [Análisis Profundo de Frameworks SDD](/blog/blog-sdd-frameworks-spec-kit-openspec-bmad)
 
 Cuando comencé a incorporar agentes de programación con IA en mi flujo de trabajo diario para ArceApps, la fase de luna de miel no duró mucho. Al principio, parecía magia: dejabas un prompt en el chat, veías cómo el código brotaba de la nada y le dabas a commit. Pero a medida que las aplicaciones crecían en complejidad, también lo hacía la fricción. Los agentes alucinaban decisiones arquitectónicas, sobrescribían abstracciones perfectamente válidas con implementaciones ingenuas y, lo peor de todo, rompían comportamientos existentes en silencio porque carecían del contexto general de lo que estaba intentando construir.
 

--- a/src/content/devlog/en/2026-W25-redesign-bento-grid-ai-agents.md
+++ b/src/content/devlog/en/2026-W25-redesign-bento-grid-ai-agents.md
@@ -1,0 +1,104 @@
+---
+title: "W25: Visual Architecture and Orchestrated Agents"
+description: "Complete Homepage redesign with an interactive Bento Grid, Content-Visibility enhancements, and deep advancements in AI agent documentation."
+pubDate: 2026-06-16
+tags: ["devlog", "arceapps", "ai-agents", "bento-grid", "css", "architecture"]
+heroImage: "/images/devlog-default.svg"
+---
+
+## State of the Art: Building in Public
+
+Welcome to a new entry of **ArceApps**, our comprehensive platform and ecosystem, completely independent of PuzzleHub. This fortnight, we have immersed ourselves in a dual effort encompassing both the visual and interactive impact of our portfolio, as well as the theoretical foundations of artificial intelligence. As a human-AI team, we do not settle for merely functional components; we aspire to a standard of technical excellence, absolute performance, and a memorable user experience.
+
+Throughout these two weeks of strategic planning and development, we set out to raise the standard of our main showcase: the ArceApps Homepage. Concurrently, we continued the intense work of documenting and researching AI agents, establishing the ground rules for 2026. Below, we will break down the challenges faced, the code crafted, and the lessons learned during this cycle.
+
+## Milestone 1: Homepage Redesign and the Bento Grid Architecture
+
+The primary frontend focus during this sprint was the reconstruction of the **ArceApps Portfolio** landing page. We wanted to break free from the classic linear design and adopt a denser, modern, and intuitive interface, ultimately opting for a "Bento Grid" structure.
+
+### Why a Bento Grid?
+
+The Bento Grid concept, inspired by Japanese lunchboxes, allows us to present multiple entry points (applications, devlogs, social links) in aesthetically distinct yet harmoniously arranged containers. This structure maximizes space utilization without overwhelming the user, seamlessly guiding their attention through the visual hierarchy of the cells.
+
+### CSS Implementation and Optimization
+
+To achieve this design without sacrificing performance, we implemented deep rendering and reusability optimizations within `src/styles/global.css`. A crucial change was the adoption of `content-visibility`.
+
+```css
+  .material-card {
+    @apply rounded-xl bg-surface dark:bg-dark-surface-variant border border-gray-200 dark:border-gray-800 transition-all duration-300;
+  }
+
+  .cv-auto {
+    content-visibility: auto;
+  }
+```
+
+The utility class `.cv-auto` instructs the browser to defer the rendering and layout calculation of elements that reside outside the current viewport. By applying this to entire sections of our Homepage, we drastically reduce the initial "Time to Interactive" (TTI), as the browser does not waste CPU cycles processing invisible DOM nodes.
+
+Furthermore, we consolidated the use of `.material-card`, an abstraction that guarantees design consistency across the portfolio (border radii, theme-adaptable backgrounds, and smooth transitions), avoiding the duplication of Tailwind utility code within every Astro component.
+
+### The Astro Structure
+
+In `src/components/pages/HomePage.astro`, we orchestrated the view by combining our Bento Grid with spatial design elements (diffuse glows and floating icons).
+
+```astro
+  <section id="apps" class="relative py-24 bg-surface dark:bg-dark-surface overflow-hidden cv-auto fade-in-section" style="contain-intrinsic-size: 800px;">
+    <!-- Background Decor (Glows en Bento) -->
+    <div class="absolute top-1/3 left-10 w-80 h-80 opacity-30 dark:opacity-10 pointer-events-none blur-3xl" style="background: radial-gradient(circle, color-mix(in srgb, var(--color-primary), transparent 90%) 0%, transparent 70%);"></div>
+    <div class="absolute bottom-1/3 right-10 w-96 h-96 opacity-30 dark:opacity-10 pointer-events-none blur-3xl" style="background: radial-gradient(circle, color-mix(in srgb, var(--color-secondary), transparent 90%) 0%, transparent 70%);"></div>
+
+    <div class="container mx-auto px-4 relative z-10">
+      <!-- ... -->
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 items-stretch">
+        <!-- Tarjeta Bento 1: Bitácora Destacada -->
+        <!-- ... -->
+      </div>
+    </div>
+  </section>
+```
+
+Here we observe the practical application of `cv-auto`. Note also the use of `contain-intrinsic-size: 800px;`. This is fundamentally important when utilizing `content-visibility: auto`, as it provides the browser with an estimation of the section's size, preventing abrupt scroll jumps (layout shifts) when the content finally enters the viewport and is rendered.
+
+## Milestone 2: Agent Documentation and the Future of 2026
+
+The second half of the fortnight was heavily focused on knowledge management and the updating of our internal policies and strategic guides (commits `d5a1fd1` and `358e147`).
+
+### Updating the Ecosystem for 2026
+
+We extensively updated the `rules.md` document to reflect the technological context of the year 2026. This update is not merely cosmetic; it acts as the definitive "system prompt" for our AI ecosystem. By aligning these rules with the current year, we ensure that architectural suggestions, code patterns, and selected libraries remain cutting-edge.
+
+### Exploration and Research on Reddit
+
+Engineering is not limited to writing code. Much of the value is generated by researching trends and analyzing community frustrations. This fortnight, we published `ideas-articulos-ia-agentes.md`, a document compiling ideas based on deep investigations into AI agents across forums like Reddit.
+
+This research allows us to understand the current gaps in the implementation of Multi-Agent ecosystems and prepares us to draft technical content that provides real, tested solutions for our developer audience, solidifying the ArceApps portfolio's position as a valuable resource within the community.
+
+## Milestone 3: The Challenge of the Week - Cohesion in Style Architecture
+
+The greatest challenge was not simply creating the Bento Grid, but integrating it cohesively with our existing CSS architecture, respecting dark mode support without excessively bloating the file size or the HTML markup.
+
+In commit `0268e49`, we implemented complex styles directly within `global.css` to handle aspects like the interactivity of the code copy button in markdown blocks and scroll-linked animations.
+
+```css
+  /* Scroll-Driven Animations */
+  @supports (animation-timeline: view()) {
+    .fade-in-section {
+      animation: fade-in-up linear both;
+      animation-timeline: view();
+      animation-range: entry 10% cover 30%;
+    }
+  }
+```
+
+We implemented native Scroll-Driven Animations using pure CSS, leveraging `@supports` to ensure progressive enhancement. This means that modern browsers (2026) will enjoy fluid, user-scroll-linked animations processed on the GPU and compositor thread, while older browsers will simply receive a static but fully functional experience (thanks to fallback logic in other CSS blocks).
+
+This attention to detail within the visual architecture ensures a user experience that feels native, robust, and maximally optimized.
+
+## Lessons Learned and Final Reflection
+
+The transition towards a Bento Grid structure, combined with aggressive optimizations like `content-visibility`, has demonstrated to us that aesthetics and performance are not mutually exclusive when the appropriate technologies are applied. The separation of concerns between Astro components (markup) and global CSS (shared behaviors) remains vital for the maintainability of ArceApps.
+
+In the upcoming weeks, we plan to delve deeper into the implementation of the concepts researched regarding artificial intelligence agents. Translating compiled theoretical knowledge into practical components or CI/CD flows orchestrated by agents will be our next major milestone.
+
+The ArceApps ecosystem continues to mature, transforming not just into a project gallery, but into a living software engineering laboratory for 2026. See you in the next log!

--- a/src/content/devlog/es/2026-W25-redesign-bento-grid-ai-agents.md
+++ b/src/content/devlog/es/2026-W25-redesign-bento-grid-ai-agents.md
@@ -1,0 +1,104 @@
+---
+title: "W25: La Arquitectura Visual y Agentes Orquestados"
+description: "Rediseño completo de la Homepage con Bento Grid interactivo, mejoras en Content-Visibility y avances profundos en la documentación de agentes IA."
+pubDate: 2026-06-16
+tags: ["devlog", "arceapps", "ia-agents", "bento-grid", "css", "architecture"]
+heroImage: "/images/devlog-default.svg"
+---
+
+## Estado del Arte: Construyendo en Público
+
+Bienvenidos a un nuevo registro de **ArceApps**, nuestra plataforma y ecosistema integral, independiente de PuzzleHub. Esta quincena nos hemos sumergido en un doble esfuerzo que abarca tanto el impacto visual e interactivo de nuestro portafolio, como las bases teóricas de la inteligencia artificial. Como equipo humano-IA, no nos conformamos con tener componentes funcionales; aspiramos a un estándar de excelencia técnica, rendimiento absoluto y experiencia de usuario memorable.
+
+En estas dos semanas de desarrollo y planificación estratégica, nos propusimos elevar el estándar de nuestro escaparate principal: la Homepage de ArceApps. Al mismo tiempo, continuamos la intensa labor de documentación e investigación de los agentes de IA, estableciendo las reglas del juego para 2026. A continuación, desglosaremos los retos, el código y las lecciones aprendidas durante este ciclo.
+
+## Hito 1: El Rediseño de la Homepage y la Arquitectura Bento Grid
+
+El principal enfoque de frontend durante este sprint fue la reconstrucción de la página principal del **ArceApps Portfolio**. Queríamos escapar del clásico diseño lineal y adoptar una interfaz más densa, moderna e intuitiva, optando por una estructura "Bento Grid".
+
+### ¿Por qué un Bento Grid?
+
+El concepto Bento Grid, inspirado en las cajas de comida japonesas, nos permite presentar múltiples puntos de entrada (aplicaciones, bitácora, enlaces sociales) en contenedores estéticamente diferenciados pero armónicamente dispuestos. Esta estructura maximiza el uso del espacio sin abrumar al usuario, guiando su atención de manera fluida mediante la jerarquía visual de las celdas.
+
+### Implementación y Optimización de CSS
+
+Para lograr este diseño sin sacrificar el rendimiento, implementamos optimizaciones profundas a nivel de renderizado y reusabilidad en `src/styles/global.css`. Un cambio crucial fue la adopción de `content-visibility`.
+
+```css
+  .material-card {
+    @apply rounded-xl bg-surface dark:bg-dark-surface-variant border border-gray-200 dark:border-gray-800 transition-all duration-300;
+  }
+
+  .cv-auto {
+    content-visibility: auto;
+  }
+```
+
+La clase utilitaria `.cv-auto` instruye al navegador a diferir el renderizado y el cálculo de layout de los elementos que se encuentran fuera del viewport. Al aplicar esto a secciones completas de nuestra Homepage, reducimos drásticamente el "Time to Interactive" (TTI) inicial, ya que el navegador no gasta ciclos de CPU en procesar nodos del DOM invisibles.
+
+Además, consolidamos el uso de `.material-card`, una abstracción que garantiza la consistencia del diseño en todo el portafolio (radios de borde, fondos adaptables a temas claros/oscuros y transiciones suaves), evitando la duplicación de código de Tailwind en cada componente Astro.
+
+### La Estructura en Astro
+
+En `src/components/pages/HomePage.astro`, orquestamos la vista combinando nuestro Bento Grid con elementos de diseño espacial (glows difusos e íconos flotantes).
+
+```astro
+  <section id="apps" class="relative py-24 bg-surface dark:bg-dark-surface overflow-hidden cv-auto fade-in-section" style="contain-intrinsic-size: 800px;">
+    <!-- Background Decor (Glows en Bento) -->
+    <div class="absolute top-1/3 left-10 w-80 h-80 opacity-30 dark:opacity-10 pointer-events-none blur-3xl" style="background: radial-gradient(circle, color-mix(in srgb, var(--color-primary), transparent 90%) 0%, transparent 70%);"></div>
+    <div class="absolute bottom-1/3 right-10 w-96 h-96 opacity-30 dark:opacity-10 pointer-events-none blur-3xl" style="background: radial-gradient(circle, color-mix(in srgb, var(--color-secondary), transparent 90%) 0%, transparent 70%);"></div>
+
+    <div class="container mx-auto px-4 relative z-10">
+      <!-- ... -->
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 items-stretch">
+        <!-- Tarjeta Bento 1: Bitácora Destacada -->
+        <!-- ... -->
+      </div>
+    </div>
+  </section>
+```
+
+Aquí observamos la aplicación práctica de `cv-auto`. Noten también el uso de `contain-intrinsic-size: 800px;`. Esto es fundamental al usar `content-visibility: auto`, ya que le da al navegador una estimación del tamaño de la sección, evitando saltos bruscos en el scroll (layout shifts) cuando el contenido finalmente entra en el viewport y es renderizado.
+
+## Hito 2: Documentación de Agentes y el Futuro de 2026
+
+La segunda mitad de la quincena estuvo fuertemente enfocada en la gestión del conocimiento y la actualización de nuestras políticas internas y guías estratégicas (commit `d5a1fd1` y `358e147`).
+
+### Actualización del Ecosistema a 2026
+
+Actualizamos extensamente el documento `rules.md` para reflejar el contexto tecnológico del año 2026. Esta actualización no es meramente cosmética; actúa como el "prompt del sistema" definitivo para nuestro ecosistema de IA. Al alinear estas reglas con el año actual, garantizamos que las sugerencias arquitectónicas, los patrones de código y las librerías seleccionadas estén a la vanguardia.
+
+### Exploración e Investigación en Reddit
+
+La ingeniería no se limita a escribir código. Gran parte del valor se genera investigando tendencias y analizando las frustraciones de la comunidad. En esta quincena, publicamos `ideas-articulos-ia-agentes.md`, un documento que compila ideas basadas en investigaciones profundas sobre agentes de IA en foros como Reddit.
+
+Esta investigación nos permite entender las brechas actuales en la implementación de ecosistemas Multi-Agente y nos prepara para redactar contenido técnico que aporte soluciones reales y testeadas a nuestra audiencia de desarrolladores, solidificando la posición del portafolio ArceApps como un recurso valioso en la comunidad.
+
+## Hito 3: El Reto de la Semana - Coherencia en la Arquitectura de Estilos
+
+El mayor desafío no fue crear el Bento Grid, sino integrarlo de manera coherente con nuestra arquitectura CSS existente, respetando el soporte para modo oscuro sin inflar excesivamente el tamaño del archivo o el marcado de HTML.
+
+En el commit `0268e49`, implementamos estilos complejos directamente en el `global.css` para manejar aspectos como la interactividad del botón de copiar código en bloques markdown y las animaciones ligadas al scroll.
+
+```css
+  /* Scroll-Driven Animations */
+  @supports (animation-timeline: view()) {
+    .fade-in-section {
+      animation: fade-in-up linear both;
+      animation-timeline: view();
+      animation-range: entry 10% cover 30%;
+    }
+  }
+```
+
+Implementamos Scroll-Driven Animations nativas mediante CSS puro, utilizando `@supports` para garantizar el "progressive enhancement". Esto significa que los navegadores modernos (2026) disfrutarán de animaciones fluidas vinculadas al scroll del usuario, procesadas en la GPU y en el hilo del compositor, mientras que los navegadores antiguos simplemente tendrán una experiencia estática pero funcional (gracias a la lógica alternativa en otros bloques css).
+
+Esta atención al detalle en la arquitectura visual asegura una experiencia de usuario que se siente nativa, robusta y optimizada al máximo.
+
+## Lecciones Aprendidas y Reflexión Final
+
+La transición hacia una estructura Bento Grid, combinada con optimizaciones agresivas como `content-visibility`, nos ha demostrado que la estética y el rendimiento no son mutuamente excluyentes si se aplican las tecnologías adecuadas. La separación de responsabilidades entre los componentes de Astro (marcado) y el CSS global (comportamientos compartidos) sigue siendo vital para la mantenibilidad de ArceApps.
+
+En las próximas semanas, planeamos profundizar en la implementación de los conceptos investigados sobre agentes de inteligencia artificial. Traducir el conocimiento teórico compilado en componentes prácticos o flujos de CI/CD orquestados por agentes será nuestro próximo gran hito.
+
+El ecosistema de ArceApps continúa madurando, transformándose no solo en una galería de proyectos, sino en un laboratorio vivo de ingeniería de software para 2026. ¡Nos vemos en el próximo registro!


### PR DESCRIPTION
Generated bilingual devlog for W25 covering the new Bento Grid homepage redesign and AI agent documentation updates as per the Scribe Agent prompt. Also fixed several legacy broken links in localized blog posts to ensure pipeline stability.

---
*PR created automatically by Jules for task [6746384115385641938](https://jules.google.com/task/6746384115385641938) started by @ArceApps*