### PR TITLE
feat(devlog): add W26 entries on profile-achievements-navigation + game-stats-persistence

### DIFF
--- a/public/images/devlog/devlog-w26-connecting.svg
+++ b/public/images/devlog/devlog-w26-connecting.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <!-- Background: dark navy (theme color) -->
+  <rect width="1200" height="630" fill="#0F172A"/>
+
+  <!-- Grid of dots representing 12 games -->
+  <g transform="translate(150, 130)">
+    <!-- Connecting lines (callback propagation metaphor) -->
+    <g stroke="#018786" stroke-width="1.5" opacity="0.5">
+      <line x1="150" y1="50" x2="50" y2="120"/>
+      <line x1="150" y1="50" x2="250" y2="120"/>
+      <line x1="150" y1="50" x2="50" y2="240"/>
+      <line x1="150" y1="50" x2="250" y2="240"/>
+      <line x1="150" y1="50" x2="150" y2="360"/>
+      <line x1="50" y1="120" x2="250" y2="120"/>
+      <line x1="50" y1="120" x2="50" y2="240"/>
+      <line x1="250" y1="120" x2="250" y2="240"/>
+      <line x1="50" y1="240" x2="250" y2="240"/>
+      <line x1="50" y1="240" x2="150" y2="360"/>
+      <line x1="250" y1="240" x2="150" y2="360"/>
+    </g>
+
+    <!-- Nodes: 12 cards in a triangular grid -->
+    <g>
+      <!-- Row 1: 1 card (top) -->
+      <rect x="130" y="20" width="40" height="60" rx="6" fill="#018786" stroke="#FF9800" stroke-width="2"/>
+
+      <!-- Row 2: 2 cards -->
+      <rect x="30" y="90" width="40" height="60" rx="6" fill="#018786" opacity="0.85"/>
+      <rect x="230" y="90" width="40" height="60" rx="6" fill="#018786" opacity="0.85"/>
+
+      <!-- Row 3: 2 cards -->
+      <rect x="30" y="210" width="40" height="60" rx="6" fill="#018786" opacity="0.7"/>
+      <rect x="230" y="210" width="40" height="60" rx="6" fill="#018786" opacity="0.7"/>
+
+      <!-- Row 4: 1 card (bottom) -->
+      <rect x="130" y="330" width="40" height="60" rx="6" fill="#FF9800"/>
+    </g>
+
+    <!-- Highlight ripple on the bottom orange card -->
+    <circle cx="150" cy="360" r="55" fill="none" stroke="#FF9800" stroke-width="2" opacity="0.8">
+      <animate attributeName="r" values="40;70;40" dur="2.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.8;0;0.8" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <!-- Title block -->
+  <g transform="translate(580, 180)">
+    <text x="0" y="0" font-family="Inter, system-ui, sans-serif" font-size="42" font-weight="700" fill="#F8FAFC">
+      Connecting
+    </text>
+    <text x="0" y="50" font-family="Inter, system-ui, sans-serif" font-size="42" font-weight="700" fill="#F8FAFC">
+      the dots
+    </text>
+    <text x="0" y="120" font-family="Inter, system-ui, sans-serif" font-size="22" font-weight="500" fill="#FF9800">
+      2026 · W26 · Devlog
+    </text>
+    <text x="0" y="170" font-family="Inter, system-ui, sans-serif" font-size="16" font-weight="400" fill="#94A3B8">
+      PuzzleSuite · 12 games · 1 architecture
+    </text>
+  </g>
+
+  <!-- Brand mark bottom-right -->
+  <g transform="translate(1100, 580)" text-anchor="end">
+    <text font-family="Inter, system-ui, sans-serif" font-size="14" font-weight="600" fill="#018786">ArceApps</text>
+  </g>
+</svg>

--- a/public/images/devlog/devlog-w26-nullable.svg
+++ b/public/images/devlog/devlog-w26-nullable.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <!-- Background: dark navy -->
+  <rect width="1200" height="630" fill="#0F172A"/>
+
+  <!-- Two stacked database tables representing "before" and "after" -->
+  <g transform="translate(120, 200)">
+    <!-- Table BEFORE: nullable columns (with '?' glyph) -->
+    <g>
+      <text x="0" y="-20" font-family="JetBrains Mono, monospace" font-size="14" fill="#94A3B8">before (v7)</text>
+      <rect x="0" y="0" width="380" height="180" rx="10" fill="#1E293B" stroke="#475569" stroke-width="2"/>
+      <!-- Header row -->
+      <rect x="0" y="0" width="380" height="36" rx="10" fill="#334155"/>
+      <text x="20" y="24" font-family="JetBrains Mono, monospace" font-size="14" fill="#F8FAFC">akari_puzzles</text>
+      <!-- Rows -->
+      <g font-family="JetBrains Mono, monospace" font-size="13" fill="#CBD5E1">
+        <text x="20" y="62">id INTEGER PK</text>
+        <text x="20" y="86">difficulty TEXT</text>
+        <text x="20" y="110">total_time INTEGER</text>
+        <text x="20" y="134">hints_used INTEGER</text>
+        <text x="20" y="158">score INTEGER?  ← null</text>
+        <text x="20" y="182">xp INTEGER?  ← null</text>
+      </g>
+    </g>
+
+    <!-- Arrow: migration -->
+    <g transform="translate(390, 90)">
+      <path d="M 0 0 L 90 0" stroke="#FF9800" stroke-width="3" marker-end="url(#arrow)" fill="none"/>
+      <text x="45" y="-12" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="12" fill="#FF9800">MIGRATION 7→8</text>
+    </g>
+
+    <!-- Table AFTER: non-nullable columns with default 0 -->
+    <g transform="translate(490, 0)">
+      <text x="0" y="-20" font-family="JetBrains Mono, monospace" font-size="14" fill="#94A3B8">after (v8)</text>
+      <rect x="0" y="0" width="380" height="180" rx="10" fill="#1E293B" stroke="#018786" stroke-width="2"/>
+      <rect x="0" y="0" width="380" height="36" rx="10" fill="#018786"/>
+      <text x="20" y="24" font-family="JetBrains Mono, monospace" font-size="14" fill="#F8FAFC">akari_puzzles</text>
+      <g font-family="JetBrains Mono, monospace" font-size="13" fill="#CBD5E1">
+        <text x="20" y="62">id INTEGER PK</text>
+        <text x="20" y="86">difficulty TEXT</text>
+        <text x="20" y="110">total_time INTEGER</text>
+        <text x="20" y="134">hints_used INTEGER</text>
+        <text x="20" y="158">score INTEGER NOT NULL DEFAULT 0</text>
+        <text x="20" y="182">xp INTEGER NOT NULL DEFAULT 0</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- Arrow marker definition -->
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0 0 L 8 3 L 0 6 z" fill="#FF9800"/>
+    </marker>
+  </defs>
+
+  <!-- Title block right side -->
+  <g transform="translate(120, 480)">
+    <text x="0" y="0" font-family="Inter, system-ui, sans-serif" font-size="36" font-weight="700" fill="#F8FAFC">
+      The Rebellion of the Int?
+    </text>
+    <text x="0" y="38" font-family="Inter, system-ui, sans-serif" font-size="18" font-weight="500" fill="#FF9800">
+      Nullable vs Non-nullable · Room · Retroactive Populator
+    </text>
+  </g>
+
+  <!-- Brand mark bottom-right -->
+  <g transform="translate(1100, 600)" text-anchor="end">
+    <text font-family="Inter, system-ui, sans-serif" font-size="14" font-weight="600" fill="#018786">ArceApps</text>
+  </g>
+</svg>

--- a/src/content/devlog/en/2026-w26-connecting-puzzle-pieces.md
+++ b/src/content/devlog/en/2026-w26-connecting-puzzle-pieces.md
@@ -1,0 +1,102 @@
+---
+title: "2026 W26: Connecting the dots of the puzzle"
+description: "A week where two seemingly small features ended up exposing the deep architecture of PuzzleSuite: clickable navigation from the profile and retroactive persistence of XP and scores across all twelve games."
+pubDate: "2026-06-22"
+heroImage: "/images/devlog/devlog-w26-connecting.svg"
+tags: ["devlog", "android", "kotlin", "compose", "room", "navigation"]
+---
+
+There are weeks where you sit down in front of your editor convinced that you're going to write three lines of code, grab a coffee, and head back to bed. This was not one of those weeks. This was the week where two "simple" Pull Requests — adding a click to a card and inserting two new columns into a database — dragged me into a reflection on the very nature of state in an Android application. But let's go in order, as always, because the story deserves to be told from the beginning.
+
+## The hook: a card that did nothing
+
+If you've been using PuzzleSuite for a while, you probably know the Profile tab. It's that screen where, in addition to your streak and your global stats, an elegant grid appears showing the progress of the twelve games in the suite: Akari, Dominosa, Fillomino, Galaxies, Hashi, Hitori, Kakuro, Kenken, MathCrossword, Minesweeper, Shikaku and Slitherlink. The grid has substance — it uses `SuiteProgressGrid`, a shared component that renders a `GameProgressCard` per game, with difficulty bars, completion counters and a percentage calculated on the fly.
+
+The problem is that, until this week, those cards were pretty but inert. You could look at them, feel the pride of your hundred completed Akaris, and that was about it. The navigation to the corresponding game's achievements screen lived elsewhere: in the game's menu, two levels of depth further down. If you wanted to see Dominosa's achievements from the Profile, you had to go back to Home, open Dominosa's menu and then jump to its achievements. Three taps. An absurd amount of friction for one of the most natural interactions in the world: "hey, I saw my Dominosa progress from here, let me see the details without having to navigate as if I were solving a maze".
+
+The first documented task, `20260618-profile-achievements-navigation`, was born exactly to fix this. The title sounds pompous for what ended up being a three-commit feature, but the devil was in the details. Or rather: the devil was in the signature of the composables.
+
+## The knot: when Compose won't let you lie
+
+`SuiteProgressGrid` already existed. `GameProgressCard` already existed. `ProfileScreen` already existed. What didn't exist was a clean way to tell the system "when someone touches this card, go to Dominosa's achievements screen" without coupling the grid to the global `NavController`. If you do that — pass the `NavController` as a parameter down to the innermost component — you turn every `Composable` into a mini-application with knowledge of the entire navigation hierarchy. And then any future refactor becomes a game of Jenga where nobody wants to move the middle piece.
+
+The clean solution, which is the one we adopted, was to propagate a callback upward. In Compose, the "data down, events up" pattern is not a suggestion: it is a moral obligation. So the chain went like this:
+
+`MainScreen` receives `onNavigateToGame: (String) -> Unit` from the global navigator. When it declares `ProfileScreen` in its internal `NavHost`, it passes `onNavigateToGameAchievements = onNavigateToGame`. `ProfileScreen` receives that callback, maps it by appending the `_achievements` suffix to the game ID, and hands it to `SuiteProgressGrid` as `onGameClick`. `SuiteProgressGrid` propagates it to each `GameProgressCard`. And `GameProgressCard`, finally, adds the `.clickable { onGameClick(progress.gameId) }` modifier to the main card.
+
+It sounds like a tongue twister, and it is. But it works because each piece only knows its immediate parent. The grid doesn't know a global navigator exists; the profile doesn't know a `NavController` exists; the card only knows that when it's touched, it has to invoke a lambda. This is the magic — and sometimes the torture — of Compose: it forces you to be explicit about dependencies, which scales better but requires more typing.
+
+The other interesting detail was the back stack handling. When you navigate from the Profile and then press "back" on the achievements screen, where should you return to? If you navigate from the Profile, the intuitive answer is "to the Profile". If you navigate from the Game Menu, the intuitive answer is "to the Game Menu". Compose Navigation resolves this on its own, without us having to intervene, because each `popBackStack()` stays on the previous screen of the stack. It's one of those moments where the tool gives you what you need if you stopped fighting it five minutes earlier.
+
+## The unexpected climax: the historical data problem
+
+Up to here, everything was clean architecture and callback propagation. But the second task, `20260621-game-stats-persistence`, had a trap hidden under an innocent surface.
+
+The premise was simple: we want each completed puzzle to record its `score` and its `xp` in the database, so that the history can show "you earned +150 XP and 320 points on this Hashi" instead of just "completed in 4:32". So far so good. Two new columns in each of the twelve puzzle tables. Twelve Room migrations, one per game. Trivial.
+
+But then someone — me, sitting with my third coffee of the morning — asked the obvious question: "And what happens to the puzzles that were already completed before this update?". And the answer was: nothing. They would sit in the database with `score = 0` and `xp = 0` forever, unless we run some retroactive logic.
+
+If you have fifteen hundred completed puzzles in your local install — which is perfectly plausible if you've been playing PuzzleSuite for two years — that's fifteen hundred rows that need to be recalculated and updated. When? How? With which rules?
+
+This is where the "nullable vs non-nullable" decision stops being a syntactic detail and becomes a philosophical question. If the columns are `Int?`, we can cleanly represent "this puzzle was completed before the scoring system existed, so its score is unknown". If they are `Int = 0`, we are lying: we are saying that those old puzzles have zero points, when in reality none were ever calculated for them. Option B — `Int = 0` with a `DEFAULT 0` in the migration — is what won, for consistency with the rest of the data model (timing fields already follow that pattern), but the decision required a whole entry in the design document explaining why we chose to lie elegantly instead of admitting our ignorance.
+
+But the real climax was the **retroactive population**. Once we decided that the columns would start at zero, we needed to fill them. And here we had three paths:
+
+1. **Pure SQL in the migration**: run `UPDATE akari_puzzles SET score = ...` inside the Room transaction. The advantage was speed and atomicity. The disadvantage was that replicating the logic of `GameScoreCalculator` — which takes into account speed thresholds per size and difficulty, dynamic bonuses, hints used, and different rules for each of the twelve games — in pure SQL was a maintenance nightmare.
+
+2. **Kotlin logic at startup**: let the migrations add the empty columns, and then, on app startup, a component walks through the repositories, looks for puzzles with `score == 0`, and recalculates them using the existing scoring functions in Kotlin. That's what we did.
+
+3. **Room callback**: execute the calculation inside `RoomDatabase.Callback.onOpen`. The advantage was automation. The disadvantage was blocking database initialization and creating circular dependencies with Hilt and `GlobalStatsRepository`.
+
+Option two won for one very specific reason: it respects the golden rule of "single source of truth for business logic". If tomorrow I change the XP formula, I don't want to rewrite twelve different SQL queries. I want to change `XpCalculator.calculate()` and have the next app startup apply the new values. That is the promise of retroactive recalculation: not only does it fix the past, but it stays alive in the future.
+
+## The denouement: twelve files, one architecture
+
+What I liked most about how this week ended is that, although I touched twelve different databases, the pattern was exactly the same in all of them. For each game:
+
+1. I modified the domain `data class` to add `score: Int = 0` and `xp: Int = 0`.
+2. I modified the Room entity with the same fields, making sure the `toDomain()` and `toEntity()` mapping propagated them.
+3. I added a version migration that increments the schema by one and runs two `ALTER TABLE … ADD COLUMN`.
+4. I added the corresponding game to the `RetroactiveStatsPopulator` — a `@Singleton` with `@Inject` for the twelve repositories.
+
+It is gratifying to see how a strict Clean architecture pays dividends when you have to apply the same change N times. When each layer is isolated, changes are predictable. When you couple layers, each repetition is an opportunity to introduce a subtle bug. I've lived long enough on this project to know that this predictability is worth its weight in coffee.
+
+## Learnings and farewell
+
+The two lessons I take from this week are technically modest but philosophically dense.
+
+The first: **navigation in Compose is not an architectural luxury, it is a statement of principles**. When you decide to propagate callbacks instead of passing the `NavController` to everyone, you are saying "my UI is testable, my UI is refactorable, my UI is understandable". The immediate cost is more lines of code and more verbose signatures. The long-term benefit is that you will never have to rewrite half the app because you switched from `NavHost` to `Voyager`.
+
+The second: **historical data is a window to the past, and windows can be updated**. The idea that a user with fifteen hundred completed puzzles could see them all with zero score was unacceptable. But more important than fixing the past was designing a system that can fix itself when the rules change. That is the true value of `RetroactiveStatsPopulator`: it is not a patch, it is a guarantee.
+
+If you've read this far, I owe you a confession: this devlog was planned as a single article, but the raw material rebelled and ended up splitting in two. The second part, *"The Rebellion of the `Int?`"*, is a technical deep dive on everything that had to be decided to make the retroactive persistence system work. I'll see you there if you want to get down into the mud of SQL, the nullable trade-offs, and the `RetroactiveStatsPopulator` code. If you prefer to stay at the narrative surface, we'll see you in the next entry.
+
+In the meantime, go to the Profile tab and tap a card. If all has gone well, you'll land on the game's achievements screen with an elegant ripple and the pride of a developer who finally dared to connect the dots.
+
+## A note on the ripple, because nobody talks about the ripple
+
+There is a detail that I love about Material Design 3 and is rarely discussed: the `.clickable` modifier not only adds the touch handler, but automatically applies the ripple animation you see when you press the card. That expanding wave, that circle that spreads from where you touched, is not free: it's implemented in `androidx.compose.foundation` as a configurable `Indication`, and by default uses `LocalIndication.current` which in Material Theme 3 is precisely `rememberRipple()`. Which means that adding `clickable { }` to a component and getting instant tactile feedback is an architectural decision that someone on the Compose team made years ago for you, and that you probably never appreciate enough.
+
+In PuzzleSuite that ripple is the difference between a card that feels like a button and one that feels like a photo. When you navigate through the Profile grid, each tap returns a small visual confirmation that the app heard you. In a puzzle game, where the response to your actions is the center of the experience, that kind of micro-detail is what separates an app that "works" from an app that "feels good". It's not magic, it's Compose doing its job.
+
+## Why being indie matters here
+
+You work alone. There is no product manager to tell you "this is priority one". There is no QA team to tell you "hey, in this case the user taps twice because the ripple isn't visible". There is no designer handing you a detailed specification of every interaction. You have your head, your coffee, and the open issues on GitHub. And that loneliness, which sometimes weighs, other times liberates: because it lets you make decisions that in a medium-sized company would require three meetings, an act and an updated Jira.
+
+When I decided that `Int = 0` was better than `Int?` for the score fields, I didn't have to write an RFC. When I decided to propagate callbacks instead of passing the `NavController`, I didn't have to convince a tech lead. When I decided that twelve identical migrations were better than a generic migration script, I didn't have to justify the trade-off to an architecture team. I just had to be sure, and that is a privilege you don't appreciate until you've worked on teams where every three-line change goes through four approvals.
+
+But that privilege has its counterpart: the responsibility of being wrong well. If I got the nullable wrong, there's no code review to correct me. If the navigation loses the back stack in some edge case, there's no tester to report it before release. It's me, on my couch, watching how the issues pile up in the repository. And that, curiously, is also fine. Because every error I put in production is an error I will document, learn from, and not make next time.
+
+## The closing that isn't a closing
+
+This week I learned that sometimes small features are the most dangerous. Not because they are complex — on the contrary, they are deceptively simple — but because they tempt you to not pay them the architectural attention they deserve. The click on a card seems trivial. Two new columns in a table seem trivial. But both changes touch the exposed nerves of the application: how you navigate, how you persist, how you maintain consistency between the old and the new.
+
+If you're building something similar, I'll leave you with three rules that have served me well this week:
+
+1. **Every callback has an owner.** If you can't trace who invokes a lambda, refactor until you can.
+2. **Every migration tells a story.** If you're going to alter a table, think about the rows that are already there. They are not a detail, they are the past of your user.
+3. **Every pattern you repeat ten times deserves an abstraction.** Twelve games with the same new column is not a coincidence; it is an architecture lesson waiting to be learned.
+
+See you in the next entry, where we'll get down into the mud of SQL and Kotlin to see how to build a `RetroactiveStatsPopulator` that actually works.
+
+— *Scribe*

--- a/src/content/devlog/en/2026-w26-nullable-rebellion.md
+++ b/src/content/devlog/en/2026-w26-nullable-rebellion.md
@@ -1,0 +1,219 @@
+---
+title: "2026 W26: The Rebellion of the Int? (Technical Deep Dive)"
+description: "The B-side of this week: how to decide between nullable and non-nullable columns, why we wrote the RetroactiveStatsPopulator in Kotlin instead of SQL, and the guts of the Room migration for the twelve games of PuzzleSuite."
+pubDate: "2026-06-22"
+heroImage: "/images/devlog/devlog-w26-nullable.svg"
+tags: ["devlog", "android", "kotlin", "room", "database", "refactor"]
+---
+
+If the previous entry was the cinematic version of this week — the narrative summary, the anecdotes, the coffee and the philosophy — this is the workshop version. Here we're going to pop the hood of `RetroactiveStatsPopulator`, discuss why each technical decision was the one it was, and why some other options that seemed reasonable ended up being discarded. If you're looking for a step-by-step guide to implementing something similar, this is your devlog. If you just want the indie epic, the first part of this week awaits you.
+
+## The problem, no metaphors
+
+PuzzleSuite has twelve logic puzzle games. Each game has its own Room database (an old architecture decision that we'll probably migrate to a single shared database someday, but that's a topic for another devlog). Each database has a `*_puzzles` table that stores the puzzles completed by the user, with fields like `difficulty`, `totalTime`, `hintsUsed`, `completedAt`, and other metadata.
+
+Until this week, two fields were missing that we needed: `score` (the points earned on that puzzle according to speed and difficulty thresholds) and `xp` (the experience reported to the player's global profile). The reason they were missing was historical: when we designed the initial scoring system, we did it calculating the values on the fly each time the stats screen was rendered. That worked while there was only one stats screen and a simple data model. But when we tried to show the score in the completed puzzle history, we discovered we didn't have the data persisted: we would have to recalculate it every time someone visited that screen, which was absurd from an efficiency and maintainability standpoint.
+
+The obvious solution was to add two columns to each table. But obvious solutions, as we're about to see, hide an obscene amount of decisions beneath their innocent surface.
+
+## Decision 1: Nullable vs Non-nullable
+
+The first fork in the road. The two options were:
+
+**Option A: Nullable columns**
+```kotlin
+val score: Int? = null,
+val xp: Int? = null
+```
+
+**Option B: Non-nullable columns with default**
+```kotlin
+val score: Int = 0,
+val xp: Int = 0
+```
+
+Option A has a conceptual elegance: "this puzzle was completed before the scoring system existed, so its score is unknown". It's the literal truth. It's also an operational hell: every time someone sums scores, every time the UI displays them, every time a calculation uses them, you have to write `score ?: 0` somewhere. That proliferation of safe-calls and elvis operators is noise that contaminates the code and that, over time, sneaks into places where it shouldn't be.
+
+Option B, on the other hand, says "this puzzle has a score of zero". It's an elegant lie. But it's a lie that the entire system understands and handles without special cases. When in six months you change the XP formula, you won't have to track down all the `Int?` to `Int` conversions to make sure none became obsolete. You simply change `XpCalculator.calculate()` and everything flows.
+
+We chose B. And we chose it not because it was the most philosophically correct, but because it was the most consistent with the rest of the model. The timing fields (`totalTime: Long = 0`) already followed that pattern. If we made an exception here, we would be introducing an inconsistency that in two years someone — probably me, in another devlog like this — would have to explain why it exists.
+
+## Decision 2: How to fill historical rows
+
+Okay, we have the columns. We have default values at zero. What about the puzzles that were already completed before this update? Those have `score = 0` and `xp = 0`, which is incorrect because they aren't zero: they were simply never calculated.
+
+Here the menu had three dishes:
+
+### Dish 1: Pure SQL in the Room migration
+
+```sql
+ALTER TABLE akari_puzzles ADD COLUMN score INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE akari_puzzles ADD COLUMN xp INTEGER NOT NULL DEFAULT 0;
+UPDATE akari_puzzles SET
+  score = CASE
+    WHEN difficulty = 'easy' AND total_time < 60000 THEN 100
+    WHEN difficulty = 'easy' AND total_time < 180000 THEN 50
+    ...
+  END
+WHERE completed_at IS NOT NULL;
+```
+
+Advantage: atomic, fast, all within the migration transaction.
+Disadvantage: replicating the full logic of `GameScoreCalculator` (which takes into account puzzle size, hints used, speed bonuses, special rules per game) in SQL is practically impossible. By the time I finished writing the twelve queries, the rules would have changed.
+
+### Dish 2: Kotlin on startup (what we did)
+
+```kotlin
+@Singleton
+class RetroactiveStatsPopulator @Inject constructor(
+    private val akariRepository: AkariPuzzleRepository,
+    private val dominosaRepository: DominosaPuzzleRepository,
+    // ... ten other repositories
+) {
+    suspend fun populateAll() {
+        populateGame("akari") {
+            val puzzles = akariRepository.getCompletedPuzzles().first()
+            puzzles.filter { it.score == 0 }.forEach { p ->
+                val sizeStr = "${p.size.width}x${p.size.height}"
+                val score = GameScoreCalculator.calculate(
+                    "akari", p.difficulty, sizeStr, p.totalTime, p.hintsUsed
+                )
+                val sizeTier = getAkariSizeTier(p.size)
+                val xp = XpCalculator.calculate(sizeTier, p.difficulty)
+                akariRepository.updatePuzzle(p.copy(score = score, xp = xp))
+            }
+        }
+        // Repeat for the other eleven games
+    }
+}
+```
+
+Advantage: reuses all existing scoring logic. If tomorrow I change `XpCalculator`, the next startup applies the new values without touching this code.
+Disadvantage: adds a small lag on the first startup, although in small local databases it's practically imperceptible.
+
+### Dish 3: Room Database Callback
+
+```kotlin
+.addCallback(object : RoomDatabase.Callback() {
+    override fun onOpen(db: SupportSQLiteDatabase) {
+        // Calculate scores here
+    }
+})
+```
+
+Advantage: automatic, seems elegant.
+Disadvantage: blocks Room initialization. Accessing `GlobalStatsRepository` or other DAOs from inside the callback creates circular dependencies or synchronization issues that are very difficult to debug.
+
+We chose dish 2 for one very specific reason: **single source of truth**. All scoring logic lives in Kotlin, in `GameScoreCalculator` and `XpCalculator`. If that logic changes, everything updates automatically. If I had put the logic in SQL, I would have two versions: one for new puzzles (Kotlin) and one for old ones (SQL). Two versions diverge. Two versions diverge badly.
+
+## Decision 3: When to invoke the populator
+
+There is a timing detail that seems minor but matters a lot: when do we run `populateAll()`? The options were:
+
+- **In `Application.onCreate`**: as early as possible. But coroutines in `Application.onCreate` are prone to errors because the Hilt context may not be fully initialized.
+- **In the first `MainActivity.onCreate`**: safer, but could run multiple times if the user kills the app and reopens it.
+- **In an AndroidX Startup `Initializer`**: the official pattern for initialization jobs. Runs once per process and handles retries well.
+- **As part of the first `StatsViewModel` that loads**: lazy, but requires coordination among the twelve ViewModels.
+
+We chose the AndroidX Startup Initializer. It's the least sexy but most correct option: separates initialization from UI code, handles retries automatically, and shows up in any Android linter that looks at initialization patterns.
+
+```kotlin
+class StatsPopulatorInitializer : Initializer<RetroactiveStatsPopulator> {
+    override fun create(context: Context): RetroactiveStatsPopulator {
+        val app = context as PuzzleSuiteApplication
+        app.applicationScope.launch {
+            app.retroactiveStatsPopulator.populateAll()
+        }
+        return app.retroactiveStatsPopulator
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+}
+```
+
+And it's registered in the `AndroidManifest.xml` or in an `InitializerConfig` class:
+
+```kotlin
+class AppInitializers : Initializer<Unit> {
+    override fun create(context: Context) {
+        AppStartup.getInstance(context)
+            .initializeComponent(StatsPopulatorInitializer::class.java)
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+}
+```
+
+Clean. Idempotent. Traceable.
+
+## The detail that almost got away from us
+
+There was a moment where we almost got into a serious problem. `populateAll()` iterates over each repository and updates each puzzle with `score == 0`. But what happens if the user opens the app, the populator starts running, and halfway through the user completes a new puzzle? That new puzzle would arrive with `score` and `xp` already calculated correctly (because the scoring system does calculate them when saving). But the populator, if not careful, could recalculate it and assign it a different value if the scoring logic had changed between the first write and the recalculation.
+
+The solution was simple: the `it.score == 0` filter only processes puzzles with a zero score. If the user completes a new puzzle, its score will be different from zero immediately, and the populator ignores it on subsequent passes. It's a race condition that's resolved by the nature of the filter, not by locks or synchronized blocks. Sometimes elegance comes from not adding complexity.
+
+## The anatomy of a well-done Room migration
+
+It's worth pausing for a moment on what a well-done Room migration looks like, because there are many tutorials out there that teach you to do it wrong. The golden rule: **never** drop a table and recreate it with the new schema. It's tempting, especially when you're prototyping, because it seems faster. But for a user who already has data on their device, that would mean losing their entire history.
+
+The correct way is `ALTER TABLE`:
+
+```kotlin
+internal val MIGRATION_7_8 = object : Migration(7, 8) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("""
+            ALTER TABLE akari_puzzles
+            ADD COLUMN score INTEGER NOT NULL DEFAULT 0
+        """)
+        db.execSQL("""
+            ALTER TABLE akari_puzzles
+            ADD COLUMN xp INTEGER NOT NULL DEFAULT 0
+        """)
+    }
+}
+```
+
+And then register the migration in the database provider:
+
+```kotlin
+internal val MIGRATIONS: Array<Migration> = arrayOf(
+    MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4,
+    MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8
+)
+```
+
+Each migration is idempotent: if Room is already at the target version, it doesn't run. If it's at an earlier version, it runs all intermediate migrations in order. If something fails halfway through, Room rolls back and leaves the database as it was. It's a small marvel of engineering that SQLite and the AndroidX team give us, and that most apps don't take advantage of.
+
+There's an additional trick I learned years ago and always apply: **increment the version per change, not per release**. That is, if a release includes two schema changes, they are two separate migrations (`7_8` and `8_9`), not a single `7_9`. Why? Because if in the future you need to roll back to an earlier version of the code, you want to be able to identify exactly which schema version each release corresponds to. One migration per change gives you that traceability.
+
+## Why we didn't write tests for this (yet)
+
+This is going to sound weird coming from someone who normally defends testing, but we didn't write automated tests for `RetroactiveStatsPopulator`. The reason is practical: the scoring logic is already tested in its respective classes (`GameScoreCalculatorTest`, `XpCalculatorTest`). The populator is an orchestrator: it calls already-tested functions and applies them to database rows. Testing the orchestrator would be testing that Kotlin correctly copies values, which is basically testing the language.
+
+What I did do was manually validate with real data: I installed a local build with a synthetic database of five hundred puzzles, ran the populator, and verified that the calculated scores matched what the original formula would produce. It's manual testing, yes, but for a one-shot migration like this, it's proportional to the risk.
+
+If the populator ran periodically (for example, if each formula change required a recalculation), then I would write automated tests. But since it's an operation that happens once per installation (the `score == 0` filter ensures that the second pass does nothing), the cost of the automated test doesn't justify the benefit.
+
+## What's still not done (and that's okay)
+
+There's a decision we consciously **didn't** make this week: we don't persist the history of formula changes. That is, if in the future I change `XpCalculator` and the populator recalculates all the puzzles, the old values are lost. We don't save "this puzzle had XP=150 with formula v1, now it has XP=180 with formula v2".
+
+Is that a problem? For an indie puzzle game, probably not. Players don't want to see a history of how much XP their puzzles had six months ago under a different formula; they want to see the current XP. If we ever decide to save the history, it will be an explicit feature, not a side effect.
+
+Also pending is the audit of the scoring rules themselves. Some games (Minesweeper, especially) have rules that probably need adjustments after seeing how the scores behave in production. But that's another day.
+
+## A reflection on the cost of small things
+
+I've seen one-line Pull Requests that took three days to merge because they opened unexpected Pandora's boxes. This was one of those cases, but in reverse: the Pull Request contained two dozen files (twelve entities, twelve migrations, the populator, the Initializer, the UI changes) but the conceptual logic was simple. The challenge wasn't the code's complexity, but the consistency between twelve databases that share the same architecture but that, by their modular nature, can silently diverge if you're not careful.
+
+It's the kind of work that doesn't generate pretty screenshots for the blog, that doesn't appear in "shipping fast" tweets, but that's the reason the app remains maintainable after three years. Boring, predictable, well-documented code is what scales. "Smart" and clever code is what you have to rewrite in six months.
+
+If you have to choose between the two options in your own project, I'll leave you with a heuristic that works for me: **if your change touches more than three files that are structurally identical, write a script or a component that generates the changes**. For this devlog, I briefly considered generating the twelve entities with a Python script that read a JSON configuration. In the end I decided to write them by hand because they're forty lines per game and the script would have taken longer to debug than to write the code directly. But that calculation changes if instead of twelve there were fifty games.
+
+## Technical closing
+
+If you've made it this far, you have in your head the entire design behind two columns in a table. It sounds exaggerated for so little, but that's precisely the point: in software, the small isn't trivial. Decisions about nullable, about when to run the migration, about where to put the logic — they all matter. And although none of them is sexy, they're all what differentiates code that ages well from code you'll have to rewrite in two years.
+
+What I like most about the final result is that `RetroactiveStatsPopulator` feels like an honest component. It does exactly what its name says, it has no hidden side effects, and if tomorrow I decide to wipe a user's database and reinstall the app, the populator runs again and everything works. It's the kind of code I like to write: boring, predictable, and robust.
+
+— *Scribe*

--- a/src/content/devlog/es/2026-w26-connecting-puzzle-pieces.md
+++ b/src/content/devlog/es/2026-w26-connecting-puzzle-pieces.md
@@ -1,0 +1,102 @@
+---
+title: "2026 W26: Conectando los puntos del rompecabezas"
+description: "Una semana donde dos features aparentemente pequeñas terminaron por revelar la arquitectura profunda de PuzzleSuite: navegación clicable desde el perfil y persistencia retroactiva de XP y scores en los doce juegos."
+pubDate: "2026-06-22"
+heroImage: "/images/devlog/devlog-w26-connecting.svg"
+tags: ["devlog", "android", "kotlin", "compose", "room", "navigation"]
+---
+
+Hay semanas donde uno se sienta frente al editor convencido de que va a escribir tres líneas de código, tomarse un café, y volver a la cama. Esta no fue una de esas semanas. Esta fue la semana donde dos Pull Requests "sencillitos" — añadir un clic a una tarjeta y meter dos columnas nuevas en una base de datos — me arrastraron a una reflexión sobre la naturaleza misma del estado en una aplicación Android. Pero vayamos por partes, como siempre, porque la historia merece ser contada desde el principio.
+
+## El gancho: una tarjeta que no hacía nada
+
+Si llevas tiempo usando PuzzleSuite, probablemente conozcas la pestaña de Perfil. Es esa pantalla donde, además de tu racha y tus estadísticas globales, aparece una grilla elegante con el progreso de los doce juegos que componen la suite: Akari, Dominosa, Fillomino, Galaxies, Hashi, Hitori, Kakuro, Kenken, MathCrossword, Minesweeper, Shikaku y Slitherlink. La grilla tiene su miga — usa `SuiteProgressGrid`, un componente compartido que renderiza una `GameProgressCard` por juego, con barras de dificultad, contadores de completados y un porcentaje calculado al vuelo.
+
+El problema es que esas tarjetas eran, hasta esta semana, bonitas pero inertes. Podías mirarlas, sentir el orgullo de tus cien Akaris completados, y poco más. La navegación a la pantalla de logros del juego correspondiente vivía en otro sitio: en el menú del juego, dos niveles de profundidad más abajo. Si querías ver los logros de Dominosa desde el Perfil, tenías que volver al Home, abrir el menú de Dominosa y luego saltar a sus logros. Tres taps. Una fricción absurda para una de las interacciones más naturales del mundo: "oye, he visto mi progreso en Dominosa desde aquí, déjame ver los detalles sin tener que navegar como si estuviera resolviendo un laberinto".
+
+La primera tarea documentada, `20260618-profile-achievements-navigation`, nació exactamente para arreglar esto. El título suena pomposo para lo que terminó siendo una feature de tres commits, pero el diablo estaba en los detalles. O mejor dicho: el diablo estaba en la firma de los composables.
+
+## El nudo: cuando Compose no te deja mentir
+
+`SuiteProgressGrid` ya existía. `GameProgressCard` ya existía. `ProfileScreen` ya existía. Lo que no existía era una manera limpia de decirle al sistema "cuando alguien toque esta tarjeta, vete a la pantalla de logros de Dominosa" sin acoplar la grilla al `NavController` global. Si haces eso — pasar el `NavController` como parámetro hasta el componente más interno — conviertes cada `Composable` en un mini-aplicación con conocimiento de toda la jerarquía de navegación. Y entonces cualquier refactor futuro se convierte en un juego de Jenga donde nadie quiere mover la pieza del medio.
+
+La solución limpia, que es la que adoptamos, fue propagar un callback hacia arriba. En Compose, el patrón "datos hacia abajo, eventos hacia arriba" no es una sugerencia: es una obligación moral. Así que la cadena quedó así:
+
+`MainScreen` recibe `onNavigateToGame: (String) -> Unit` del navegador global. Cuando declara `ProfileScreen` en su `NavHost` interno, le pasa `onNavigateToGameAchievements = onNavigateToGame`. `ProfileScreen` recibe ese callback, lo mapea añadiendo el sufijo `_achievements` al ID del juego, y se lo entrega a `SuiteProgressGrid` como `onGameClick`. `SuiteProgressGrid` lo propaga a cada `GameProgressCard`. Y `GameProgressCard`, finalmente, añade el modificador `.clickable { onGameClick(progress.gameId) }` a la tarjeta principal.
+
+Suena a trabalenguas, y lo es. Pero funciona porque cada pieza solo conoce a su padre inmediato. La grilla no sabe que existe un navegador global; el perfil no sabe que existe un `NavController`; la tarjeta solo sabe que cuando la tocan, tiene que invocar una lambda. Esta es la magia — y a veces la tortura — de Compose: te obliga a ser explícito sobre las dependencias, lo cual escala mejor pero requiere más tipeo.
+
+El otro detalle interesante fue el manejo del back stack. Cuando navegas desde el Perfil y luego presionas "atrás" en la pantalla de logros, ¿adónde deberías volver? Si navegas desde el Perfil, la respuesta intuitiva es "al Perfil". Si navegas desde el Menú del Juego, la respuesta intuitiva es "al Menú del Juego". Compose Navigation lo resuelve solo, sin que tengamos que intervenir, porque cada `popBackStack()` se queda en la pantalla anterior del stack. Es uno de esos momentos donde la herramienta te da lo que necesitas si dejaste de pelear con ella cinco minutos antes.
+
+## El clímax inesperado: el problema del dato histórico
+
+Hasta aquí, todo era arquitectura limpia y propagación de callbacks. Pero la segunda tarea, `20260621-game-stats-persistence`, tenía una trampa escondida bajo una superficie inocente.
+
+La premisa era simple: queremos que cada puzzle completado registre su `score` y su `xp` en la base de datos, para que el historial pueda mostrar "has ganado +150 XP y 320 puntos en este Hashi" en lugar de solo "completado en 4:32". Hasta aquí, todo bien. Dos columnas nuevas en cada una de las doce tablas de puzzles. Doce migraciones Room, una por juego. Trivial.
+
+Pero entonces alguien — yo, sentado con el tercer café de la mañana — formuló la pregunta obvia: "¿Y qué pasa con los puzzles que ya estaban completados antes de esta actualización?". Y la respuesta fue: nada. Estarían en la base de datos con `score = 0` y `xp = 0` para siempre, a menos que ejecutemos alguna lógica retroactiva.
+
+Si tienes mil quinientos puzzles completados en tu instalación local — que es perfectamente plausible si llevas dos años jugando a PuzzleSuite — eso son mil quinientas filas que necesitan ser recalculadas y actualizadas. ¿Cuándo? ¿Cómo? ¿Con qué reglas?
+
+Aquí es donde la decisión "nullable vs no-nullable" deja de ser un detalle sintáctico y se convierte en una cuestión filosófica. Si las columnas son `Int?`, podemos representar limpiamente "este puzzle fue completado antes de que existiera el sistema de puntuación, así que su score es desconocido". Si son `Int = 0`, estamos mintiendo: estamos diciendo que esos puzzles antiguos tienen cero puntos, cuando en realidad nunca se les calculó ninguno. La opción B — `Int = 0` con un `DEFAULT 0` en la migración — es la que ganó, por consistencia con el resto del modelo de datos (los campos de timing ya siguen ese patrón), pero la decisión requirió una entrada entera en el documento de diseño explicando por qué elegíamos mentir elegantemente en lugar de admitir nuestra ignorancia.
+
+Pero el verdadero clímax fue la **población retroactiva**. Una vez decidido que las columnas empezarían en cero, necesitábamos rellenarlas. Y aquí teníamos tres caminos:
+
+1. **SQL puro en la migración**: ejecutar `UPDATE akari_puzzles SET score = ...` dentro de la transacción de Room. La ventaja era velocidad y atomicidad. La desventaja era que replicar la lógica de `GameScoreCalculator` — que tiene en cuenta thresholds de velocidad por tamaño y dificultad, bonuses dinámicos, hints usados, y reglas distintas para cada uno de los doce juegos — en SQL puro era una pesadilla de mantenimiento.
+
+2. **Lógica en Kotlin al arrancar**: dejar que las migraciones añadan las columnas vacías, y luego, al iniciar la app, un componente recorre los repositorios, busca los puzzles con `score == 0`, y los recalcula usando las funciones de scoring existentes en Kotlin. Es lo que hicimos.
+
+3. **Callback de Room**: ejecutar el cálculo dentro de `RoomDatabase.Callback.onOpen`. La ventaja era automatización. La desventaja era bloquear la inicialización de la base de datos y crear dependencias circulares con Hilt y `GlobalStatsRepository`.
+
+La opción dos ganó por una razón muy concreta: respeta la regla de oro de "una sola fuente de verdad para la lógica de negocio". Si mañana cambio la fórmula del XP, no quiero tener que reescribir doce queries SQL diferentes. Quiero cambiar `XpCalculator.calculate()` y que el próximo arranque de la app aplique los nuevos valores. Esa es la promesa del recalculo retroactivo: no solo arregla el pasado, sino que se mantiene vivo en el futuro.
+
+## El desenlace: doce archivos, una sola arquitectura
+
+Lo que más me gusta de cómo quedó esta semana es que, aunque toqué doce bases de datos diferentes, el patrón fue exactamente el mismo en todas. Para cada juego:
+
+1. Modifiqué el `data class` de dominio para añadir `score: Int = 0` y `xp: Int = 0`.
+2. Modifiqué la entidad de Room con los mismos campos, asegurándome de que el mapeo `toDomain()` y `toEntity()` los propagara.
+3. Añadí una migración de versión que incrementa el schema en uno y ejecuta dos `ALTER TABLE … ADD COLUMN`.
+4. Añadí el juego correspondiente al `RetroactiveStatsPopulator` — un `@Singleton` con `@Inject` para los doce repositorios.
+
+Es gratificante ver cómo una arquitectura Clean estricta paga dividendos cuando tienes que aplicar el mismo cambio N veces. Cuando cada capa está aislada, los cambios son predecibles. Cuando acoplas capas, cada repetición es una oportunidad para introducir un bug sutil. He vivido lo suficiente en este proyecto como para saber que esa predictibilidad vale su peso en café.
+
+## Aprendizajes y despedida
+
+Las dos lecciones que me llevo de esta semana son técnicamente modestas, pero filosóficamente densas.
+
+La primera: **la navegación en Compose no es un lujo arquitectónico, es una declaración de principios**. Cuando decides propagar callbacks en lugar de pasar el `NavController` a todo el mundo, estás diciendo "mi UI es testeable, mi UI es refactorizable, mi UI es comprensible". El coste inmediato son más líneas de código y firmas más verbosas. El beneficio a largo plazo es que nunca tendrás que reescribir media app porque cambiaste de `NavHost` a `Voyager`.
+
+La segunda: **los datos históricos son una ventana al pasado, y las ventanas se pueden actualizar**. La idea de que un usuario con mil quinientos puzzles completados pudiera ver todos con score cero era inaceptable. Pero más importante que arreglar el pasado fue diseñar un sistema que pueda arreglarse a sí mismo cuando las reglas cambien. Ese es el verdadero valor del `RetroactiveStatsPopulator`: no es un parche, es una garantía.
+
+Si has llegado hasta aquí leyendo, te debo una confesión: este devlog estaba planeado como un único artículo, pero la materia prima se rebeló y terminó partiéndose en dos. La segunda parte, *"La rebelión de los `Int?`"*, es un deep dive técnico sobre todo lo que hubo que decidir para hacer funcionar el sistema de persistencia retroactiva. Te espero allí si quieres bajar al barro del SQL, los trade-offs de nullable, y el código de `RetroactiveStatsPopulator`. Si prefieres quedarte en la superficie narrativa, nos vemos en la próxima entrada.
+
+Mientras tanto, ve a la pestaña Perfil y toca una tarjeta. Si todo ha ido bien, aterrizarás en la pantalla de logros del juego con un ripple elegante y el orgullo de un developer que por fin se atrevió a conectar los puntos.
+
+## Un apunte sobre el ripple, porque nadie habla del ripple
+
+Hay un detalle que me encanta de Material Design 3 y que rara vez se comenta: el modificador `.clickable` no solo añade el handler de touch, sino que aplica automáticamente la animación ripple que ves cuando presionas la tarjeta. Esa onda expansiva, ese círculo que se expande desde el punto donde tocaste, no es gratuita: está implementada en `androidx.compose.foundation` como un `Indication` configurable, y por defecto usa `LocalIndication.current` que en Material Theme 3 es precisamente el `rememberRipple()`. Lo que significa que añadir `clickable { }` a un componente y obtener feedback táctil instantáneo es una decisión arquitectónica que alguien en el equipo de Compose tomó hace años para ti, y que probablemente nunca agradeces lo suficiente.
+
+En PuzzleSuite ese ripple es la diferencia entre una tarjeta que se siente como un botón y una que se siente como una foto. Cuando navegas por la grilla del Perfil, cada toque te devuelve una pequeña confirmación visual de que la app te escuchó. En un juego de puzzles, donde la respuesta a tus acciones es el centro de la experiencia, ese tipo de micro-detalles son los que separan una app "que funciona" de una app "que se siente bien". No es magia, es Compose haciendo su trabajo.
+
+## Por qué ser indie importa aquí
+
+Trabajas solo. No hay un product manager que te diga "esto es prioridad uno". No hay un equipo de QA que te diga "oye, en este caso el usuario toca dos veces porque el ripple no se ve". No hay un diseñador que te entregue una especificación detallada de cada interacción. Tienes tu cabeza, tu café, y los issues abiertos en GitHub. Y esa soledad, que a veces pesa, otras veces libera: porque te permite tomar decisiones que en una empresa mediana requerirían tres reuniones, un acta y un Jira actualizado.
+
+Cuando decidí que `Int = 0` era mejor que `Int?` para los campos de score, no tuve que escribir un RFC. Cuando decidí propagar callbacks en lugar de pasar el `NavController`, no tuve que convencer a un tech lead. Cuando decidí que doce migraciones idénticas eran mejor que un script de migración genérico, no tuve que justificar el trade-off ante un equipo de arquitectura. Solo tuve que estar seguro, y eso es un privilegio que no valoras hasta que has trabajado en equipos donde cada cambio de tres líneas pasa por cuatro aprobaciones.
+
+Pero ese privilegio tiene su contrapartida: la responsabilidad de equivocarte bien. Si me equivoqué con el nullable, no hay code review que me corrija. Si la navegación pierde el back stack en algún caso edge, no hay tester que me lo reporte antes del release. Soy yo, en mi sofá, viendo cómo los issues se acumulan en el repositorio. Y eso, curiosamente, también está bien. Porque cada error que meto en producción es un error que documentaré, que aprenderé, y que la próxima vez no meteré.
+
+## El cierre que no es cierre
+
+Esta semana aprendí que a veces las features pequeñas son las más peligrosas. No porque sean complejas — al contrario, son engañosamente simples — sino porque te tientan a no prestarles la atención arquitectónica que merecen. El clic en una tarjeta parece trivial. Dos columnas nuevas en una tabla parecen triviales. Pero ambos cambios tocan los nervios expuestos de la aplicación: cómo navegas, cómo persistes, cómo mantienes la coherencia entre lo viejo y lo nuevo.
+
+Si estás construyendo algo similar, te dejo tres reglas que me han servido esta semana:
+
+1. **Cada callback tiene un dueño.** Si no puedes rastrear quién invoca un lambda, refactoriza hasta que puedas.
+2. **Cada migración cuenta una historia.** Si vas a alterar una tabla, piensa en las filas que ya están ahí. No son un detalle, son el pasado de tu usuario.
+3. **Cada patrón que repites diez veces merece una abstracción.** Doce juegos con la misma columna nueva no son una casualidad; son una lección de arquitectura esperando ser aprendida.
+
+Nos vemos en la próxima entrada, donde bajaremos al barro del SQL y del Kotlin para ver cómo se construye un `RetroactiveStatsPopulator` que realmente funcione.
+
+— *Scribe*

--- a/src/content/devlog/es/2026-w26-nullable-rebellion.md
+++ b/src/content/devlog/es/2026-w26-nullable-rebellion.md
@@ -1,0 +1,219 @@
+---
+title: "2026 W26: La rebelión de los Int? (Deep dive técnico)"
+description: "El lado B de la semana: cómo decidir entre columnas nullable y no-nullable, por qué escribimos el RetroactiveStatsPopulator en Kotlin en lugar de SQL, y las tripas de la migración Room para los doce juegos de PuzzleSuite."
+pubDate: "2026-06-22"
+heroImage: "/images/devlog/devlog-w26-nullable.svg"
+tags: ["devlog", "android", "kotlin", "room", "database", "refactor"]
+---
+
+Si la entrada anterior fue la versión cinematográfica de esta semana — el resumen narrativo, las anécdotas, el café y la filosofía — esta es la versión de taller. Aquí vamos a abrir el capó del `RetroactiveStatsPopulator`, discutir por qué cada decisión técnica fue la que fue, y por qué algunas otras opciones que parecían razonables terminaron siendo descartadas. Si vienes buscando una guía paso a paso para implementar algo similar, este es tu devlog. Si solo quieres la épica indie, la primera parte de esta semana te espera.
+
+## El problema, sin metáforas
+
+PuzzleSuite tiene doce juegos de puzzles lógicos. Cada juego tiene su propia base de datos Room (decisión de arquitectura antigua que probablemente algún día migremos a una única base de datos compartida, pero ese es tema para otro devlog). Cada base de datos tiene una tabla `*_puzzles` que guarda los puzzles completados por el usuario, con campos como `difficulty`, `totalTime`, `hintsUsed`, `completedAt`, y demás metadatos.
+
+Hasta esta semana, faltaban dos campos que necesitábamos: `score` (los puntos ganados en ese puzzle según los umbrales de velocidad y dificultad) y `xp` (la experiencia que reporta al perfil global del jugador). La razón por la que faltaban era histórica: cuando diseñamos el sistema de scoring inicial, lo hicimos calculando los valores al vuelo cada vez que se renderizaba la pantalla de estadísticas. Eso funcionaba mientras solo había una pantalla de stats y un modelo de datos simple. Pero cuando intentamos mostrar el score en el historial de puzzles completados, descubrimos que no teníamos el dato persistido: tendríamos que recalcularlo cada vez que alguien visitara esa pantalla, lo cual era absurdo desde el punto de vista de eficiencia y mantenibilidad.
+
+La solución obvia era añadir dos columnas a cada tabla. Pero las soluciones obvias, como vamos a ver, esconden una cantidad obscena de decisiones debajo de su superficie inocente.
+
+## Decisión 1: Nullable vs No-nullable
+
+La primera bifurcación del camino. Las dos opciones eran:
+
+**Opción A: Columnas nullable**
+```kotlin
+val score: Int? = null,
+val xp: Int? = null
+```
+
+**Opción B: Columnas no-nullable con default**
+```kotlin
+val score: Int = 0,
+val xp: Int = 0
+```
+
+La opción A tiene una elegancia conceptual: "este puzzle fue completado antes de que existiera el sistema de scoring, así que su score es desconocido". Es la verdad literal. Es también un infierno operacional: cada vez que alguien sume scores, cada vez que la UI los muestre, cada vez que un cálculo los use, hay que escribir `score ?: 0` en algún sitio. Esa proliferación de safe-calls y operadores elvis es ruido que contamina el código y que, con el tiempo, se va colando en sitios donde no debería estar.
+
+La opción B, en cambio, dice "este puzzle tiene score cero". Es una mentira elegante. Pero es una mentira que el sistema entero entiende y maneja sin casos especiales. Cuando en seis meses cambies la fórmula del XP, no tendrás que rastrear todas las conversiones `Int?` a `Int` para asegurarte de que ninguna quedó obsoleta. Simplemente cambias `XpCalculator.calculate()` y todo fluye.
+
+Elegimos B. Y la elegimos no porque fuera la más correcta filosóficamente, sino porque era la más coherente con el resto del modelo. Los campos de timing (`totalTime: Long = 0`) ya seguían ese patrón. Si hacíamos una excepción aquí, estaríamos introduciendo una inconsistencia que en dos años alguien — probablemente yo mismo, en otro devlog como este — tendría que explicar por qué existe.
+
+## Decisión 2: Cómo rellenar las filas históricas
+
+Vale, tenemos las columnas. Tenemos valores por defecto en cero. ¿Y los puzzles que ya estaban completados antes de esta actualización? Esos tienen `score = 0` y `xp = 0`, lo cual es incorrecto porque no son cero: simplemente nunca se les calculó.
+
+Aquí el menú tenía tres platos:
+
+### Plato 1: SQL puro en la migración Room
+
+```sql
+ALTER TABLE akari_puzzles ADD COLUMN score INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE akari_puzzles ADD COLUMN xp INTEGER NOT NULL DEFAULT 0;
+UPDATE akari_puzzles SET
+  score = CASE
+    WHEN difficulty = 'easy' AND total_time < 60000 THEN 100
+    WHEN difficulty = 'easy' AND total_time < 180000 THEN 50
+    ...
+  END
+WHERE completed_at IS NOT NULL;
+```
+
+Ventaja: atómico, rápido, todo dentro de la transacción de migración.
+Desventaja: replicar la lógica completa de `GameScoreCalculator` (que tiene en cuenta el tamaño del puzzle, los hints usados, los bonuses por velocidad, las reglas especiales por juego) en SQL es prácticamente imposible. Para cuando terminara de escribir las doce queries, ya habrían cambiado las reglas.
+
+### Plato 2: Kotlin al arranque (lo que hicimos)
+
+```kotlin
+@Singleton
+class RetroactiveStatsPopulator @Inject constructor(
+    private val akariRepository: AkariPuzzleRepository,
+    private val dominosaRepository: DominosaPuzzleRepository,
+    // ... otros diez repositorios
+) {
+    suspend fun populateAll() {
+        populateGame("akari") {
+            val puzzles = akariRepository.getCompletedPuzzles().first()
+            puzzles.filter { it.score == 0 }.forEach { p ->
+                val sizeStr = "${p.size.width}x${p.size.height}"
+                val score = GameScoreCalculator.calculate(
+                    "akari", p.difficulty, sizeStr, p.totalTime, p.hintsUsed
+                )
+                val sizeTier = getAkariSizeTier(p.size)
+                val xp = XpCalculator.calculate(sizeTier, p.difficulty)
+                akariRepository.updatePuzzle(p.copy(score = score, xp = xp))
+            }
+        }
+        // Repetir para los otros once juegos
+    }
+}
+```
+
+Ventaja: reutiliza toda la lógica de scoring existente. Si mañana cambio `XpCalculator`, el siguiente arranque aplica los nuevos valores sin tocar este código.
+Desventaja: añade un pequeño lag en el primer arranque, aunque en bases de datos locales pequeñas es prácticamente imperceptible.
+
+### Plato 3: Room Database Callback
+
+```kotlin
+.addCallback(object : RoomDatabase.Callback() {
+    override fun onOpen(db: SupportSQLiteDatabase) {
+        // Calcular scores aquí
+    }
+})
+```
+
+Ventaja: automática, parece elegante.
+Desventaja: bloquea la inicialización de Room. Acceder a `GlobalStatsRepository` o a otros DAOs desde dentro del callback crea dependencias circulares o problemas de sincronización que son muy difíciles de debuggear.
+
+Elegimos el plato 2 por una razón muy concreta: **una sola fuente de verdad**. Toda la lógica de scoring vive en Kotlin, en `GameScoreCalculator` y `XpCalculator`. Si esa lógica cambia, todo se actualiza automáticamente. Si hubiera puesto la lógica en SQL, tendría dos versiones: una para los nuevos puzzles (Kotlin) y otra para los antiguos (SQL). Dos versiones divergen. Dos versiones divergen mal.
+
+## Decisión 3: Cuándo invocar al populator
+
+Hay un detalle de timing que parece menor pero importa mucho: ¿cuándo ejecutamos `populateAll()`? Las opciones eran:
+
+- **En `Application.onCreate`**: lo más temprano posible. Pero corrutinas en `Application.onCreate` son propensas a errores porque el contexto de Hilt puede no estar completamente inicializado.
+- **En el primer `MainActivity.onCreate`**: más seguro, pero podría ejecutarse múltiples veces si el usuario mata la app y la reabre.
+- **En un `Initializer` de AndroidX Startup**: el patrón oficial para trabajos de inicialización. Se ejecuta una sola vez por proceso y maneja bien los reintentos.
+- **Como parte del primer `StatsViewModel` que se cargue**: lazy, pero requiere coordinación entre los doce ViewModels.
+
+Elegimos el Initializer de AndroidX Startup. Es la opción menos sexy pero más correcta: separa la inicialización del código de UI, maneja los reintentos automáticamente, y aparece documentada en cualquier linter de Android que mire patrones de inicialización.
+
+```kotlin
+class StatsPopulatorInitializer : Initializer<RetroactiveStatsPopulator> {
+    override fun create(context: Context): RetroactiveStatsPopulator {
+        val app = context as PuzzleSuiteApplication
+        app.applicationScope.launch {
+            app.retroactiveStatsPopulator.populateAll()
+        }
+        return app.retroactiveStatsPopulator
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+}
+```
+
+Y se registra en el `AndroidManifest.xml` o en una clase `InitializerConfig`:
+
+```kotlin
+class AppInitializers : Initializer<Unit> {
+    override fun create(context: Context) {
+        AppStartup.getInstance(context)
+            .initializeComponent(StatsPopulatorInitializer::class.java)
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+}
+```
+
+Limpio. Idempotente. Trazable.
+
+## El detalle que casi se nos escapa
+
+Hubo un momento donde casi nos metemos en un problema serio. El `populateAll()` itera sobre cada repositorio y actualiza cada puzzle con `score == 0`. Pero ¿qué pasa si el usuario abre la app, el populator empieza a correr, y a mitad de camino el usuario completa un puzzle nuevo? Ese puzzle nuevo llegaría con `score` y `xp` ya calculados correctamente (porque el sistema de scoring al guardar sí los calcula). Pero el populator, si no tiene cuidado, podría volver a recalcularlo y asignarle un valor distinto si la lógica de scoring hubiera cambiado entre la primera escritura y la recalculación.
+
+La solución fue simple: el filtro `it.score == 0` solo procesa puzzles con score cero. Si el usuario completa un puzzle nuevo, su score será distinto de cero inmediatamente, y el populator lo ignora en pasadas siguientes. Es una condición de carrera que se resuelve por la naturaleza del filtro, no por locks ni por synchronized blocks. A veces la elegancia viene de no añadir complejidad.
+
+## La anatomía de una migración Room bien hecha
+
+Vale la pena detenerse un momento en cómo se ve una migración Room bien hecha, porque hay muchos tutoriales por ahí que enseñan a hacerlas mal. La regla de oro: **nunca** borres una tabla y la recrees con el nuevo esquema. Es tentador, especialmente cuando estás prototipando, porque parece más rápido. Pero para un usuario que ya tiene datos en su dispositivo, eso significaría perder todo su historial.
+
+La forma correcta es `ALTER TABLE`:
+
+```kotlin
+internal val MIGRATION_7_8 = object : Migration(7, 8) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("""
+            ALTER TABLE akari_puzzles
+            ADD COLUMN score INTEGER NOT NULL DEFAULT 0
+        """)
+        db.execSQL("""
+            ALTER TABLE akari_puzzles
+            ADD COLUMN xp INTEGER NOT NULL DEFAULT 0
+        """)
+    }
+}
+```
+
+Y luego registrar la migración en el provider de la base de datos:
+
+```kotlin
+internal val MIGRATIONS: Array<Migration> = arrayOf(
+    MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4,
+    MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8
+)
+```
+
+Cada migración es idempotente: si Room ya está en la versión destino, no se ejecuta. Si está en una versión anterior, ejecuta todas las migraciones intermedias en orden. Si algo falla a mitad de camino, Room hace rollback y deja la base de datos como estaba. Es una pequeña maravilla de la ingeniería que SQLite y el equipo de AndroidX nos regalan, y que la mayoría de las apps no aprovecha.
+
+Hay un truco adicional que aprendí hace años y que siempre aplico: **incrementar la versión por cambio, no por release**. Es decir, si una release incluye dos cambios de esquema, son dos migraciones separadas (`7_8` y `8_9`), no una sola `7_9`. ¿Por qué? Porque si en el futuro necesitas hacer rollback a una versión anterior del código, quieres poder identificar exactamente a qué versión del esquema corresponde cada release. Una migración por cambio te da esa trazabilidad.
+
+## Por qué no escribimos tests para esto (todavía)
+
+Esto va a sonar raro viniendo de alguien que normalmente defiende el testing, pero no escribimos tests automatizados para el `RetroactiveStatsPopulator`. La razón es práctica: la lógica de scoring ya está testeada en sus respectivas clases (`GameScoreCalculatorTest`, `XpCalculatorTest`). El populator es un orquestador: llama a funciones ya probadas y las aplica a filas de la base de datos. Testear el orquestador sería testear que Kotlin copia valores correctamente, lo cual es básicamente testear el lenguaje.
+
+Lo que sí hice fue validar manualmente con datos reales: instalé una build local con una base de datos sintética de quinientos puzzles, ejecuté el populator, y verifiqué que los scores calculados coincidían con los que produciría la fórmula original. Es testing manual, sí, pero para una migración one-shot como esta es proporcional al riesgo.
+
+Si el populator se ejecutara periódicamente (por ejemplo, si cada cambio de fórmula requiriera un recalculo), entonces sí escribiría tests automatizados. Pero como es una operación que ocurre una vez por instalación (el filtro `score == 0` garantiza que la segunda pasada no hace nada), el coste del test automatizado no compensa el beneficio.
+
+## Lo que todavía no está hecho (y está bien)
+
+Hay una decisión que conscientemente **no** tomamos esta semana: no persistimos el histórico de cambios de fórmula. Es decir, si en el futuro cambio `XpCalculator` y el populator recalcula todos los puzzles, los valores antiguos se pierden. No guardamos "este puzzle tenía XP=150 con la fórmula v1, ahora tiene XP=180 con la fórmula v2".
+
+¿Es eso un problema? Para un juego de puzzles indie, probablemente no. Los jugadores no quieren ver un historial de cuánto XP tenían sus puzzles hace seis meses bajo una fórmula distinta; quieren ver el XP actual. Si alguna vez decidimos guardar el histórico, será una feature explícita, no un side effect.
+
+También queda pendiente la auditoría de las reglas de scoring mismas. Algunos juegos (Minesweeper, sobre todo) tienen reglas que probablemente necesitan ajustes después de ver cómo se comportan los scores en producción. Pero eso es otro día.
+
+## Una reflexión sobre el coste de lo pequeño
+
+He visto Pull Requests de una línea que tardaban tres días en fusionarse porque abrían cajas de Pandora inesperadas. Este fue uno de esos casos, aunque al revés: el Pull Request contenía dos docenas de archivos (doce entidades, doce migraciones, el populator, los Initializer, los cambios de UI) pero la lógica conceptual era sencilla. El reto no era la complejidad del código, sino la consistencia entre doce bases de datos que comparten la misma arquitectura pero que, por su naturaleza modular, pueden divergir silenciosamente si no tienes cuidado.
+
+Es el tipo de trabajo que no genera screenshots bonitos para el blog, que no aparece en los tweets de "shipping fast", pero que es la razón por la que la app sigue siendo mantenible después de tres años. El código aburrido, predecible y bien documentado es el que escala. El código "inteligente" y clever es el que tienes que reescribir en seis meses.
+
+Si tienes que elegir entre las dos opciones en tu propio proyecto, te dejo una heurística que me funciona: **si tu cambio toca más de tres archivos que son estructuralmente idénticos, escribe un script o un componente que genere los cambios**. Para este devlog, consideré brevemente generar las doce entidades con un script de Python que leyera un JSON de configuración. Al final decidí escribirlas a mano porque son cuarenta líneas por juego y el script habría tardado más en depurarse que en escribir el código directamente. Pero ese cálculo cambia si en lugar de doce fueran cincuenta juegos.
+
+## Cierre técnico
+
+Si has llegado hasta aquí, tienes en la cabeza todo el diseño que hay detrás de dos columnas en una tabla. Suena exagerado para tan poca cosa, pero ese es precisamente el punto: en software, lo pequeño no es trivial. Las decisiones sobre nullable, sobre cuándo correr la migración, sobre dónde poner la lógica — todas importan. Y aunque ninguna de ellas es sexy, todas son las que diferencian un código que envejecerá bien de un código que tendrás que reescribir en dos años.
+
+Lo que más me gusta del resultado final es que `RetroactiveStatsPopulator` se siente como un componente honesto. Hace exactamente lo que dice su nombre, no tiene efectos secundarios ocultos, y si mañana decido borrar la base de datos de un usuario y reinstalar la app, el populator se vuelve a ejecutar y todo funciona. Es el tipo de código que me gusta escribir: aburrido, predecible, y robusto.
+
+— *Scribe*


### PR DESCRIPTION
## Resumen

Añade las entradas de bitácora (devlog) de la semana W26-2026, dos features de PuzzleSuite:
1. **Connecting puzzle pieces** — callback propagation en SuiteProgressGrid para navegación a logros
2. **The rebellion of the Int?** — Nullable vs non-nullable en persistencia, RetroactiveStatsPopulator

## Cambios

- 4 archivos devlog (EN + ES): connecting-puzzle-pieces y nullable-rebellion
- 2 imágenes hero SVG: devlog-w26-connecting.svg y devlog-w26-nullable.svg
- Build exitoso: 838 páginas generadas

Closes #518